### PR TITLE
Drop _reuse und _use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.13.0
+- Completely dropped _use and _reuse (they never looked nice anyway).
+- Both are now replace with an element adder method taking a single existing object.
+- Owner is only overriden if not yet set.
+
 ## 0.12.4
 Fixed a StackOverflowError with which occured when using Owner fields with inheritance 
 

--- a/README.md
+++ b/README.md
@@ -377,11 +377,10 @@ Collections of DSL-Objects are created using a nested closure. The name of the o
 name of the inner closures the element name (which defaults to field name minus a trailing 's'). The syntax for adding
 keyed members to a list and to a map is identical (obviously, only keyed objects can be added to a map).
 
-Additionally, a special `_use()` method is created that takes an existing object and adds it to the structure. This 
-allows for structuring your code (for example by creating the object in a method)
-
-Existing object can also be added using the simple collection adders. In that case, **the owner field of the added 
-objects** are not set. 
+The inner creator can also take an existing object instead of a closure, which adds that object to the collection.
+In that case, **the owner field of the added object is only set, when it does not yet have an owner**.
+ 
+This syntax is especially useful for delegating the creation of objects into a separate method.
 
 As with simple objects, the inner closures return the existing object for reuse
 
@@ -400,12 +399,17 @@ class UnKeyed {
 
 @DSL
 class Keyed {
+    @Owner owner
     @Key String name
     String value
 }
 
-def objectForReuse = UnKeyed.create { name = "reuse" }
+def objectForReuse = UnKeyed.create { name "reuse" }
 def anotherObjectForReuse
+
+def createAnObject(String name, String value) {
+    Keyed.create(name) { value(value) }
+}
 
 Config.create {
     elements {
@@ -415,7 +419,7 @@ Config.create {
         element {
             name "another element"
         }
-        _use objectForReuse
+        element objectForReuse
     }
     keyedElements {
         anotherObjectForReuse = keyedElement ("klaus") {
@@ -426,7 +430,8 @@ Config.create {
         mapElement ("dieter") {
             value "another"
         }
-        mapElement anotherObjectForReuse
+        mapElement anotherObjectForReuse // owner is NOT changed
+        mapElement createAnObject("Hans", "Franz") // owner is set to Config instance
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -377,13 +377,11 @@ Collections of DSL-Objects are created using a nested closure. The name of the o
 name of the inner closures the element name (which defaults to field name minus a trailing 's'). The syntax for adding
 keyed members to a list and to a map is identical (obviously, only keyed objects can be added to a map).
 
-Additionally, two special methods are created that takes an existing object and adds it to the structure:
+Additionally, a special `_use()` method is created that takes an existing object and adds it to the structure. This 
+allows for structuring your code (for example by creating the object in a method)
 
-- `_use()` takes an existing object. This allows for structuring your cod (for example by creating the object in a method)
-
-- `_reuse()` does the same, but does not set the owner field of the inner object to the new container.
-
-- if the added element does not have an owner field, both methods behave identically.
+Existing object can also be added using the simple collection adders. In that case, **the owner field of the added 
+objects** are not set. 
 
 As with simple objects, the inner closures return the existing object for reuse
 
@@ -428,7 +426,7 @@ Config.create {
         mapElement ("dieter") {
             value "another"
         }
-        _reuse anotherObjectForReuse
+        mapElement anotherObjectForReuse
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -776,4 +776,3 @@ Future plans:
 - Eclipse dsld
 - strip common suffixes from alternative names (MavenProject, GradleProject -> maven, gradle)
 - allow custom names for alternatives
-- syntactic sugar for reuse (something like <<, which unfortunately does not work)

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
@@ -359,7 +359,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                     .addTo(contextClass);
         }
 
-        createPublicMethod(REUSE_METHOD_NAME)
+        createPublicMethod(methodName)
                 .param(elementType, "value")
                 .callS(getOuterInstanceXforField(fieldNode), "add", varX("value"))
                 .addTo(contextClass);
@@ -557,7 +557,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         }
 
         //noinspection ConstantConditions
-        createPublicMethod(REUSE_METHOD_NAME)
+        createPublicMethod(methodName)
                 .param(elementType, "value")
                 .callS(getOuterInstanceXforField(fieldNode), "put",
                         args(propX(varX("value"), getKeyField(elementType).getName()), varX("value"))

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
@@ -294,11 +294,11 @@ class FieldConfig {
 
     PsiClassType getElementType() {
 
-        isList() ? field.type.parameters[0] as PsiType : isMap() ? getValueType() : null
+        isList() ? keyType : isMap() ? getValueType() : null
     }
 
     PsiType getKeyType() {
-        field.type.parameters[0] as PsiType
+        field.type.parameters.length > 0 ? field.type.parameters[0] as PsiType : null
     }
 
     PsiType getValueType() {
@@ -306,7 +306,7 @@ class FieldConfig {
     }
 
     PsiEllipsisType getElementTypeAsVararg() {
-        new PsiEllipsisType(elementType)
+        return elementType ? new PsiEllipsisType(elementType) : null
     }
 
     boolean isOfType(String typeString) {

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/DSL.gdsl
@@ -213,7 +213,7 @@ contributor(context(scope: closureScope(isArg: true), ctype:hasAnnotation("com.b
                 }
 
                 method(
-                        name: "_reuse",
+                        name: innerMostKnownClosureField.memberName,
                         doc: """Reuses an existing instance of $elementType.type.qualifiedName.
 This will not affect the owner of the added object.""" as String,
                         params: [value: elementType.type.qualifiedName],

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -177,7 +177,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         def otherInstance = create("pk.Foo") {
             bars {
-                _reuse(aBar)
+                bar(aBar)
             }
         }
 
@@ -215,7 +215,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         create("pk.Fum") {
             bars {
-                _reuse aBar
+                bar aBar
             }
         }
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/OwnerReferencesSpec.groovy
@@ -146,7 +146,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            _use aBar
+            bar aBar
         }
 
         then:
@@ -198,7 +198,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
             @DSL
             class Bar {
                 @Key String name
-                @Owner Foo owner
+                @Owner Object owner
             }
 
             @DSL
@@ -224,7 +224,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
     }
 
 
-    def "using exisiting objects in map closure sets owner"() {
+    def "using existing objects in map closure sets owner"() {
         given:
         createInstance('''
             package pk
@@ -244,7 +244,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            _use(aBar)
+            bar(aBar)
         }
 
         then:
@@ -310,7 +310,7 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         instance.bars.Dieter.owner.is(instance)
     }
 
-    def "owner may not be overriden"() {
+    def "owner will not be overriden"() {
         given:
         createInstance('''
             package pk
@@ -329,46 +329,10 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
         bar.owner = instance
 
         when:
-        bar.owner = instance
+        bar.owner = clazz.create {}
 
         then:
-        def e = thrown(IllegalStateException)
-        e.message == "Owner must not be overridden."
-
-    }
-
-    def "Multiple uses of an object are not allowed"() {
-        given:
-        createClass('''
-            package pk
-
-            @DSL
-            class Foo {
-                List<Bar> bars
-            }
-
-            @DSL
-            class Bar {
-                @Owner Foo owner
-            }
-        ''')
-        def aBar
-        instance = clazz.create {
-            bars {
-               aBar = bar {}
-            }
-        }
-
-        when:
-        clazz.create {
-            bars {
-                _use aBar
-            }
-        }
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == "Owner must not be overridden."
+        bar.owner == instance
 
     }
 

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -755,7 +755,7 @@ class TransformSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            _reuse(aBar)
+            bar(aBar)
         }
 
         then:
@@ -785,47 +785,11 @@ class TransformSpec extends AbstractDSLSpec {
 
         when:
         instance.bars {
-            _reuse(aBar)
+            bar(aBar)
         }
 
         then:
         instance.bars.klaus.url == "welt"
-    }
-
-    @Ignore
-    def "direct reusing using simple collection accessors"() {
-        given:
-        createInstance('''
-            package pk
-
-            @DSL
-            class Foo {
-                Map<String, Bar> bars
-            }
-
-            @DSL
-            class Bar {
-                @Key String name
-                String url
-            }
-        ''')
-        def aBar = create("pk.Bar", "klaus") {
-            url "welt"
-        }
-        instance.bars {
-            bar("dieter") {}
-        }
-
-        when:
-        instance bar(aBar)
-
-        then:
-        instance.bars.dieter.url != null
-        instance.bars.klaus != null
-
-        and: "Owner of reused object is not"
-        instance.bars.klaus.owner == null
-
     }
 
     def "equals, hashcode and toString methods are created"() {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -1,6 +1,7 @@
 package com.blackbuild.groovy.configdsl.transform.model
 
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import spock.lang.Ignore
 
 import java.lang.reflect.Method
 
@@ -789,6 +790,42 @@ class TransformSpec extends AbstractDSLSpec {
 
         then:
         instance.bars.klaus.url == "welt"
+    }
+
+    @Ignore
+    def "direct reusing using simple collection accessors"() {
+        given:
+        createInstance('''
+            package pk
+
+            @DSL
+            class Foo {
+                Map<String, Bar> bars
+            }
+
+            @DSL
+            class Bar {
+                @Key String name
+                String url
+            }
+        ''')
+        def aBar = create("pk.Bar", "klaus") {
+            url "welt"
+        }
+        instance.bars {
+            bar("dieter") {}
+        }
+
+        when:
+        instance bar(aBar)
+
+        then:
+        instance.bars.dieter.url != null
+        instance.bars.klaus != null
+
+        and: "Owner of reused object is not"
+        instance.bars.klaus.owner == null
+
     }
 
     def "equals, hashcode and toString methods are created"() {

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User2.groovy
@@ -19,7 +19,7 @@ def c = Config.create {
                     partner("Hans", "Dieter")
                 }
 
-                _reuse(auth)
+                bar(auth)
 
                 authorization {
                     copyFrom(auth)


### PR DESCRIPTION
Drops the ugly _reuse and _use methods in favor of the member name of the target collection. Owner is only set (if not yet set), but will not be overridden.
