### PR TITLE
Fix #20 Closures for create methods are now optional

### DIFF
--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/DSLASTTransformation.java
@@ -736,6 +736,13 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         createPublicMethod("apply")
                 .returning(newClass(annotatedClass))
+                .namedParams()
+                .applyNamedParams()
+                .doReturn("this")
+                .addTo(annotatedClass);
+
+        createPublicMethod("apply")
+                .returning(newClass(annotatedClass))
                 .delegatingClosureParam(annotatedClass)
                 .callThis("apply", args(new MapExpression(), varX("closure")))
                 .doReturn("this")
@@ -760,6 +767,18 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         createPublicMethod("create")
                 .returning(newClass(annotatedClass))
                 .mod(Opcodes.ACC_STATIC)
+                .namedParams()
+                .optionalStringParam("name", keyField)
+                .declareVariable("result", keyField != null ? ctorX(annotatedClass, args("name")) : ctorX(annotatedClass))
+                .callMethod("result", "copyFromTemplate")
+                .callMethod("result", "apply", args("params"))
+                .callValidationOn("result")
+                .doReturn("result")
+                .addTo(annotatedClass);
+
+        createPublicMethod("create")
+                .returning(newClass(annotatedClass))
+                .mod(Opcodes.ACC_STATIC)
                 .optionalStringParam("name", keyField)
                 .delegatingClosureParam(annotatedClass)
                 .doReturn(callX(annotatedClass, "create",
@@ -767,7 +786,17 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                         args(new MapExpression(), varX("name"), varX("closure"))
                         : args(new MapExpression(), varX("closure"))
                 ))
+                .addTo(annotatedClass);
 
+        createPublicMethod("create")
+                .returning(newClass(annotatedClass))
+                .mod(Opcodes.ACC_STATIC)
+                .optionalStringParam("name", keyField)
+                .doReturn(callX(annotatedClass, "create",
+                        keyField != null ?
+                        args(new MapExpression(), varX("name"))
+                        : args(new MapExpression())
+                ))
                 .addTo(annotatedClass);
 
         createPublicMethod("createFromScript")

--- a/src/main/resources/com/blackbuild/groovy/configdsl/transform/ConfigDslIDESupport.gdsl
+++ b/src/main/resources/com/blackbuild/groovy/configdsl/transform/ConfigDslIDESupport.gdsl
@@ -14,7 +14,13 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
     method(
             name: "apply",
             doc: "Applies the configuration in the closure." as String,
-            params: [params: 'Map<String,?>', closure: Closure.class.name],
+            params: [params: 'java.util.Map<String,?>', closure: Closure.class.name],
+            type: clazz.type.qualifiedName
+    )
+    method(
+            name: "apply",
+            doc: "Applies the configuration in the closure." as String,
+            params: [params: 'java.util.Map<String,?>'],
             type: clazz.type.qualifiedName
     )
 
@@ -30,7 +36,14 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
                 name: "create",
                 doc: "Creates a new instance of ${clazz.type.qualifiedName} using 'key' as $clazz.key" as String,
                 isStatic: true,
-                params: [params: 'Map<String,?>', "$clazz.key": "java.lang.String", closure: Closure.class.name],
+                params: [params: 'java.util.Map<String,?>', "$clazz.key": "java.lang.String", closure: Closure.class.name],
+                type: clazz.type.qualifiedName
+        )
+        method(
+                name: "create",
+                doc: "Creates a new instance of ${clazz.type.qualifiedName} using 'key' as $clazz.key" as String,
+                isStatic: true,
+                params: [params: 'java.util.Map<String,?>', "$clazz.key": "java.lang.String"],
                 type: clazz.type.qualifiedName
         )
         method(
@@ -46,7 +59,14 @@ contributor(ctype:hasAnnotation("com.blackbuild.groovy.configdsl.transform.DSL")
                 name: "create",
                 doc: "Creates a new instance of ${clazz.type.qualifiedName}" as String,
                 isStatic: true,
-                params: [params: 'Map<String,?>', closure: Closure.class.name],
+                params: [params: 'java.util.Map<String,?>', closure: Closure.class.name],
+                type: clazz.type.qualifiedName
+        )
+        method(
+                name: "create",
+                doc: "Creates a new instance of ${clazz.type.qualifiedName}" as String,
+                isStatic: true,
+                params: [params: 'java.util.Map<String,?>'],
                 type: clazz.type.qualifiedName
         )
         method(

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/model/TransformSpec.groovy
@@ -142,6 +142,12 @@ class TransformSpec extends AbstractDSLSpec {
 
         then:
         instance.class.name == "pk.Foo"
+
+        when: 'Closure is optional'
+        instance = clazz.create()
+
+        then:
+        noExceptionThrown()
     }
 
     def "factory methods with named parameters"() {
@@ -161,6 +167,13 @@ class TransformSpec extends AbstractDSLSpec {
         then:
         instance.class.name == "pk.Foo"
         instance.value == 'bla'
+
+        when: 'Closure is optional'
+        instance = clazz.create(value: 'blub')
+
+        then:
+        noExceptionThrown()
+        instance.value == 'blub'
     }
 
     @Ignore("see https://github.com/blackbuild/config-dsl/issues/38")
@@ -208,6 +221,13 @@ class TransformSpec extends AbstractDSLSpec {
 
         and: "no name() accessor is created"
         instance.class.metaClass.getMetaMethod("name", String) == null
+
+        when: 'Closure is optional'
+        instance = clazz.create("Klaus")
+
+        then:
+        noExceptionThrown()
+        instance.name == "Klaus"
     }
 
     def "factory methods with key and named parameters"() {
@@ -231,6 +251,14 @@ class TransformSpec extends AbstractDSLSpec {
 
         and: "no name() accessor is created"
         instance.class.metaClass.getMetaMethod("name", String) == null
+
+        when: 'Closure is optional'
+        instance = clazz.create("Klaus", value: 'blub')
+
+        then:
+        noExceptionThrown()
+        instance.name == "Klaus"
+        instance.value == 'blub'
     }
 
     @Ignore("see https://github.com/blackbuild/config-dsl/issues/38")


### PR DESCRIPTION
Fix #20 Closures for create methods are now optional

The apply method with named parameters has now also an optional closure parameter