### PR TITLE
Validation on Boolean improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 - New Features
     - Compatibility with Groovy 3. KlumAST is currently still built with Groovy 2.4 (for compatitibility with Jenkins). Note that this is not yet automatically tested.
     - Replace basic jackson transformation with a dedicated JacksonModule (see [Jackson Integration](https://github.com/klum-dsl/klum-ast/wiki/Migration))).
+- Improvements
+  - `boolean` fields are never validated (makes no sense), `Boolean` fields are evaluated against not null, not against Groovy Truth (i.e. the (see [#223](https://github.com/klum-dsl/klum-ast/issues/223))
 - Breaking changes
+    - it is a compile error to place the `@Validate` annotation on a boolean field.
     - KlumAST is split into different modules, klum-ast-compile is compile-time only,
       klum-ast-runtime is needed for runtime as well. This completes
       the changes started in 1.2.0 (see [Migration](https://github.com/klum-dsl/klum-ast/wiki/Migration))

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/Validator.java
@@ -109,6 +109,9 @@ public class Validator {
         if (field.isAnnotationPresent(Owner.class))
             return;
 
+        if (field.getType() == boolean.class)
+            return;
+
         validateInnerDslObjects(field);
 
         if (!shouldValidate(field))
@@ -120,12 +123,15 @@ public class Validator {
         Class<?> validationValue = validate != null ? validate.value() : Validate.GroovyTruth.class;
 
         if (validationValue == Validate.GroovyTruth.class) {
-            if (!castToBoolean(value)) {
-                String message = validate != null ? validate.message() : "";
-                if (message.isEmpty())
-                    message = String.format("'%s' must be set.", field.getName());
-                InvokerHelper.assertFailed(field.getName() + " as Boolean", message);
-            }
+            if (field.getType() == Boolean.class && value != null)
+                return;
+            if (castToBoolean(value))
+                return;
+
+            String message = validate != null ? validate.message() : "";
+            if (message.isEmpty())
+                message = String.format("'%s' must be set.", field.getName());
+            InvokerHelper.assertFailed(field.getName() + " as Boolean", message);
             return;
         }
 

--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/ValidatorTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/ValidatorTest.groovy
@@ -132,5 +132,63 @@ class ValidatorTest extends AbstractRuntimeTest {
         noExceptionThrown()
     }
 
+    @Issue("223")
+    def "Validation on Boolean checks not null instead of Groovy Truth"() {
+        given:
+        createClass('''
+            package pk
+            import com.blackbuild.groovy.configdsl.transform.Validate
+
+            @DSL
+            class Foo {
+                @Validate Boolean value
+            }
+        ''')
+        instance = newInstanceOf("pk.Foo")
+
+        when:
+        new Validator(instance).execute()
+
+        then:
+        thrown(AssertionError)
+
+        when:
+        instance.value = false
+        new Validator(instance).execute()
+
+        then: 'False should satisfy validation'
+        noExceptionThrown()
+
+        when:
+        instance.value = true
+        new Validator(instance).execute()
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Issue("223")
+    def "boolean fields are ignored on Validation Mode VALIDATE_UNMARKED"() {
+        given:
+        createClass('''
+            package pk
+            import com.blackbuild.groovy.configdsl.transform.Validate
+            import com.blackbuild.groovy.configdsl.transform.Validation
+
+            @DSL
+            @Validation(option=Validation.Option.VALIDATE_UNMARKED)
+            class Foo {
+                boolean value
+            }
+        ''')
+        instance = newInstanceOf("pk.Foo")
+
+        when:
+        new Validator(instance).execute()
+
+        then: 'boolean fields are ignored'
+        noExceptionThrown()
+    }
+
 
 }

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -375,6 +375,11 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     }
 
     private void checkValidateAnnotationOnSingleField(FieldNode fieldNode) {
+        if (fieldNode.getType().equals(ClassHelper.boolean_TYPE)) {
+            addCompileError("Validation is not valid on 'boolean' fields, use 'Boolean' instead.", fieldNode);
+            return;
+        }
+
         AnnotationNode validateAnnotation = getAnnotation(fieldNode, VALIDATE_ANNOTATION);
         String message = getMemberStringValue(validateAnnotation, "message");
         Expression validationExpression = validateAnnotation.getMember("value");

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ValidationSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ValidationSpec.groovy
@@ -795,4 +795,19 @@ class ValidationSpec extends AbstractDSLSpec {
         then: 'Validation of outer object fails'
         thrown(AssertionError)
     }
+
+    @Issue("223")
+    def "Validation on boolean is illegal"() {
+        when:
+        createClass('''
+            @DSL
+            class Outer {
+                @Validate
+                boolean myValue
+            }
+        ''')
+
+        then: 'Compilation fails'
+        thrown(MultipleCompilationErrorsException)
+    }
 }


### PR DESCRIPTION
Improve boolean validation

- `boolean` fields must not be annotated with `@Validate`
- `boolean` fields are ignored even when Validation Option is validate unmarked
- `Boolean` field valdation fails only on null values, not on `False`

Fix #223
