### PR TITLE
Provide useful ways to work with class trees

### DIFF
--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
@@ -7,7 +7,7 @@ import java.lang.annotation.*;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
-@Inherited
+@Inherited // This is currently not used, see https://issues.apache.org/jira/browse/GROOVY-6765
 @GroovyASTTransformationClass(classes={CanonicalASTTransformation.class, DSLConfigASTTransformation.class})
 public @interface DSLConfig {
 
@@ -16,6 +16,9 @@ public @interface DSLConfig {
      */
     String key() default "";
 
+    /**
+     * is the Object polymorphic, i.e. should the factory contain an additional class parameter.
+     */
     boolean polymorphic() default false;
 
 }

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
@@ -3,13 +3,11 @@ package com.blackbuild.groovy.configdsl.transform;
 import org.codehaus.groovy.transform.CanonicalASTTransformation;
 import org.codehaus.groovy.transform.GroovyASTTransformationClass;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
+@Inherited
 @GroovyASTTransformationClass(classes={CanonicalASTTransformation.class, DSLConfigASTTransformation.class})
 public @interface DSLConfig {
 
@@ -17,5 +15,7 @@ public @interface DSLConfig {
      * Which field of this class is used as the key when an instance of this class is used in a collection.
      */
     String key() default "";
+
+    boolean polymorphic() default false;
 
 }

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -83,18 +83,20 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         String methodName = getMethodNameForField(fieldNode);
 
-        if (hasAnnotation(fieldNode.getType(), DSL_CONFIG_ANNOTATION))
-            createClosureMethod(fieldNode);
+        if (hasAnnotation(fieldNode.getType(), DSL_CONFIG_ANNOTATION)) {
+            createSingleDSLObjectClosureMethod(fieldNode);
+            createSingleFieldSetterMethod(fieldNode);
+        }
         else if (Map.class.isAssignableFrom(fieldNode.getType().getTypeClass()))
             createMapMethod(fieldNode);
         else if (List.class.isAssignableFrom(fieldNode.getType().getTypeClass()))
             createListMethod(fieldNode);
         else
-            createSimpleMethod(fieldNode);
+            createSingleFieldSetterMethod(fieldNode);
 
     }
 
-    private void createSimpleMethod(FieldNode fieldNode) {
+    private void createSingleFieldSetterMethod(FieldNode fieldNode) {
         String methodName = getMethodNameForField(fieldNode);
 
         annotatedClass.addMethod(
@@ -423,7 +425,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         return contextClass;
     }
 
-    private void createClosureMethod(FieldNode fieldNode) {
+    private void createSingleDSLObjectClosureMethod(FieldNode fieldNode) {
         String methodName = getMethodNameForField(fieldNode);
 
         ClassNode innerType = fieldNode.getType();

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -490,6 +490,30 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
                 );
         }
 
+        List<ClassNode> classesList = getClassesList(fieldNode, elementType);
+        for (ClassNode implementation : classesList) {
+            String alternativeName = uncapitalizedSimpleClassName(implementation);
+
+            contextClass.addMethod(
+                    alternativeName,
+                    Opcodes.ACC_PUBLIC,
+                    ClassHelper.VOID_TYPE,
+                    params(param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(implementation)),
+                    NO_EXCEPTIONS,
+                    block(
+                            stmt(callX(getOuterInstanceXforField(fieldNode), "put",
+                                args(varX("key"),
+                                    callX(
+                                            implementation,
+                                            "create",
+                                            args("key", "closure")
+                                    )
+                                )
+                            ))
+                    )
+            );
+        }
+
         //noinspection ConstantConditions
         contextClass.addMethod(
                 "reuse",

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.codehaus.groovy.ast.ClassHelper.CLASS_Type;
+import static org.codehaus.groovy.ast.ClassHelper.STRING_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.make;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.buildWildcardType;
@@ -58,12 +59,34 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         annotatedClass = (ClassNode) nodes[1];
         keyField = getKeyField(annotatedClass);
 
+        if (keyField != null)
+            createKeyConstructor();
+
         createApplyMethod();
         createFactoryMethods();
 
         createFieldMethods();
 
         createCanonicalMethods();
+    }
+
+    private void createKeyConstructor() {
+        annotatedClass.addConstructor(
+                ACC_PUBLIC,
+                params(),
+                NO_EXCEPTIONS,
+                block()
+        );
+
+        annotatedClass.addConstructor(
+                ACC_PUBLIC,
+                params(param(STRING_TYPE, "key")),
+                NO_EXCEPTIONS,
+                block(
+                        ctorThisS(),
+                        assignS(propX(varX("this"), keyField.getName()), varX("key"))
+                )
+        );
     }
 
     private void createCanonicalMethods() {

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -71,12 +71,13 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
     }
 
     private void createKeyConstructor() {
-        annotatedClass.addConstructor(
-                ACC_PUBLIC,
-                params(),
-                NO_EXCEPTIONS,
-                block()
-        );
+        if (annotatedClass.getDeclaredConstructor(params()) == null)
+            annotatedClass.addConstructor(
+                    ACC_PUBLIC,
+                    params(),
+                    NO_EXCEPTIONS,
+                    block()
+            );
 
         annotatedClass.addConstructor(
                 ACC_PUBLIC,

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -42,7 +42,6 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
     private static final ClassNode EQUALS_HASHCODE_ANNOT = make(EqualsAndHashCode.class);
     private static final ClassNode TOSTRING_ANNOT = make(ToString.class);
 
-    private AnnotationNode configAnnotation;
     private ClassNode annotatedClass;
     private FieldNode keyField;
 
@@ -51,7 +50,6 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         init(nodes, source);
 
-        configAnnotation = (AnnotationNode) nodes[0];
         annotatedClass = (ClassNode) nodes[1];
         keyField = getKeyField(annotatedClass);
 
@@ -523,7 +521,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
     private FieldNode getKeyField(ClassNode target)
     {
-        String keyFieldName = getMemberStringValue(getAnnotation(target, DSL_CONFIG_ANNOTATION), "key");
+        String keyFieldName = getKeyFieldName(target);
 
         if (keyFieldName == null) return null;
 
@@ -545,6 +543,14 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         }
 
         return result;
+    }
+
+    private String getKeyFieldName(ClassNode target) {
+        if (target == null) return null;
+
+        String result = getNullSafeMemberStringValue(getAnnotation(target, DSL_CONFIG_ANNOTATION), "key", null);
+
+        return result != null ? result : getKeyFieldName(target.getSuperClass());
     }
 
     private Parameter createAnnotatedClosureParameter(ClassNode target) {

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -417,6 +417,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         InnerClassNode contextClass = createInnerContextClass(fieldNode);
 
         String methodName = getElementNameForCollectionField(fieldNode);
+        FieldNode fieldKey = getKeyField(elementType);
 
         contextClass.addMethod(
                 methodName,
@@ -433,6 +434,22 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
                         ))
                 )
         );
+
+        if (!isFinal(elementType)) {
+                contextClass.addMethod(
+                        methodName,
+                        Opcodes.ACC_PUBLIC,
+                        ClassHelper.VOID_TYPE,
+                        params(createSubclassClassParameter(annotatedClass), param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType)),
+                        NO_EXCEPTIONS,
+                        block(
+                                declS(varX("created"), callX(varX("typeToCreate"), "newInstance", args("key"))),
+                                stmt(callX(getOuterInstanceXforField(fieldNode), "put",
+                                         args(varX("key"), callX(varX("created"), "apply", varX("closure"))))
+                                )
+                        )
+                );
+        }
 
         //noinspection ConstantConditions
         contextClass.addMethod(

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -229,24 +229,26 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         FieldNode fieldKey = getKeyField(elementType);
 
-        contextClass.addMethod(
-                methodName,
-                Opcodes.ACC_PUBLIC,
-                ClassHelper.VOID_TYPE,
-                fieldKey != null ?
-                        params(param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType))
-                        : params(createAnnotatedClosureParameter(elementType)),
-                NO_EXCEPTIONS,
-                block(
-                        stmt(callX(getOuterInstanceXforField(fieldNode), "add",
-                                callX(
-                                        elementType,
-                                        "create",
-                                        fieldKey != null ? args("key", "closure") : args("closure")
-                                )
-                        ))
-                )
-        );
+        if (!isAbstract(elementType)) {
+            contextClass.addMethod(
+                    methodName,
+                    Opcodes.ACC_PUBLIC,
+                    ClassHelper.VOID_TYPE,
+                    fieldKey != null ?
+                            params(param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType))
+                            : params(createAnnotatedClosureParameter(elementType)),
+                    NO_EXCEPTIONS,
+                    block(
+                            stmt(callX(getOuterInstanceXforField(fieldNode), "add",
+                                    callX(
+                                            elementType,
+                                            "create",
+                                            fieldKey != null ? args("key", "closure") : args("closure")
+                                    )
+                            ))
+                    )
+            );
+        }
 
         if (!isFinal(elementType)) {
             if (fieldKey != null) {
@@ -413,21 +415,23 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         String methodName = getElementNameForCollectionField(fieldNode);
         FieldNode fieldKey = getKeyField(elementType);
 
-        contextClass.addMethod(
-                methodName,
-                Opcodes.ACC_PUBLIC,
-                ClassHelper.VOID_TYPE,
-                params(param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType)),
-                NO_EXCEPTIONS,
-                block(
-                        stmt(callX(getOuterInstanceXforField(fieldNode), "put",
-                                args(
-                                        varX("key"),
-                                        callX(elementType, "create", args("key", "closure"))
-                                )
-                        ))
-                )
-        );
+        if (!isAbstract(elementType)) {
+            contextClass.addMethod(
+                    methodName,
+                    Opcodes.ACC_PUBLIC,
+                    ClassHelper.VOID_TYPE,
+                    params(param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType)),
+                    NO_EXCEPTIONS,
+                    block(
+                            stmt(callX(getOuterInstanceXforField(fieldNode), "put",
+                                    args(
+                                            varX("key"),
+                                            callX(elementType, "create", args("key", "closure"))
+                                    )
+                            ))
+                    )
+            );
+        }
 
         if (!isFinal(elementType)) {
                 contextClass.addMethod(

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static org.codehaus.groovy.ast.ClassHelper.CLASS_Type;
 import static org.codehaus.groovy.ast.ClassHelper.STRING_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.make;
+import static org.codehaus.groovy.ast.expr.MethodCallExpression.NO_ARGUMENTS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.buildWildcardType;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.makeClassSafeWithGenerics;
@@ -263,8 +264,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
                         params(createSubclassClassParameter(annotatedClass), param(ClassHelper.STRING_TYPE, "key"), createAnnotatedClosureParameter(elementType)),
                         NO_EXCEPTIONS,
                         block(
-                                declS(varX("created"), callX(varX("typeToCreate"), "newInstance")),
-                                assignS(propX(varX("created"), fieldKey.getName()), varX("key")),
+                                declS(varX("created"), callX(varX("typeToCreate"), "newInstance", args("key"))),
                                 stmt(callX(getOuterInstanceXforField(fieldNode), "add", callX(varX("created"), "apply", varX("closure"))))
                         )
                 );
@@ -511,9 +511,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
                             : params(createSubclassClassParameter(annotatedClass), createAnnotatedClosureParameter(innerType)),
                     NO_EXCEPTIONS,
                     block(
-                            declS(varX("created"), callX(varX("typeToCreate"), "newInstance")),
-
-
+                            declS(varX("created"), callX(varX("typeToCreate"), "newInstance", hasKeyField ? args("key") : NO_ARGUMENTS)),
                             assignS(propX(varX("this"), fieldNode.getName()),
                                     callX(varX("created"), "apply", varX("closure"))
                             )

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLField.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLField.java
@@ -30,4 +30,8 @@ public @interface DSLField {
      */
     String element() default "";
 
+    /**
+     * Names the classes that are available as shortcuts for this field. Only used for list/map fields.
+     */
+    Class[] alternatives() default {};
 }

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
@@ -12,10 +12,12 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSLCo
     ClassConfig clazz = new ClassConfig(psiClass)
     method(name: "apply", params: [closure: Closure.class.name], type: clazz.type.qualifiedName)
 
-    if (clazz.key)
+    if (clazz.key) {
         method(name: "create", isStatic: true, params: ["$clazz.key": "java.lang.String", closure: Closure.class.name], type: clazz.type.qualifiedName)
-    else
+        method(constructor: true, params: ["$clazz.key": "java.lang.String"])
+    } else {
         method(name: "create", isStatic: true, params: [closure: Closure.class.name], type: clazz.type.qualifiedName)
+    }
 
     classType?.fields?.each { PsiField rawField ->
 

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
@@ -61,6 +61,7 @@ contributor(context(scope: closureScope(isArg: true), ctype:hasAnnotation("com.b
             delegatesTo(elementType.type)
         } else {
             method(name: innerMostKnownClosureField.element, params: elementType.key ? ["$elementType.key": "java.lang.String", value: 'Closure'] : [value: 'Closure'], type: 'void')
+            // TODO: alternatives
             method(name: "reuse", params: [value: elementType.type.qualifiedName], type: 'void')
         }
     }
@@ -129,6 +130,11 @@ class FieldConfig {
 
     boolean isCollectionOfDslObjects() {
         elementType?.resolve()?.getAnnotation("com.blackbuild.groovy.configdsl.transform.DSLConfig")
+    }
+
+    List<PsiClass> getAlternatives() {
+        this.fieldAnnotation?.findAttributeValue("alternatives")
+        // TODO implement
     }
 
     @Override

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
@@ -24,7 +24,20 @@ class AbstractDSLSpec extends Specification {
         instance = clazz.newInstance()
     }
 
+    def newInstanceOf(String className) {
+        return loader.loadClass(className).newInstance()
+    }
+
     def createClass(String code) {
         clazz = loader.parseClass(code)
     }
+
+    def create(String classname, Closure closure) {
+        loader.loadClass(classname).create(closure)
+    }
+
+    def create(String classname, String key, Closure closure) {
+        loader.loadClass(classname).create(key, closure)
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
@@ -25,7 +25,7 @@ class AbstractDSLSpec extends Specification {
     }
 
     def newInstanceOf(String className) {
-        return loader.loadClass(className).newInstance()
+        return getClass(className).newInstance()
     }
 
     def createClass(String code) {
@@ -33,11 +33,16 @@ class AbstractDSLSpec extends Specification {
     }
 
     def create(String classname, Closure closure) {
-        loader.loadClass(classname).create(closure)
+        getClass(classname).create(closure)
     }
 
     def create(String classname, String key, Closure closure) {
-        loader.loadClass(classname).create(key, closure)
+        getClass(classname).create(key, closure)
     }
+
+    def Class<?> getClass(String classname) {
+        loader.loadClass(classname)
+    }
+
 
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/AbstractDSLSpec.groovy
@@ -12,7 +12,10 @@ class AbstractDSLSpec extends Specification {
 
     def setup() {
         def importCustomizer = new ImportCustomizer()
-        importCustomizer.addImports("com.blackbuild.groovy.configdsl.transform.DSLConfig", "com.blackbuild.groovy.configdsl.transform.DSLField")
+        importCustomizer.addImports(
+                "com.blackbuild.groovy.configdsl.transform.DSLConfig",
+                "com.blackbuild.groovy.configdsl.transform.DSLField"
+        )
 
         CompilerConfiguration config = new CompilerConfiguration()
         config.addCompilationCustomizers(importCustomizer)

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -358,5 +358,50 @@ class InheritanceSpec extends AbstractDSLSpec {
         thrown(MissingMethodException)
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    def "Polymorphic list methods with mappings"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+
+                @DSLField(alternatives=[Foo, Bar])
+                List<Foo> foos
+            }
+
+            @DSLConfig
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                bar {
+                    value = "dieter"
+                }
+                foo {
+                }
+            }
+        }
+
+        then:
+        instance.foos[0].class.name == "pk.Bar"
+        instance.foos[0].value == "dieter"
+        instance.foos[1].class.name == "pk.Foo"
+
+    }
+
+
 
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -21,16 +21,47 @@ class InheritanceSpec extends AbstractDSLSpec {
             }
         ''')
 
+        expect:
+        create("pk.Bar") {}.class.name == "pk.Bar"
+
         when:
         instance = create("pk.Bar") {
             name "Klaus"
             value "High"
-
         }
 
         then:
         instance.name == "Klaus"
         instance.value == "High"
+    }
+
+    def "parent class defines key"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+                String parentValue
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Bar", "Klaus") {
+            parentValue "Low"
+            value "High"
+        }
+
+        then:
+        instance.name == "Klaus"
+        instance.value == "High"
+        instance.parentValue == "Low"
     }
 
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -99,6 +99,7 @@ class InheritanceSpec extends AbstractDSLSpec {
         instance.foo.value == "dieter"
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
     def "Polymorphic list methods"() {
         given:
         createClass('''
@@ -143,6 +144,7 @@ class InheritanceSpec extends AbstractDSLSpec {
 
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
     def "Polymorphic list methods with keys"() {
         given:
         createClass('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -273,4 +273,35 @@ class InheritanceSpec extends AbstractDSLSpec {
         instance.foos.heinz.name == "heinz"
     }
 
+    def "abstract fields must not have a non polymorphic accessor"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                Foo foo
+            }
+
+            @DSLConfig
+            abstract class Foo {
+                String name
+            }
+        ''')
+
+        when:
+        clazz.getMethod("foo", Closure)
+
+        then:
+        thrown(NoSuchMethodException)
+
+        when:
+        clazz.getMethod("foo", Class, Closure)
+
+        then:
+        noExceptionThrown()
+
+    }
+
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -5,7 +5,6 @@ import spock.lang.Ignore
 
 class InheritanceSpec extends AbstractDSLSpec {
 
-    @Ignore
     def "objects inheriting from DSLObjects are also DSLObjects"() {
         given:
         createClass('''
@@ -23,17 +22,15 @@ class InheritanceSpec extends AbstractDSLSpec {
         ''')
 
         when:
-        loader.loadClass
+        instance = create("pk.Bar") {
+            name "Klaus"
+            value "High"
 
-        .newInstance()
-        instance.bars {
-            bar { name "Dieter" }
-            bar { name "Klaus"}
         }
 
         then:
-        instance.bars[0].name == "Dieter"
-        instance.bars[1].name == "Klaus"
+        instance.name == "Klaus"
+        instance.value == "High"
     }
 
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -64,5 +64,39 @@ class InheritanceSpec extends AbstractDSLSpec {
         instance.parentValue == "Low"
     }
 
+    def "Polymorphic closure methods"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                Foo foo
+            }
+
+            @DSLConfig
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+            foo(getClass("pk.Bar")) {
+                name = "klaus"
+                value = "dieter"
+            }
+        }
+
+        then:
+        instance.foo.class.name == "pk.Bar"
+        instance.foo.name == "klaus"
+        instance.foo.value == "dieter"
+    }
 
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -1,0 +1,40 @@
+package com.blackbuild.groovy.configdsl.transform.model
+
+import spock.lang.Ignore
+
+
+class InheritanceSpec extends AbstractDSLSpec {
+
+    @Ignore
+    def "objects inheriting from DSLObjects are also DSLObjects"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        loader.loadClass
+
+        .newInstance()
+        instance.bars {
+            bar { name "Dieter" }
+            bar { name "Klaus"}
+        }
+
+        then:
+        instance.bars[0].name == "Dieter"
+        instance.bars[1].name == "Klaus"
+    }
+
+
+}

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -402,6 +402,48 @@ class InheritanceSpec extends AbstractDSLSpec {
 
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    def "Polymorphic map methods with mappings"() {
+        given:
+        createClass('''
+            package pk
 
+            @DSLConfig
+            class Owner {
 
+                @DSLField(alternatives=[Foo, Bar])
+                Map<String, Foo> foos
+            }
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                bar("klaus") {
+                    value = "dieter"
+                }
+                foo("heinz") {
+                }
+            }
+        }
+
+        then:
+        instance.foos.klaus.class.name == "pk.Bar"
+        instance.foos.klaus.name == "klaus"
+        instance.foos.klaus.value == "dieter"
+        instance.foos.heinz.class.name == "pk.Foo"
+        instance.foos.heinz.name == "heinz"
+    }
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -99,4 +99,90 @@ class InheritanceSpec extends AbstractDSLSpec {
         instance.foo.value == "dieter"
     }
 
+    def "Polymorphic list methods"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                List<Foo> foos
+            }
+
+            @DSLConfig
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                foo(getClass("pk.Bar")) {
+                    name = "klaus"
+                    value = "dieter"
+                }
+                foo {
+                    name = "heinz"
+                }
+            }
+        }
+
+        then:
+        instance.foos[0].class.name == "pk.Bar"
+        instance.foos[0].name == "klaus"
+        instance.foos[0].value == "dieter"
+        instance.foos[1].class.name == "pk.Foo"
+        instance.foos[1].name == "heinz"
+
+    }
+
+    def "Polymorphic list methods with keys"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                List<Foo> foos
+            }
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                foo(getClass("pk.Bar"), "klaus") {
+                    value = "dieter"
+                }
+                foo("heinz") {
+                }
+            }
+        }
+
+        then:
+        instance.foos[0].class.name == "pk.Bar"
+        instance.foos[0].name == "klaus"
+        instance.foos[0].value == "dieter"
+        instance.foos[1].class.name == "pk.Foo"
+        instance.foos[1].name == "heinz"
+
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -187,4 +187,46 @@ class InheritanceSpec extends AbstractDSLSpec {
 
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    def "Polymorphic map methods"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                Map<String, Foo> foos
+            }
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+            }
+
+            @DSLConfig
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                foo(getClass("pk.Bar"), "klaus") {
+                    value = "dieter"
+                }
+                foo("heinz") {
+                }
+            }
+        }
+
+        then:
+        instance.foos.klaus.class.name == "pk.Bar"
+        instance.foos.klaus.name == "klaus"
+        instance.foos.klaus.value == "dieter"
+        instance.foos.heinz.class.name == "pk.Foo"
+        instance.foos.heinz.name == "heinz"
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -300,7 +300,62 @@ class InheritanceSpec extends AbstractDSLSpec {
 
         then:
         noExceptionThrown()
+    }
 
+    def "lists of abstract fields must not have polymorphic accessors"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                List<Foo> foos
+            }
+
+            @DSLConfig
+            abstract class Foo {
+                String name
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                foo {}
+            }
+        }
+
+        then:
+        thrown(MissingMethodException)
+    }
+
+    def "maps of abstract fields must not have polymorphic accessors"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Owner {
+                Map<String, Foo> foos
+            }
+
+            @DSLConfig(key = "name")
+            abstract class Foo {
+                String name
+            }
+        ''')
+
+        when:
+        instance = create("pk.Owner") {
+
+            foos {
+                foo("Bla") {}
+            }
+        }
+
+        then:
+        thrown(MissingMethodException)
     }
 
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/InheritanceSpec.groovy
@@ -1,5 +1,6 @@
 package com.blackbuild.groovy.configdsl.transform.model
 
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import spock.lang.Ignore
 
 
@@ -63,6 +64,49 @@ class InheritanceSpec extends AbstractDSLSpec {
         instance.value == "High"
         instance.parentValue == "Low"
     }
+
+    def "parent class defines no key, child does leads to exception"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                String name
+                String parentValue
+            }
+
+            @DSLConfig(key = "name")
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
+    def "parent class defines no key, child defines different key"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+                String parentValue
+            }
+
+            @DSLConfig(key = "value")
+            class Bar extends Foo {
+                String value
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
 
     def "Polymorphic closure methods"() {
         given:

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/MetaSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/MetaSpec.groovy
@@ -1,0 +1,58 @@
+package com.blackbuild.groovy.configdsl.transform.model
+
+import spock.lang.Specification
+
+
+/**
+ * Small tests to test AbstractDSLSpec itself.
+ */
+class MetaSpec extends AbstractDSLSpec {
+
+    def "test create without key"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                String name
+            }
+        ''')
+
+        when:
+        instance = create("pk.Foo") {
+            name = "Klaus"
+        }
+
+        then:
+        noExceptionThrown()
+        instance.name == "Klaus"
+    }
+
+    def "test create with key"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+                String value
+            }
+        ''')
+
+        when:
+        instance = create("pk.Foo", "Klaus") {
+            value "Bla"
+        }
+
+        then:
+        noExceptionThrown()
+        instance.name == "Klaus"
+        instance.value == "Bla"
+    }
+
+
+
+
+}

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -10,7 +10,7 @@ class TransformSpec extends AbstractDSLSpec {
     def "factory methods should be created"() {
         given:
         createClass('''
-            package com.blackbuild.groovy.configdsl.transform.test
+            package pk
 
             @DSLConfig
             class Foo {
@@ -24,7 +24,7 @@ class TransformSpec extends AbstractDSLSpec {
         instance = clazz.create() {}
 
         then:
-        instance.class.name == "com.blackbuild.groovy.configdsl.transform.test.Foo"
+        instance.class.name == "pk.Foo"
     }
 
     def "factory methods with existing factories"() {
@@ -58,7 +58,7 @@ class TransformSpec extends AbstractDSLSpec {
     def "factory methods with key"() {
         given:
         createClass('''
-            package com.blackbuild.groovy.configdsl.transform.test
+            package pk
 
             @DSLConfig(key = "name")
             class Foo {
@@ -77,6 +77,26 @@ class TransformSpec extends AbstractDSLSpec {
 
         and: "no name() accessor is created"
         !instance.class.declaredMethods.find { it.name == "name" }
+    }
+
+    def "constructor is created for keyed object"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+            }
+        ''')
+
+        when:
+        instance = clazz.newInstance("Klaus")
+
+        then:
+        noExceptionThrown()
+        instance.name == "Klaus"
+
     }
 
     def "simple member method"() {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -98,30 +98,6 @@ class TransformSpec extends AbstractDSLSpec {
         instance.name == "Klaus"
     }
 
-    def "keyed constructor reuses existing empty constructor"() {
-        given:
-        createClass('''
-            package pk
-
-            @DSLConfig(key = "name")
-            class Foo {
-                String name
-                int length
-
-                Foo() {
-                    length = 1
-                }
-            }
-        ''')
-
-        when:
-        instance = clazz.newInstance("Klaus")
-
-        then:
-        instance.length == 1
-
-    }
-
     def "simple member method"() {
         given:
         createInstance('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -96,6 +96,29 @@ class TransformSpec extends AbstractDSLSpec {
         then:
         noExceptionThrown()
         instance.name == "Klaus"
+    }
+
+    def "keyed constructor reuses existing empty constructor"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig(key = "name")
+            class Foo {
+                String name
+                int length
+
+                Foo() {
+                    length = 1
+                }
+            }
+        ''')
+
+        when:
+        instance = clazz.newInstance("Klaus")
+
+        then:
+        instance.length == 1
 
     }
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -97,7 +97,7 @@ class TransformSpec extends AbstractDSLSpec {
 
     def "simple member method for reusable config objects"() {
         given:
-        createInstance('''
+        createClass('''
             package pk
 
             @DSLConfig
@@ -112,9 +112,12 @@ class TransformSpec extends AbstractDSLSpec {
         ''')
 
         when:
-        def bar = loader.loadClass("pk.Bar").newInstance()
-        bar.apply { name = "Dieter" }
-        instance.inner = bar
+        def bar = create("pk.Bar") {
+            name = "Dieter"
+        }
+        instance = create("pk.Foo") {
+            inner bar
+        }
 
         then:
         instance.inner.name == "Dieter"
@@ -528,8 +531,9 @@ class TransformSpec extends AbstractDSLSpec {
                 String url
             }
         ''')
-        def aBar = loader.loadClass("pk.Bar").newInstance()
-        aBar.url = "welt"
+        def aBar = create("pk.Bar") {
+            url "welt"
+        }
 
         when:
         instance.bars {
@@ -557,9 +561,9 @@ class TransformSpec extends AbstractDSLSpec {
                 String url
             }
         ''')
-        def aBar = loader.loadClass("pk.Bar").newInstance()
-        aBar.name = "klaus"
-        aBar.url = "welt"
+        def aBar = create("pk.Bar", "klaus") {
+            url "welt"
+        }
 
         when:
         instance.bars {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
@@ -24,3 +24,5 @@ def c = Config.create {
 }
 
 println c.environments.bal.authorizations
+
+new Environment()


### PR DESCRIPTION
- Provides polymorphic closure methods with the actual class as additional parameter
- Provides a new attribute in DSLField 'alternatives' allowing to specify various subclasses of the element type (only valid for lists and maps).
