### PR TITLE
Fix #110, load the model from classpath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 - Replaced the `@ReadOnly` annotation with a `@Field(FieldType.PROTECTED)` (see [#108](https://github.com/klum-dsl/klum-ast/issues/108))
 - Included a TRANSIENT field type to allow fields that are not part of the model (see [#102](https://github.com/klum-dsl/klum-ast/issues/102))
 - PROTECTED (former ReadOnly) fields now DO create adder methods, although protected (see [#78](https://github.com/klum-dsl/klum-ast/issues/78))
+- __(Potentially) breaking changes:__
+    - Introduce a new createFromClasspath method (see [#110](https://github.com/klum-dsl/klum-ast/issues/110))
+    - this means that either klum-ast or future klum-util package needs to be present in the classpath during
+      runtime
+
 
 ## 1.1.1
 - access to owner from inner closures failed with static type checking (see [#99](https://github.com/klum-dsl/klum-ast/issues/99))

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Turn your models into supermodels!
 
 # Breaking changes
 
-Beginning from 0.98 models are now (almost) read only. Take a look at 
-[Migration](https://github.com/klum-dsl/klum-ast/wiki/Migration) in the wiki for necessary
-steps to migrate.
+New features being introduced in 1.2.0 will need KlumAST (or KlumUtil) to
+be present on the classpath during runtime. The details are not yet finalized, take
+care when adopting a 1.2.0 release candidate.
 
 
 # What is KlumAST?

--- a/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
+++ b/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
@@ -1,0 +1,63 @@
+package com.blackbuild.klum.ast.util;
+
+import groovy.lang.GroovyObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Helper methods fro use in convenience factories. This will eventually take a lot of code from
+ * the AST generated methods.
+ */
+public class FactoryHelper {
+
+    public static final String MODEL_CLASS_KEY = "model-class";
+
+    private FactoryHelper() {
+        // static only
+    }
+
+    public static <T extends GroovyObject> T createFromClasspath(Class<T> type) {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        String path = "META-INF/klum-model/" + type.getName() + ".properties";
+
+        try (InputStream stream = loader.getResourceAsStream(path)) {
+            assertResourceExists(path, stream);
+
+            String configModelClassName = readModelClass(path, stream);
+
+            return createModelFrom(type, loader, path, configModelClassName);
+
+        } catch (IOException e) {
+            throw new IllegalStateException("Error while reading marker properties.", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends GroovyObject> T createModelFrom(Class<T> type, ClassLoader loader, String path, String configModelClassName) {
+        try {
+            Class<T> modelClass = (Class<T>) loader.loadClass(configModelClassName);
+            return (T) type.getMethod("createFrom", Class.class).invoke(null, modelClass);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Class '" + configModelClassName + "' defined in " + path + " does not exist", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not read model from " + configModelClassName);
+        }
+    }
+
+    private static void assertResourceExists(String path, InputStream stream) {
+        if (stream == null)
+            throw new IllegalStateException("File " + path + " not found in classpath.");
+    }
+
+    private static String readModelClass(String path, InputStream stream) throws IOException {
+        Properties marker = new Properties();
+        marker.load(stream);
+        String configModelClassName = marker.getProperty(MODEL_CLASS_KEY);
+        if (configModelClassName == null)
+            throw new IllegalStateException("No entry 'model-class' found in " + path);
+        return configModelClassName;
+    }
+
+}

--- a/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
+++ b/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2017 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.blackbuild.klum.ast.util;
 
 import groovy.lang.GroovyObject;

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AbstractDSLSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AbstractDSLSpec.groovy
@@ -73,6 +73,10 @@ class AbstractDSLSpec extends Specification {
         return loader.parseClass(code)
     }
 
+    def createSecondaryClass(String code, String filename) {
+        return loader.parseClass(code, filename)
+    }
+
     def create(String classname, Closure closure) {
         getClass(classname).create(closure)
     }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConvenienceFactoriesSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConvenienceFactoriesSpec.groovy
@@ -296,4 +296,64 @@ class ConvenienceFactoriesSpec extends AbstractDSLSpec {
         instance.name == "Dieter"
     }
 
+    def "read model from classpath"() {
+        given:
+        def classPathRoot = temp.newFolder()
+        def properties = new File(classPathRoot, "META-INF/klum-model/pk.Config.properties")
+        properties.parentFile.mkdirs()
+        createClass'''
+            package pk
+
+            @DSL
+            class Config {
+                String name
+                String value
+            }'''
+        createSecondaryClass'''
+            package impl
+            pk.Config.create {
+                name "hallo"
+                value "welt"
+            }''', "Configuration.groovy"
+        properties.text = "model-class: impl.Configuration"
+        loader.addURL(classPathRoot.toURI().toURL())
+
+        when:
+        instance = clazz.createFromClasspath()
+
+        then:
+        instance.name == "hallo"
+        instance.value == "welt"
+    }
+
+    def "read model from classpath with delegating script"() {
+        given:
+        def classPathRoot = temp.newFolder()
+        def properties = new File(classPathRoot, "META-INF/klum-model/pk.Config.properties")
+        properties.parentFile.mkdirs()
+        createClass'''
+            package pk
+
+            @DSL
+            class Config {
+                String name
+                String value
+            }'''
+        createSecondaryClass'''
+            package impl
+            @groovy.transform.BaseScript(DelegatingScript) import groovy.util.DelegatingScript
+            name "hallo"
+            value "welt"
+            ''', "Configuration.groovy"
+        properties.text = "model-class: impl.Configuration"
+        loader.addURL(classPathRoot.toURI().toURL())
+
+        when:
+        instance = clazz.createFromClasspath()
+
+        then:
+        instance.name == "hallo"
+        instance.value == "welt"
+    }
+
 }

--- a/wiki/Convenience-Factories.md
+++ b/wiki/Convenience-Factories.md
@@ -75,3 +75,52 @@ Config.create {
 __Note__: Currently, `createFrom` does not support any polymorphic creation. This might be added later,
  see: ([#43](https://github.com/klum-dsl/klum-core/issues/43))
 
+# Classpath
+
+In addition, 1.2.0 introduces a new experimental feature for instantiating a a model automatically by placing
+a property file in your model library. In order for this to work, the model needs one or more single
+entry points, i.e. instances that are usually present only once (like the all encompassing Config object).
+
+By placing a marker into the classpath, this class can automatically be instantiated without the consumer needing
+to know the name of the configuration class. This takes the dependency from the code into the jar-orchestration /
+the buildscript.
+
+Given the following classes:
+
+`Model.groovy`:
+```groovy
+package pk
+@DSL class Model {
+    // ... definitions, inner elements etc.
+}
+
+```
+
+`Configuration.groovy`:
+```groovy
+package impl
+Model.create {
+  // regular dsl code
+}
+```
+
+By including a separate properties file in the jar of [[Usage#model]], this model
+can automatically be instantiated. The file must be named `/META-INF/klum-model/<schema-classname>.properties`
+and contain a single property: `model-class`, which contains the full classname of the Entry-Point script (which
+can bea regular as well as a DelegatingScript):
+
+`/META-INF/klum-model/pk.Model.properties`
+```properties
+model-class: impl.Configuration
+```
+
+This allows the code consuming the model to simply obtain it via:
+
+```groovy
+def model = Model.createFromClasspath()
+```
+
+Using this technique, the same consumer can work with different models (most of the time: different packages),
+without any need to change or somehow inject the name of the Model class.
+
+In fact, this might actually become the preferred method of consuming a model.

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -29,10 +29,13 @@ For Gradle, setup is similar:
 
 ```groovy
 dependencies {
-    compileOnly 'com.blackbuild.klum.ast:klum-ast:@version@'
+    compile 'com.blackbuild.klum.ast:klum-ast:@version@'
     compileOnly 'org.codehaus.groovy:groovy-all:2.4.12'
 }
 ```
+
+__Attention:__  as of 1.2.0, advanced features of KlumAST need the library to
+be present on the classpath during runtime
 
 # Project setup
 
@@ -62,6 +65,10 @@ The schema usually consists of one or more script files containing either a `Mod
  
 The model is than packed into a jar file (for convenience a shadowed jar containing the schema as well), which can 
  be used as the single dependency for all consumers.
+
+If the model has single entry points, i.e. instances of classes that are only present once in the
+model (which is usually the case), the model can make use of the new `createFromClasspath` feature, see
+[[Convenience Factories#classpath]] for details.
  
 ### Consumer
 


### PR DESCRIPTION
This change allows to automatically determine the entry-point of a model jar via a helper file in the classpath.