### PR TITLE
Remove renaming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@ pending
 - **Breaking change**
 - Major renaming of annotations:
   - DSLConfig -> DSL
-  - DSLField -> Field
 - Owner and Keys are now decorated by own annotations
+- Removed Ability to rename fields using the field annotation
+- The ability to rename the inner values is retained.
 
 0.11.0
 ======

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
@@ -211,7 +211,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     private String getElementNameForCollectionField(FieldNode fieldNode) {
         AnnotationNode fieldAnnotation = getAnnotation(fieldNode, DSL_FIELD_ANNOTATION);
 
-        String result = getNullSafeMemberStringValue(fieldAnnotation, "element", null);
+        String result = getNullSafeMemberStringValue(fieldAnnotation, "members", null);
 
         if (result != null && result.length() > 0) return result;
 

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
@@ -196,16 +196,10 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     }
 
     private void createSingleFieldSetterMethod(FieldNode fieldNode) {
-        createPublicMethod(getMethodNameForField(fieldNode))
+        createPublicMethod(fieldNode.getName())
                 .param(fieldNode.getType(), "value")
                 .assignS(propX(varX("this"), fieldNode.getName()), varX("value"))
                 .addTo(annotatedClass);
-    }
-
-    private String getMethodNameForField(FieldNode fieldNode) {
-        AnnotationNode fieldAnnotation = getAnnotation(fieldNode, DSL_FIELD_ANNOTATION);
-
-        return getNullSafeMemberStringValue(fieldAnnotation, "value", fieldNode.getName());
     }
 
     private String getElementNameForCollectionField(FieldNode fieldNode) {
@@ -215,7 +209,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         if (result != null && result.length() > 0) return result;
 
-        String collectionMethodName = getMethodNameForField(fieldNode);
+        String collectionMethodName = fieldNode.getName();
 
         if (collectionMethodName.endsWith("s"))
             return collectionMethodName.substring(0, collectionMethodName.length() - 1);
@@ -245,7 +239,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
     private void createListOfSimpleElementsMethods(FieldNode fieldNode, ClassNode elementType) {
 
-        createPublicMethod(getMethodNameForField(fieldNode))
+        createPublicMethod(fieldNode.getName())
                 .arrayParam(elementType, "values")
                 .statement(callX(propX(varX("this"), fieldNode.getName()), "addAll", varX("values")))
                 .addTo(annotatedClass);
@@ -263,7 +257,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
     private void createContextClosure(FieldNode fieldNode, InnerClassNode contextClass) {
 
-        createPublicMethod(getMethodNameForField(fieldNode))
+        createPublicMethod(fieldNode.getName())
                 .delegatingClosureParam(contextClass)
                 .declS("context", ctorX(contextClass, varX("this")))
                 .statements(delegateToClosure())
@@ -452,7 +446,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     }
 
     private void createMapOfSimpleElementsMethods(FieldNode fieldNode, ClassNode keyType, ClassNode valueType) {
-        String methodName = getMethodNameForField(fieldNode);
+        String methodName = fieldNode.getName();
 
         createPublicMethod(methodName)
                 .param(fieldNode.getType(), "values")
@@ -547,7 +541,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     }
 
     private void createSingleDSLObjectClosureMethod(FieldNode fieldNode) {
-        String methodName = getMethodNameForField(fieldNode);
+        String methodName = fieldNode.getName();
 
         ClassNode fieldType = fieldNode.getType();
         FieldNode keyField = getKeyField(fieldType);

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
@@ -9,12 +9,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Controls specific behaviour for certain fields. Currently, this annotation only makes sense for
+ * collection fields.
+ */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.SOURCE)
 public @interface Field {
 
     /**
-     * Name of the inner methods for collections. If empty (default), use fieldname/value stripped of a trailing 's'
+     * Name of the inner methods for collections. If empty (default), use fieldname stripped of a trailing 's'
      * (i.e. if the field is called environments, the elements are called environment by default. If the fieldname
      * does not end with an 's', the field name is used as is.
      */

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
@@ -14,22 +14,11 @@ import java.lang.annotation.Target;
 public @interface Field {
 
     /**
-     * Name of the method(s) of the dsl for this field. If empty, use fieldname. If the annotated field is a collection,
-     * use, this is the name of a wrapping closure. In this case, a '-' denotes no wrapping closure at all.
-     */
-    String value() default "";
-
-    /**
-     * If true, this field is optional, i.e. during validation is accepted to be empty/null.
-     */
-    boolean optional() default false;
-
-    /**
      * Name of the inner methods for collections. If empty (default), use fieldname/value stripped of a trailing 's'
      * (i.e. if the field is called environments, the elements are called environment by default. If the fieldname
      * does not end with an 's', the field name is used as is.
      */
-    String element() default "";
+    String members() default "";
 
     /**
      * Names the classes that are available as shortcuts for this field. Only used for list/map fields.

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
@@ -182,7 +182,7 @@ class FieldConfig {
         name = this.fieldAnnotation?.findDeclaredAttributeValue("value")?.node?.text ?: field.name
         name = name.replace('"', '')
         optional = this.fieldAnnotation?.findDeclaredAttributeValue("optional")?.node?.text ?: false
-        element = this.fieldAnnotation?.findDeclaredAttributeValue("element")?.node?.text?.replace('"', '')
+        element = this.fieldAnnotation?.findDeclaredAttributeValue("members")?.node?.text?.replace('"', '')
 
         if (!element)
             element = name.endsWith('s') ? name[0..-2] : name

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
@@ -88,7 +88,7 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
                         type: 'void'
                 )
                 method(
-                        name: field.element,
+                        name: field.memberName,
                         doc: "Adds a single ${field.elementType} to $field.name list" as String,
                         params: [value: field.elementType?.canonicalText],
                         type: 'void'
@@ -101,7 +101,7 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
                         type: 'void'
                 )
                 method(
-                        name: field.element,
+                        name: field.memberName,
                         doc: "Adds a single ${field.elementType} to $field.name map using key as the key." as String,
                         params: [key: field.keyType?.canonicalText, value: field.valueType?.canonicalText],
                         type: 'void'
@@ -122,18 +122,18 @@ contributor(context(scope: closureScope(), ctype:hasAnnotation("com.blackbuild.g
 
     ClassConfig clazz = new ClassConfig(psiClass)
 
-    def innerMostKnownClosureField = clazz.allDslCollectionFields.find{FieldConfig field -> enclosingCall(field.name) || enclosingCall(field.element)}
+    def innerMostKnownClosureField = clazz.allDslCollectionFields.find{FieldConfig field -> enclosingCall(field.name) || enclosingCall(field.memberName)}
 
     if (innerMostKnownClosureField) {
 
         def elementType = innerMostKnownClosureField.targetConfig
 
-        if (enclosingCall(innerMostKnownClosureField.element)) {
+        if (enclosingCall(innerMostKnownClosureField.memberName)) {
             delegatesTo(elementType.type)
         } else {
             method(
-                    name: innerMostKnownClosureField.element,
-                    doc: "Creates s single instance of $innerMostKnownClosureField.element and adds it." as String,
+                    name: innerMostKnownClosureField.memberName,
+                    doc: "Creates s single instance of $innerMostKnownClosureField.memberName and adds it." as String,
                     params: elementType.key ? ["$elementType.key": "java.lang.String", value: 'Closure'] : [value: 'Closure'],
                     type: 'void'
             )
@@ -167,8 +167,7 @@ The added objects must not have an owner yet.""" as String,
 @SuppressWarnings("GroovyAssignabilityCheck")
 class FieldConfig {
     String name
-    boolean optional
-    String element
+    String memberName
     PsiField field
 
     ClassConfig targetConfig
@@ -179,13 +178,11 @@ class FieldConfig {
     FieldConfig(PsiField field) {
         this.field = field
         this.fieldAnnotation = field.getAnnotation("com.blackbuild.groovy.configdsl.transform.Field")
-        name = this.fieldAnnotation?.findDeclaredAttributeValue("value")?.node?.text ?: field.name
-        name = name.replace('"', '')
-        optional = this.fieldAnnotation?.findDeclaredAttributeValue("optional")?.node?.text ?: false
-        element = this.fieldAnnotation?.findDeclaredAttributeValue("members")?.node?.text?.replace('"', '')
+        name = field.name
+        memberName = this.fieldAnnotation?.findDeclaredAttributeValue("members")?.node?.text?.replace('"', '')
 
-        if (!element)
-            element = name.endsWith('s') ? name[0..-2] : name
+        if (!memberName)
+            memberName = name.endsWith('s') ? name[0..-2] : name
 
         ClassConfig config = new ClassConfig(field.classType)
         if (config.dslClass) {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/DebugSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/DebugSpec.groovy
@@ -4,6 +4,9 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ImportCustomizer
 import spock.lang.Specification
 
+/**
+ * No actual test, just a place to quickly debug Transformation.
+ */
 class DebugSpec extends AbstractDSLSpec {
 
     def "Can be debugged"() {
@@ -14,11 +17,8 @@ class Config {
 
     String name
 
-    @Field(optional = true) String value
+    @Field String value
     int age
-
-    //@Field("env")
-    //Map<String, Environment> environments = [:]
 }
 
 @DSL

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -848,6 +848,33 @@ class TransformSpec extends AbstractDSLSpec {
         thrown(MultipleCompilationErrorsException)
     }
 
+    def "error: alternatives field of Field annotation is only allowed on collections"() {
+        when:
+        createClass('''
+            package pk
 
+            @DSL
+            class Foo {
+                @Field(alternatives = [Foo]) String name
+            }
+        ''')
 
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
+    def "error: members field of Field annotation is only allowed on collections"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Foo {
+                @Field(members = "bla") String name
+            }
+        ''')
+
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -264,22 +264,6 @@ class TransformSpec extends AbstractDSLSpec {
         instance.inner.name == "Dieter"
     }
 
-    def "simple member method with renaming annotation"() {
-        given:
-        createInstance('''
-            @DSL
-            class Foo {
-                @Field("firstname") String name
-                String lastname
-            }
-        ''')
-
-        when:
-        instance.firstname "Dieter"
-
-        then:
-        instance.name == "Dieter"
-    }
     def "test existing method"() {
         given:
         createInstance('''
@@ -292,21 +276,6 @@ class TransformSpec extends AbstractDSLSpec {
 
         expect: "Original method is called"
         instance.name("Dieter") == "run"
-    }
-
-    def "test existing method with renaming"() {
-        given:
-        createInstance('''
-            @DSL
-            class Foo {
-                @Field("firstname") String name
-                String lastname
-                def firstname(String value) {return "run"}
-            }
-        ''')
-
-        expect: "Original method is called"
-        instance.firstname("Dieter") == "run"
     }
 
     def "create inner object via closure"() {
@@ -608,7 +577,7 @@ class TransformSpec extends AbstractDSLSpec {
 
             @DSL
             class Foo {
-                @Field(element="more")
+                @Field(members="more")
                 List<String> values
             }
         ''')

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -570,7 +570,7 @@ class TransformSpec extends AbstractDSLSpec {
         instance.values == ["Dieter", "Klaus", "Heinz", "singleadd"]
     }
 
-    def "simple list element with different element name"() {
+    def "simple list element with different member name"() {
         given:
         createInstance('''
             package pk

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
@@ -9,10 +9,10 @@ class Config {
 
     String name
 
-    @Field(optional = true) String value
+    @Field String value
     int age
 
-    @Field(value = "envs", element = "e")
+    @Field(members = "e")
     Map<String, Environment> environments
 
     Options options
@@ -47,13 +47,6 @@ class Authorization {
     Map<String, String> partners;
 
     List<Integer> everything;
-
-    @Field("rens")
-    List<Integer> renamed;
-
-    @Field(value = "others", element = "more")
-    List<Integer> another;
-
 }
 
 class Other {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
@@ -12,7 +12,7 @@ class Config {
     @Field String value
     int age
 
-    @Field(members = "e")
+    @Field(members = "env")
     Map<String, Environment> environments
 
     Options options
@@ -20,7 +20,7 @@ class Config {
 
 @DSL
 class Options {
-    Map<String, String> oValues
+    Map<String, String> values
     boolean condition
 
     def getAllUnderscoreOptions() {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User.groovy
@@ -6,13 +6,13 @@ def c = Config.create {
 
     options {
         values(_a: "b", c: "d")
-        conition true
+        condition true
 
     }
 
-    envs {
+    environments  {
 
-        e("bal") {
+        env("bal") {
 
             authorizations {
 
@@ -27,7 +27,7 @@ def c = Config.create {
 }
 
 Options.create {
-    oValue("bla", "blub")
+    value("bla", "blub")
 
 }
 
@@ -46,15 +46,13 @@ Environment.create("Bla") {
         authorization {
 
         }
-        reuse()
+        _use(auth)
     }
 }
 
 println c.name
 
 def a = new Authorization()
-
-a.another
 
 a.roles "Klaus", "Dieter"
 a.role "Dieter"
@@ -66,32 +64,3 @@ a.partner("Klas", "Han")
 
 a.everything(1, 2)
 a.everything 2
-
-a.ren(10)
-a.rens(10,15)
-
-a.others(10, 5)
-a.more(8)
-
-a.apply {
-    others(10)
-    more(5)
-
-
-    Authorization.create {
-        others(10)
-
-    }
-
-    Environment.create("bla") {
-
-        url "hallo"
-
-    }
-
-    Environment.create("name") {
-        url "bla"
-
-    }
-
-}

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
@@ -7,9 +7,9 @@ def auth = Authorization.create {
 def c = Config.create {
     name "klaus"
 
-    envs {
+    environments {
 
-        e("bal") {
+        env("bal") {
             age 10
             authorizations {
 
@@ -29,4 +29,3 @@ def c = Config.create {
 
 println c.environments.bal.authorizations
 
-new Environment()

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/mockup/ConfigUser.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/mockup/ConfigUser.groovy
@@ -9,10 +9,10 @@ class Config {
 
     String name
 
-    @Field(optional = true) String value
+    @Field String value
     int age
 
-    @Field("env")
+    @Field
     Map<String, Environment> environments = [:]
 
 


### PR DESCRIPTION
Removed an unused (and yet undocumented) feature to rename the setter methods for a field. This was unnecessary, since instead of including the attribute, one could as well simply rename the field itself.

What is retained is the ability to rename the inner methods in collections.
