### PR TITLE
Fix #19: dsl for setters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   which might lead to issues in specific corner cases (DSL interface <- non DSL class <- DSL class). (see [#121](https://github.com/klum-dsl/klum-ast/issues/121))
 - New optional classloader parameter for `createFrom(String|File|Url)` (see [#123](https://github.com/klum-dsl/klum-ast/issues/123))
 - For dsl map fields, arbitrary key types (derived from the element) can be used using a new `Field.keyMapping` value (see [#127](https://github.com/klum-dsl/klum-ast/issues/127))
+- Setter-like methods (with exactly one parameter) can be declared as virtual fields using the `@Field` annotation (see [#19](https://github.com/klum-dsl/klum-ast/issues/19))
 - __(Potentially) breaking changes:__
     - Introduce a new createFromClasspath method (see [#110](https://github.com/klum-dsl/klum-ast/issues/110))
     - this means that either klum-ast or future klum-util package needs to be present in the classpath during

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/Field.java
@@ -47,7 +47,7 @@ import java.lang.annotation.Target;
  * <p>{@code @Field(member = 'library') Set<String> libraries}</p>
  * <p><b>Note that the member names must be unique across all collections of a DSL hierarchy.</b></p>
  */
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.CLASS)
 @Documented
 public @interface Field {

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DslAstHelper.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DslAstHelper.java
@@ -295,4 +295,8 @@ public class DslAstHelper {
 
         return getCodeClosureFor(target, annotation, member);
     }
+
+    static boolean hasAnnotation(AnnotatedNode node, ClassNode annotation) {
+        return !node.getAnnotations(annotation).isEmpty();
+    }
 }

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DslAstHelper.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DslAstHelper.java
@@ -299,4 +299,14 @@ public class DslAstHelper {
     static boolean hasAnnotation(AnnotatedNode node, ClassNode annotation) {
         return !node.getAnnotations(annotation).isEmpty();
     }
+
+    static int findFirstUpperCaseCharacter(String methodName) {
+        int index = 0;
+        while (index < methodName.length()) {
+            if (Character.isUpperCase(methodName.charAt(index)))
+                return index;
+            index++;
+        }
+        return -1;
+    }
 }

--- a/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/MutatorsHandler.java
+++ b/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/MutatorsHandler.java
@@ -24,14 +24,15 @@
 package com.blackbuild.groovy.configdsl.transform.ast;
 
 import com.blackbuild.groovy.configdsl.transform.Mutator;
-import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.InnerClassNode;
+import org.codehaus.groovy.ast.MethodNode;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.blackbuild.klum.common.CommonAstHelper.getAnnotation;
 import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.moveMethodFromModelToRWClass;
-import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpecRecurse;
 
 /**
  * Helper class to move mutators to RW class.
@@ -62,15 +63,16 @@ public class MutatorsHandler {
     private List<MethodNode> findAllDeclaredMutatorMethods() {
         List<MethodNode> mutators = new ArrayList<MethodNode>();
         for (MethodNode method : annotatedClass.getMethods()) {
-            AnnotationNode targetAnnotation = getAnnotation(method, MUTATOR_ANNOTATION);
 
-            if (targetAnnotation != null)
+
+            if (DslAstHelper.hasAnnotation(method, MUTATOR_ANNOTATION)
+                    || DslAstHelper.hasAnnotation(method, DSLASTTransformation.DSL_FIELD_ANNOTATION))
                 mutators.add(method);
         }
         return mutators;
     }
 
-//    static class ReplaceDirectAccessWithSettersVisitor extends CodeVisitorSupport {
+    //    static class ReplaceDirectAccessWithSettersVisitor extends CodeVisitorSupport {
 //
 //        private MethodNode method;
 //

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
@@ -1903,4 +1903,25 @@ class TransformSpec extends AbstractDSLSpec {
         instance.getHint(getClass("BHint")).otherValue == "bli"
     }
 
+    def "Annotated setters create dsl methods"() {
+        given:
+        createClass '''
+            @DSL class Foo {
+                Date date
+                
+                @Field
+                void setDate(long value) {
+                    this.date = new Date(value)
+                }
+            }
+            '''
+        when:
+        instance = clazz.create {
+            date 0L
+        }
+
+        then:
+        instance.date != null
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
@@ -1933,9 +1933,33 @@ class TransformSpec extends AbstractDSLSpec {
                 @Field
                 void setBar(Bar bar) {
                     this.name = bar.name
-                    println "here"
-                    println bar
-                    println name
+                }
+            }
+            
+            @DSL class Bar {
+                String name
+            }
+            '''
+        when:
+        instance = clazz.create {
+            bar {
+                name "Hans"
+            }
+        }
+
+        then:
+        instance.name == "Hans"
+    }
+
+    def "Annotated non setter methods work for dsl types"() {
+        given:
+        createClass '''
+            @DSL class Foo {
+                String name
+                
+                @Field
+                void addBar(Bar bar) {
+                    this.name = bar.name
                 }
             }
             

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
@@ -1924,4 +1924,49 @@ class TransformSpec extends AbstractDSLSpec {
         instance.date != null
     }
 
+    def "Annotated setters work for dsl types"() {
+        given:
+        createClass '''
+            @DSL class Foo {
+                String name
+                
+                @Field
+                void setBar(Bar bar) {
+                    this.name = bar.name
+                    println "here"
+                    println bar
+                    println name
+                }
+            }
+            
+            @DSL class Bar {
+                String name
+            }
+            '''
+        when:
+        instance = clazz.create {
+            bar {
+                name "Hans"
+            }
+        }
+
+        then:
+        instance.name == "Hans"
+    }
+
+    def "it is illegal to annotate nonSetter like methods with @Field"() {
+        when:
+        createClass '''
+            @DSL class Foo {
+                Date date
+                
+                @Field
+                void setDate(long value, value) {
+                }
+            }
+            '''
+        then:
+        thrown(MultipleCompilationErrorsException)
+    }
+
 }

--- a/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/UtilityTest.groovy
+++ b/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/UtilityTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2017 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform.ast
+
+import spock.lang.Specification
+
+class UtilityTest extends Specification {
+    def "test findFirstUpperCaseCharacter"() {
+        expect:
+        DslAstHelper.findFirstUpperCaseCharacter(string) == index
+
+        where:
+        string    || index
+        'setName' || 3
+        'pName'   || 1
+        'small'   || -1
+        'Big'     || 0
+        'enD'     || 2
+    }
+}

--- a/wiki/Basics.md
+++ b/wiki/Basics.md
@@ -240,12 +240,6 @@ Config.create {
 }
 ```
 
-This approach was the default one in earlier versions of the library and is still the nicest looking, 
-but since the switch to read only models, code completion in the IDE does not work anymore. The code, however still works,
-but is not longer valid for static type checking.
-
-This problem could be solved by providing an small dsld / gdsl script or a custom IDE plugin.
-
 ##### Reuse syntax
 
 By using an actual `create` call on the target type, the target object is first created and than applied to field-method:
@@ -263,6 +257,40 @@ reference of the inner object is set __before__ the configuration closure is cal
 access the owner field or methods which use it. With the second approach, the owner is set __after__ the create closure
 is completed.
 
+### Virtual Fields
+
+In addition to fields, setter like methods (i.e. methods with a single parameter) can also be annotated with `@Field`,
+making them 'virtual fields'. For virtual fields, the same dsl methods are generated as for actual fields. The name
+is derived from the method name, skipping the part of the name up to the first capital letter
+(i.e. setValue -> value, addName -> name).
+
+The annotated method is automatically converted into a Mutator method.
+
+```groovy
+@DSL class Foo {
+    String value
+
+    @Field
+    void addBar(Bar bar) {
+        this.value = bar.name
+    }
+}
+
+@DSL class Bar {
+    String name
+}
+
+def foo = Foo.create {
+    bar {
+        name "Hans"
+    }
+}
+
+assert foo.value == "Hans"
+```
+
+Note that, as in the above example, this behaviour, while working with non dsl arguments as well, makes the most sense
+for actual DSL arguments.
 
 ### Collections of DSL Objects
 


### PR DESCRIPTION
This allows marking single parameter methods as virtual fields.