### PR TITLE
Reuse improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ creates the following methods (in Config):
 
 ```groovy
 def unkeyed(UnKeyed reuse) // reuse an exiting object
-def unkeyed(@DelegatesTo(Unkeyed) Closure closure)
+Unkeyed unkeyed(@DelegatesTo(Unkeyed) Closure closure)
 def keyed(UnKeyed reuse) // reuse an exiting object
-def keyed(String key, @DelegatesTo(Unkeyed) Closure closure)
+Keyed keyed(String key, @DelegatesTo(Unkeyed) Closure closure)
 ```
 
 Usage:
@@ -356,6 +356,21 @@ Config.create {
 }
 ```
 
+The closure methods return the created objects, so you can also do the following:
+
+```groovy
+def objectForReuse
+Config.create {
+    objectForReuse = unkeyed {
+        name "other"
+    }
+}
+
+Config.create {
+    unkeyed objectForReuse
+}
+```
+
 #### Collections of DSL Objects
 
 Collections of DSL-Objects are created using a nested closure. The name of the outer closure is the field name, the 
@@ -363,6 +378,8 @@ name of the inner closures the element name (which defaults to field name minus 
 keyed members to a list and to a map is identical (obviously, only keyed objects can be added to a map).
 
 Additionally, a special reuse method is created, which takes an existing object and adds it to the structure.
+
+As with simple objects, the inner closures return the existing object for reuse
 
 ```groovy
 @DSLConfig
@@ -384,6 +401,7 @@ class Keyed {
 }
 
 def objectForReuse = UnKeyed.create { name = "reuse" }
+def anotherObjectForReuse
 
 Config.create {
     elements {
@@ -396,7 +414,7 @@ Config.create {
         reuse objectForReuse
     }
     keyedElements {
-        keyedElement ("klaus") {
+        anotherObjectForReuse = keyedElement ("klaus") {
             value "a Value"
         }
     }
@@ -404,6 +422,7 @@ Config.create {
         mapElement ("dieter") {
             value "another"
         }
+        reuse anotherObjectForReuse
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -474,11 +474,10 @@ This has two dangers:
 
 - no validity checks are performed during transformation time, leading to runtime ClassCastExceptions if the owner
   type is incorrect
-- If an object is used using the `_use()` method, the owner field will simply be overridden with the last owner.
-  Thus, an object should normally only be used once (either directly or using the `_use()` method). In other words,
-  `_use()` should be only used for objects created outside of the configuration structure. Later versions of config-dsl
-  might throw an exception when trying to override an existing owner.
-- if an object is reused, the owner field will not be overridden.
+- If an object that already has an existing owner is added using the `_use()` method, an IllegalStateException is thrown.
+  Thus, an object can only be _used_ once (either directly or using the `_use()` method). In other words,
+  `_use()` can only be used for objects created outside of the configuration structure.
+- if an object is _reused_ instead (using `_reuse()`, the owner field will not be overridden.
 
 ```groovy
 @DSLConfig

--- a/README.md
+++ b/README.md
@@ -377,7 +377,13 @@ Collections of DSL-Objects are created using a nested closure. The name of the o
 name of the inner closures the element name (which defaults to field name minus a trailing 's'). The syntax for adding
 keyed members to a list and to a map is identical (obviously, only keyed objects can be added to a map).
 
-Additionally, a special reuse method is created, which takes an existing object and adds it to the structure.
+Additionally, two special methods are created that takes an existing object and adds it to the structure:
+
+- `_use()` takes an existing object. This allows for structuring your cod (for example by creating the object in a method)
+
+- `_reuse()` does the same, but does not set the owner field of the inner object to the new container.
+
+- if the added element does not have an owner field, both methods behave identically.
 
 As with simple objects, the inner closures return the existing object for reuse
 
@@ -411,7 +417,7 @@ Config.create {
         element {
             name "another element"
         }
-        reuse objectForReuse
+        _use objectForReuse
     }
     keyedElements {
         anotherObjectForReuse = keyedElement ("klaus") {
@@ -422,7 +428,7 @@ Config.create {
         mapElement ("dieter") {
             value "another"
         }
-        reuse anotherObjectForReuse
+        _reuse anotherObjectForReuse
     }
 }
 ```
@@ -468,7 +474,11 @@ This has two dangers:
 
 - no validity checks are performed during transformation time, leading to runtime ClassCastExceptions if the owner
   type is incorrect
-- If an object is reused, the owner field will simply be overridden with the last owner.
+- If an object is used using the `_use()` method, the owner field will simply be overridden with the last owner.
+  Thus, an object should normally only be used once (either directly or using the `_use()` method). In other words,
+  `_use()` should be only used for objects created outside of the configuration structure. Later versions of config-dsl
+  might throw an exception when trying to override an existing owner.
+- if an object is reused, the owner field will not be overridden.
 
 ```groovy
 @DSLConfig

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -209,22 +209,26 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         if (!isAbstract(elementType)) {
             createPublicMethod(methodName)
+                    .returning(elementType)
                     .optionalStringParam("key", fieldKey)
                     .delegatingClosureParam(elementType)
                     .declS("created", callX(elementType, "create", argsWithOptionalKeyAndClosure(fieldKey)))
                     .callS(getOuterInstanceXforField(fieldNode), "add", varX("created"))
                     .optionalAssignS(propX(varX("created"), ownerFieldOfElementName), propX(varX("this"), "outerInstance"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(contextClass);
         }
 
         if (!isFinal(elementType)) {
             createPublicMethod(methodName)
+                    .returning(elementType)
                     .classParam("typeToCreate", elementType)
                     .optionalStringParam("key", fieldKey)
                     .delegatingClosureParam(elementType)
                     .declS("created", callX(varX("typeToCreate"), "newInstance", optionalKeyArg(fieldKey)))
                     .callS(getOuterInstanceXforField(fieldNode), "add", callX(varX("created"), "apply", varX("closure")))
                     .optionalAssignS(propX(varX("created"), ownerFieldOfElementName), propX(varX("this"), "outerInstance"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(contextClass);
         }
 
@@ -390,16 +394,19 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         if (!isAbstract(elementType)) {
             createPublicMethod(methodName)
+                    .returning(elementType)
                     .param(keyType, "key")
                     .delegatingClosureParam(elementType)
                     .declS("created", callX(elementType, "create", args("key", "closure")))
                     .callS(getOuterInstanceXforField(fieldNode), "put", args(varX("key"), varX("created")))
                     .optionalAssignS(propX(varX("created"), ownerFieldOfElementName), propX(varX("this"), "outerInstance"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(contextClass);
         }
 
         if (!isFinal(elementType)) {
             createPublicMethod(methodName)
+                    .returning(elementType)
                     .classParam("typeToCreate", elementType)
                     .param(keyType, "key")
                     .delegatingClosureParam(elementType)
@@ -407,6 +414,7 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
                     .callS(varX("created"), "apply", varX("closure"))
                     .callS(getOuterInstanceXforField(fieldNode), "put", args(varX("key"), varX("created")))
                     .optionalAssignS(propX(varX("created"), ownerFieldOfElementName), propX(varX("this"), "outerInstance"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(contextClass);
         }
 

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -37,7 +37,8 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
     private static final ClassNode[] NO_EXCEPTIONS = new ClassNode[0];
     private static final ClassNode DSL_CONFIG_ANNOTATION = make(DSLConfig.class);
     private static final ClassNode DSL_FIELD_ANNOTATION = make(DSLField.class);
-    private static final String REUSE_METHOD_NAME = "reuse";
+    public static final String REUSE_METHOD_NAME = "_reuse";
+    public static final String USE_METHOD_NAME = "_use";
     private static final ClassNode EQUALS_HASHCODE_ANNOT = make(EqualsAndHashCode.class);
     private static final ClassNode TOSTRING_ANNOT = make(ToString.class);
     private ClassNode annotatedClass;
@@ -244,6 +245,11 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
         createPublicMethod(REUSE_METHOD_NAME)
                 .param(elementType, "value")
                 .callS(getOuterInstanceXforField(fieldNode), "add", varX("value"))
+                .addTo(contextClass);
+
+        createPublicMethod(USE_METHOD_NAME)
+                .param(elementType, "value")
+                .callS(getOuterInstanceXforField(fieldNode), "add", varX("value"))
                 .optionalAssignS(propX(varX("value"), ownerFieldOfElementName), propX(varX("this"), "outerInstance"), ownerFieldOfElement)
                 .addTo(contextClass);
 
@@ -429,6 +435,14 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         //noinspection ConstantConditions
         createPublicMethod(REUSE_METHOD_NAME)
+                .param(elementType, "value")
+                .callS(getOuterInstanceXforField(fieldNode), "put",
+                        args(propX(varX("value"), getKeyField(elementType).getName()), varX("value"))
+                )
+                .addTo(contextClass);
+
+        //noinspection ConstantConditions
+        createPublicMethod(USE_METHOD_NAME)
                 .param(elementType, "value")
                 .callS(getOuterInstanceXforField(fieldNode), "put",
                         args(propX(varX("value"), getKeyField(elementType).getName()), varX("value"))

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLConfigASTTransformation.java
@@ -445,22 +445,26 @@ public class DSLConfigASTTransformation extends AbstractASTTransformation {
 
         if (!isAbstract(fieldType)) {
             createPublicMethod(methodName)
+                    .returning(fieldType)
                     .optionalStringParam("key", keyField)
                     .delegatingClosureParam(fieldType)
                     .declS("created", callX(fieldType, "create", argsWithOptionalKeyAndClosure(keyField)))
                     .assignS(propX(varX("this"), fieldNode.getName()), varX("created"))
                     .optionalAssignS(propX(varX("created"), ownerFieldName), varX("this"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(annotatedClass);
         }
 
         if (!isFinal(fieldType)) {
             createPublicMethod(methodName)
+                    .returning(fieldType)
                     .classParam("typeToCreate", fieldType)
                     .optionalStringParam("key", keyField)
                     .delegatingClosureParam(fieldType)
                     .declS("created", callX(varX("typeToCreate"), "newInstance", optionalKeyArg(keyField)))
                     .assignS(propX(varX("this"), fieldNode.getName()), callX(varX("created"), "apply", varX("closure")))
                     .optionalAssignS(propX(varX("created"), ownerFieldName), varX("this"), ownerFieldOfElement)
+                    .statement(returnS(varX("created")))
                     .addTo(annotatedClass);
         }
     }

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSLConfig.gdsl
@@ -124,7 +124,13 @@ contributor(context(scope: closureScope(), ctype:hasAnnotation("com.blackbuild.g
             )
             // TODO: alternatives
             method(
-                    name: "reuse",
+                    name: DSLConfigASTTransformation.REUSE_METHOD_NAME,
+                    doc: "Reuses an existing instance of $elementType.type.qualifiedName" as String,
+                    params: [value: elementType.type.qualifiedName],
+                    type: 'void'
+            )
+            method(
+                    name: DSLConfigASTTransformation.USE_METHOD_NAME,
                     doc: "Reuses an existing instance of $elementType.type.qualifiedName" as String,
                     params: [value: elementType.type.qualifiedName],
                     type: 'void'

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -53,7 +53,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         thrown(MultipleCompilationErrorsException)
     }
 
-    def "error: owner points to not existing field"() {
+    def "error: owner points to non existing field"() {
         when:
         createClass('''
             package pk
@@ -127,7 +127,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         instance.bar.owner.is(instance)
     }
 
-    def "reusing of objects in list closure sets owner"() {
+    def "using of existing objects in list closure sets owner"() {
         given:
         createInstance('''
             package pk
@@ -146,15 +146,46 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            reuse(aBar)
+            _use aBar
         }
 
         then:
         instance.bars[0].owner.is(instance)
     }
 
-    @Ignore("yet")
-    def "reusing of objects in map closure does not set owner"() {
+    def "reusing of objects in list closure does not set owner"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                List<Bar> bars
+            }
+
+            @DSLConfig(owner = "owner")
+            class Bar {
+                Foo owner
+            }
+        ''')
+
+        when:
+        def aBar
+        instance.bars {
+            aBar = bar {}
+        }
+
+        def otherInstance = create("pk.Foo") {
+            bars {
+                _reuse(aBar)
+            }
+        }
+
+        then: "bar's owner should still be the first object"
+        otherInstance.bars[0].owner.is(instance)
+    }
+
+    def "reusing of existing objects in map closure does not set owner"() {
         given:
         createClass('''
             package pk
@@ -184,7 +215,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         create("pk.Fum") {
             bars {
-                reuse aBar
+                _reuse aBar
             }
         }
 
@@ -193,7 +224,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
     }
 
 
-    def "reusing of objects in map closure sets owner"() {
+    def "using exisiting objects in map closure sets owner"() {
         given:
         createInstance('''
             package pk
@@ -213,7 +244,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            reuse(aBar)
+            _use(aBar)
         }
 
         then:

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -153,6 +153,46 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         instance.bars[0].owner.is(instance)
     }
 
+    @Ignore("yet")
+    def "reusing of objects in map closure does not set owner"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Bar bar
+            }
+
+            @DSLConfig(key = "name", owner = "owner")
+            class Bar {
+                String name
+                Foo owner
+            }
+
+            @DSLConfig
+            class Fum {
+                Map<String, Bar> bars
+            }
+        ''')
+
+        when:
+        def aBar
+        instance = create("pk.Foo") {
+            aBar = bar("Klaus") {}
+        }
+
+        create("pk.Fum") {
+            bars {
+                reuse aBar
+            }
+        }
+
+        then:
+        aBar.owner.is(instance)
+    }
+
+
     def "reusing of objects in map closure sets owner"() {
         given:
         createInstance('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -408,6 +408,35 @@ class TransformSpec extends AbstractDSLSpec {
         instance.bars[1].name == "Klaus"
     }
 
+    def "inner list objects closure should return the object"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                List<Bar> bars
+            }
+
+            @DSLConfig
+            class Bar {
+                String name
+            }
+        ''')
+
+        when:
+        def bar1
+        def bar2
+        instance.bars {
+            bar1 = bar { name "Dieter" }
+            bar2 = bar { name "Klaus"}
+        }
+
+        then:
+        bar1.name == "Dieter"
+        bar2.name == "Klaus"
+    }
+
     def "create list of named inner objects"() {
         given:
         createInstance('''
@@ -436,6 +465,36 @@ class TransformSpec extends AbstractDSLSpec {
         instance.bars[0].url == "1"
         instance.bars[1].name == "Klaus"
         instance.bars[1].url == "2"
+    }
+
+    def "inner list objects closure with named objects should return the created object"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                List<Bar> bars
+            }
+
+            @DSLConfig(key="name")
+            class Bar {
+                String name
+                String url
+            }
+        ''')
+
+        when:
+        def bar1
+        def bar2
+        instance.bars {
+            bar1 = bar("Dieter") { url "1" }
+            bar2 = bar("Klaus") { url "2" }
+        }
+
+        then:
+        bar1.name == "Dieter"
+        bar2.name == "Klaus"
     }
 
     def "create list of named inner objects using name method"() {
@@ -684,6 +743,36 @@ class TransformSpec extends AbstractDSLSpec {
         then:
         instance.bars.Dieter.url == "1"
         instance.bars.Klaus.url == "2"
+    }
+
+    def "creation of inner objects in map should return the create object"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSLConfig
+            class Foo {
+                Map<String, Bar> bars
+            }
+
+            @DSLConfig(key="name")
+            class Bar {
+                String name
+                String url
+            }
+        ''')
+
+        when:
+        def bar1
+        def bar2
+        instance.bars {
+            bar1 = bar("Dieter") { url "1" }
+            bar2 = bar("Klaus") { url "2" }
+        }
+
+        then:
+        bar1.url == "1"
+        bar2.url == "2"
     }
 
     def "reusing of objects in closure"() {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -796,7 +796,7 @@ class TransformSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            reuse(aBar)
+            _reuse(aBar)
         }
 
         then:
@@ -826,7 +826,7 @@ class TransformSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            reuse(aBar)
+            _reuse(aBar)
         }
 
         then:

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -340,12 +340,15 @@ class TransformSpec extends AbstractDSLSpec {
         ''')
 
         when:
-        instance.inner {
+        def inner = instance.inner {
             name "Dieter"
         }
 
         then:
         instance.inner.name == "Dieter"
+
+        and: "object should be returned by closure"
+        inner != null
     }
 
     def "create inner object via key and closure"() {
@@ -366,13 +369,16 @@ class TransformSpec extends AbstractDSLSpec {
         ''')
 
         when:
-        instance.inner("Dieter") {
+        def inner = instance.inner("Dieter") {
             value 15
         }
 
         then:
         instance.inner.name == "Dieter"
         instance.inner.value == 15
+
+        and: "object should be returned by closure"
+        inner != null
     }
 
     def "create list of inner objects"() {


### PR DESCRIPTION
- The reuse() method is renamed to _reuse() to be consitent with the new _use() method. Difference between both methods is the handling of owner field. While _reuse() leaves it untouched, _use sets the owner field (if present), resulting now in an IllegalStateException if the field is already set.
- collection element closures do now return the created object. This allows easier reusing of such objects.
