### PR TITLE
Owner references

### DIFF
--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfig.java
@@ -17,8 +17,8 @@ public @interface DSLConfig {
     String key() default "";
 
     /**
-     * is the Object polymorphic, i.e. should the factory contain an additional class parameter.
+     * If set, automatically sets this field to the containing instance when adding.
      */
-    boolean polymorphic() default false;
+    String owner() default "";
 
 }

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -307,17 +307,25 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
             );
         }
 
+        BlockStatement reuseMethodBody = block(
+                stmt(callX(getOuterInstanceXforField(fieldNode), "add",
+                        varX("value")
+                ))
+        );
+
+        if (ownerFieldOfElement != null) {
+            reuseMethodBody.addStatement(
+                assignS(propX(varX("value"), ownerFieldOfElement.getName()), propX(varX("this"), "outerInstance"))
+            );
+        }
+
         contextClass.addMethod(
                 REUSE_METHOD_NAME,
                 Opcodes.ACC_PUBLIC,
                 ClassHelper.VOID_TYPE,
                 params(param(elementType, "value")),
                 NO_EXCEPTIONS,
-                block(
-                        stmt(callX(getOuterInstanceXforField(fieldNode), "add",
-                                varX("value")
-                        ))
-                )
+                reuseMethodBody
         );
 
         if (fieldKey != null) {
@@ -531,18 +539,25 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
             );
         }
 
+
         //noinspection ConstantConditions
+        BlockStatement reuseMethodBody = block(
+                stmt(callX(getOuterInstanceXforField(fieldNode), "put",
+                        args(propX(varX("value"), getKeyField(elementType).getName()), varX("value"))
+                ))
+        );
+        if (ownerFieldOfElement != null) {
+            reuseMethodBody.addStatement(
+                    assignS(propX(varX("value"), ownerFieldOfElement.getName()), propX(varX("this"), "outerInstance"))
+            );
+        }
         contextClass.addMethod(
-                "reuse",
+                REUSE_METHOD_NAME,
                 Opcodes.ACC_PUBLIC,
                 ClassHelper.VOID_TYPE,
                 params(param(elementType, "value")),
                 NO_EXCEPTIONS,
-                block(
-                        stmt(callX(getOuterInstanceXforField(fieldNode), "put",
-                                args(propX(varX("value"), getKeyField(elementType).getName()), varX("value"))
-                        ))
-                )
+                reuseMethodBody
         );
 
         contextClass.addMethod(

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -27,6 +27,71 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         getClass("pk.Bar").metaClass.getMetaMethod("owner", clazz) == null
     }
 
+    def "error: two different owners in hierarchy"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(owner="owner")
+            class Bar {
+                Foo owner
+            }
+
+            @DSLConfig(owner="owner2")
+            class ChildBar extends Bar {
+                Foo owner2
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
+    def "error: owner points to not existing field"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(owner="own")
+            class Bar {
+                Foo owner
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
+    def "error: owner field is no dsl object"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(owner="owner")
+            class Bar {
+                String owner
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
     def "owner reference for single dsl object"() {
         given:
         createClass('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -115,6 +115,43 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         then:
         instance.bar.owner.is(instance)
+
+        when:
+        instance = clazz.create {
+            bar(getClass("pk.Bar")) {}
+        }
+
+        then:
+        instance.bar.owner.is(instance)
+    }
+
+    def "owner reference for dsl object list"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                List<Bar> bars
+            }
+
+            @DSLConfig(owner="owner")
+            class Bar {
+                Foo owner
+            }
+        ''')
+
+        when:
+        instance = clazz.create {
+            bars {
+                bar {}
+                bar(getClass("pk.Bar")) {}
+            }
+        }
+
+        then:
+        instance.bars[0].owner.is(instance)
+        instance.bars[1].owner.is(instance)
     }
 
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -125,6 +125,59 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         instance.bar.owner.is(instance)
     }
 
+    def "reusing of objects in list closure sets owner"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                List<Bar> bars
+            }
+
+            @DSLConfig(owner = "owner")
+            class Bar {
+                Foo owner
+            }
+        ''')
+        def aBar = create("pk.Bar") {}
+
+        when:
+        instance.bars {
+            reuse(aBar)
+        }
+
+        then:
+        instance.bars[0].owner.is(instance)
+    }
+
+    def "reusing of objects in map closure sets owner"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Map<String, Bar> bars
+            }
+
+            @DSLConfig(key = "name", owner = "owner")
+            class Bar {
+                String name
+                Foo owner
+            }
+        ''')
+        def aBar = create("pk.Bar", "Klaus") {}
+
+        when:
+        instance.bars {
+            reuse(aBar)
+        }
+
+        then:
+        instance.bars.Klaus.owner.is(instance)
+    }
+
     def "owner reference for dsl object list"() {
         given:
         createClass('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -154,4 +154,34 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         instance.bars[1].owner.is(instance)
     }
 
+    def "owner reference for dsl object map"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Map<String, Bar> bars
+            }
+
+            @DSLConfig(key="name", owner="owner")
+            class Bar {
+                Foo owner
+                String name
+            }
+        ''')
+
+        when:
+        instance = clazz.create {
+            bars {
+                bar("Klaus") {}
+                bar(getClass("pk.Bar"), "Dieter") {}
+            }
+        }
+
+        then:
+        instance.bars.Klaus.owner.is(instance)
+        instance.bars.Dieter.owner.is(instance)
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -1,0 +1,55 @@
+package com.blackbuild.groovy.configdsl.transform.model
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+
+import java.lang.reflect.Method
+
+@SuppressWarnings("GroovyAssignabilityCheck")
+class OwnerReferencesSpec extends AbstractDSLSpec {
+
+    def "if owners is specified, no owner accessor is created"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(owner="owner")
+            class Bar {
+                Foo owner
+            }
+        ''')
+
+        then:
+        getClass("pk.Bar").metaClass.getMetaMethod("owner", clazz) == null
+    }
+
+    def "owner reference for single dsl object"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(owner="owner")
+            class Bar {
+                Foo owner
+            }
+        ''')
+
+        when:
+        instance = clazz.create {
+            bar {}
+        }
+
+        then:
+        instance.bar.owner.is(instance)
+    }
+
+}


### PR DESCRIPTION
Inner DSL Objects can optionally have a field designated as "owner" via the owner attribute of the `@DSLConfig` annotation. This field is automatically filled with the owning object when this object is set via closure or list/map closures.

This also works for reuse methods.

Note however that using reuse multiple times simply overrides the owner field each time.
