### PR TITLE
Invoker Helper.getAttribute fails

### DIFF
--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/ValidatorTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/ValidatorTest.groovy
@@ -1,5 +1,7 @@
 package com.blackbuild.klum.ast.util
 
+import spock.lang.Issue
+
 class ValidatorTest extends AbstractRuntimeTest {
 
     void "empty validation works"() {
@@ -60,6 +62,38 @@ class ValidatorTest extends AbstractRuntimeTest {
                 int value
             }
         ''')
+
+        when:
+        new Validator(instance).execute()
+
+        then:
+        thrown(AssertionError)
+
+        when:
+        instance.value = 200
+        new Validator(instance).execute()
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Issue("https://github.com/klum-dsl/klum-ast/issues/230")
+    void "BUG: validator fails on inheritance"() {
+        given:
+        createClass('''
+            package pk
+            import com.blackbuild.groovy.configdsl.transform.Validate
+
+            @DSL
+            class Foo {
+                @Validate int value
+            }
+
+            @DSL
+            class Bar extends Foo {
+            }
+        ''')
+        instance = newInstanceOf("pk.Bar")
 
         when:
         new Validator(instance).execute()

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/LifecycleSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/LifecycleSpec.groovy
@@ -495,7 +495,7 @@ class LifecycleSpec extends AbstractDSLSpec {
         instance.foo.name == "bla"
     }
 
-    def "PostApply methods can set fields of child"() {
+    def "PostApply methods can set fields of inner object"() {
         given:
         createClass('''
             package pk


### PR DESCRIPTION
if used for parent fields in Groovy 3

fix #230 