### PR TITLE
Shortcut syntax for boolean setters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 0.14.10
+- Shortcut syntax for boolean setters. Now the boolean setter can be called without argument, defaulting to
+  true. (e.g. you yould write "skipSonar()" instead of "skipSonar(true)")
+
+## 0.14.9
+- GDSL improvements
+- Changed Retention of DSL annotations to class to allow extending DSLs from a jar (i.e. have a dependency
+  on a jar containing parent DSL classes).
+
 ## 0.14.8
 - created methods should **not** be synthetic to allow proper code completion when using precompiled DSLs.
 

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
@@ -290,6 +290,12 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 .param(fieldNode.getType(), "value")
                 .assignS(propX(varX("this"), fieldNode.getName()), varX("value"))
                 .addTo(annotatedClass);
+
+        if (fieldNode.getType().equals(ClassHelper.boolean_TYPE)) {
+            createPublicMethod(fieldNode.getName())
+                    .callS(varX("this"), fieldNode.getName(), constX(true))
+                    .addTo(annotatedClass);
+        }
     }
 
     private String getElementNameForCollectionField(FieldNode fieldNode) {

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/ConfigDslIDESupport.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/ConfigDslIDESupport.gdsl
@@ -150,6 +150,13 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
                         params: [value: field.type?.canonicalText],
                         type: 'void'
                 )
+                if (field.type?.canonicalText == "boolean") {
+                    method(
+                        name: field.name,
+                        doc: "Sets the $field.name to true" as String,
+                        type: 'void'
+                    )
+                }
             }
         }
     }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -237,6 +237,24 @@ class TransformSpec extends AbstractDSLSpec {
         instance.value == "Dieter"
     }
 
+    def "simple boolean member setter should have 'true' as default"() {
+        given:
+        createClass('''
+            @DSL
+            class Foo {
+                boolean helpful
+            }
+        ''')
+
+        when:
+        instance = clazz.create {
+            helpful()
+        }
+
+        then:
+        instance.helpful == true
+    }
+
     def "simple member method for reusable config objects"() {
         given:
         createClass('''

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/Config.groovy
@@ -18,6 +18,8 @@ class Config {
     Options options
 
     List<String> attributes
+
+    boolean skip
 }
 
 @DSL

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/impl/User.groovy
@@ -10,6 +10,8 @@ def c = Config.create {
 
     }
 
+    skip()
+
     environments  {
 
         env("bal") {


### PR DESCRIPTION
Now the boolean setter can be called without argument, defaulting to true. (e.g. you yould write "skipSonar()" instead of "skipSonar(true)")
