### PR TITLE
Allow closures fields as lifecyle fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,12 @@
     - Compatibility with Groovy 3 and 4. KlumAST is currently still built with Groovy 2.4 (for compatibility with Jenkins). Tests are run with Groovy 3 and 4 as well.
     - Replace basic jackson transformation with a dedicated (beta) JacksonModule (see [Jackson Integration](https://github.com/klum-dsl/klum-ast/wiki/Migration))).
     - First steps for Layer3 models. (see [Layer3](https://github.com/klum-dsl/klum-ast/wiki/Layer3))    
-    - Split model creation into distinct phases (validation for now) (see [#156](https://github.com/klum-dsl/klum-ast/issues/156), [#155](https://github.com/klum-dsl/klum-ast/issues/155),[#187](https://github.com/klum-dsl/klum-ast/issues/187) and [Model Phases](https://github.com/klum-dsl/klum-ast/wiki/Model-Phases))
+    - Split model creation into distinct phases (see [#156](https://github.com/klum-dsl/klum-ast/issues/156), [#155](https://github.com/klum-dsl/klum-ast/issues/155),[#187](https://github.com/klum-dsl/klum-ast/issues/187) and [Model Phases](https://github.com/klum-dsl/klum-ast/wiki/Model-Phases))
     - New Phases:
       - PostTree: is run after the model is completely realized
       - AutoCreate: automatic creation of null fields
       - AutoLink: Links fields to other fields in the model
+    - In addition to lifecycle methods, fields of type `Closure` can now be used to define model provided (instead of schema provided) lifecycle methods. These closoures will be executed in their respective Lifecycle phases.
     - default implementation: by providing the attribute `defaultImpl` on either `@DSL` or `@Field`, one can allow the creation of non polymorphic field methods even for interfaces and abstract types. (see [Default Implementations](https://github.com/klum-dsl/klum-ast/wiki/Basics#default-implementations))
 - Improvements
   - CopyFrom now creates deep clones (see [#36](https://github.com/klum-dsl/klum-ast/issues/36))

--- a/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/util/layer3/annotations/AutoCreate.java
+++ b/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/util/layer3/annotations/AutoCreate.java
@@ -38,6 +38,9 @@ import java.util.Map;
  * concrete type of the object to be created can be passed as {@link #type()} parameter. If
  * the annotated field is an abstract type, the type parameter is mandatory.
  * <p>
+ * When placed on a field of type closure, the behaviour is slightly different. In that case, the closure
+ * is called during the lifecycle phase.
+ * <p>
  * AutoCreate can also be used on methods. In that case, the method is handled as a regular
  * lifecycle method.
  */

--- a/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/util/layer3/annotations/AutoLink.java
+++ b/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/util/layer3/annotations/AutoLink.java
@@ -27,7 +27,7 @@ import com.blackbuild.groovy.configdsl.transform.WriteAccess;
 
 import java.lang.annotation.*;
 
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @WriteAccess(WriteAccess.Type.LIFECYCLE)
 @Documented

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
@@ -70,8 +70,8 @@ public class PhaseDriver {
             instance.remove();
     }
 
-    public PhaseAction getCurrentPhase() {
-        return currentPhase;
+    public int getCurrentPhase() {
+        return currentPhase.getPhase();
     }
 
     public static void executeIfReady() {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/ClosureHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/ClosureHelper.java
@@ -68,7 +68,11 @@ public class ClosureHelper {
         return invokeClosureWithDelegate(closureType, delegate, delegate);
     }
 
-    public static <T> T invokeClosureWithDelegate(Closure<T> closure,  Object delegate, Object... arguments) {
+    public static <T> T invokeClosureWithDelegateAsArgument(Closure<T> closure, Object delegate) {
+        return invokeClosureWithDelegate(closure, delegate, delegate);
+    }
+    public static <T> T invokeClosureWithDelegate(Closure<T> closure, Object delegate, Object... arguments) {
+        if (closure == null) return null;
         if (delegate != null) {
             closure.setResolveStrategy(Closure.DELEGATE_FIRST);
             closure.setDelegate(delegate);

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumInstanceProxy.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumInstanceProxy.java
@@ -286,6 +286,17 @@ public class KlumInstanceProxy {
                 .map(Method::getName)
                 .distinct()
                 .forEach(method -> InvokerHelper.invokeMethod(rw, method, null));
+        DslHelper.getFieldsAnnotatedWith(instance.getClass(), annotation)
+                .stream()
+                .filter(field -> field.getType().equals(Closure.class))
+                .map(Field::getName)
+                .forEach(this::executeLifecycleClosure);
+    }
+
+    private void executeLifecycleClosure(String name) {
+        Closure<?> closure = getInstanceAttribute(name);
+        ClosureHelper.invokeClosureWithDelegateAsArgument(closure, getRwInstance());
+        setInstanceAttribute(name, null);
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/AutoCreationPhase.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/AutoCreationPhase.java
@@ -30,11 +30,12 @@ import com.blackbuild.klum.ast.util.DslHelper;
 import com.blackbuild.klum.ast.util.FactoryHelper;
 import com.blackbuild.klum.ast.util.KlumInstanceProxy;
 import com.blackbuild.klum.ast.util.layer3.annotations.AutoCreate;
+import groovy.lang.Closure;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Map;
 
+import static com.blackbuild.klum.ast.util.DslHelper.isInstantiable;
 import static java.lang.String.format;
 
 public class AutoCreationPhase extends VisitingPhaseAction {
@@ -70,8 +71,9 @@ public class AutoCreationPhase extends VisitingPhaseAction {
             throw new IllegalArgumentException(format("AutoCreate annotation for field '%s' has a key field, but annotated type '%s' is not keyed", fieldName, field.getType().getName()));
 
         Class<?> type = autoCreate.type();
-        if (type == Object.class) {
-            if (field.getType().isInterface() || (field.getType().getModifiers() & Modifier.ABSTRACT) != 0)
+        if (type.equals(Object.class)) {
+            if (field.getType().equals(Closure.class)) return;
+            if (!isInstantiable(field.getType()))
                 throw new IllegalArgumentException(format("AutoCreate annotation for abstract typed field '%s' is missing a 'type' field.", fieldName));
             type = field.getType();
         } else if (!field.getType().isAssignableFrom(type)) {

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -55,7 +55,6 @@ import static com.blackbuild.groovy.configdsl.transform.ast.MethodBuilder.*;
 import static com.blackbuild.groovy.configdsl.transform.ast.ProxyMethodBuilder.createFactoryMethod;
 import static com.blackbuild.groovy.configdsl.transform.ast.ProxyMethodBuilder.createProxyMethod;
 import static com.blackbuild.klum.common.CommonAstHelper.*;
-import static groovyjarjarasm.asm.Opcodes.*;
 import static java.util.stream.Collectors.toList;
 import static org.codehaus.groovy.ast.ClassHelper.*;
 import static org.codehaus.groovy.ast.expr.MethodCallExpression.NO_ARGUMENTS;

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
@@ -34,18 +34,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.getGetterName;
-import static com.blackbuild.groovy.configdsl.transform.ast.MethodBuilder.createMethod;
-import static com.blackbuild.groovy.configdsl.transform.ast.MethodBuilder.createProtectedMethod;
-import static com.blackbuild.groovy.configdsl.transform.ast.MethodBuilder.createPublicMethod;
+import static com.blackbuild.groovy.configdsl.transform.ast.MethodBuilder.*;
 import static com.blackbuild.klum.common.CommonAstHelper.replaceProperties;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.assignS;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.attrX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstanceProperties;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
 
 class PropertyAccessors {
     private final DSLASTTransformation dslastTransformation;
@@ -110,6 +101,7 @@ class PropertyAccessors {
                 .addTo(dslastTransformation.rwClass);
 
         pNode.setSetterBlock(null);
+
         propertiesToReplace.add(pNode);
     }
 

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/ModelVerificationVisitor.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/ModelVerificationVisitor.java
@@ -91,7 +91,7 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
         if ((currentMethod.getModifiers() & Opcodes.ACC_SYNTHETIC) != 0)
             return;
 
-        if (WriteAccessMethodsMover.getWriteAccessTypeForMethod(currentMethod).isPresent())
+        if (WriteAccessHelper.getWriteAccessTypeForMethodOrField(currentMethod).isPresent())
             return; // ignore methods already marked as write access methods
 
         if (ofType(expression.getOperation().getType(), ASSIGNMENT_OPERATOR)) {
@@ -164,7 +164,7 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
         if (currentMethod == null)
             return false;
 
-        return WriteAccessMethodsMover.getWriteAccessTypeForMethod(currentMethod).isPresent();
+        return WriteAccessHelper.getWriteAccessTypeForMethodOrField(currentMethod).isPresent();
     }
 
     private boolean isDslType(ClassNode classNode) {

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessHelper.java
@@ -1,0 +1,33 @@
+package com.blackbuild.groovy.configdsl.transform.ast.mutators;
+
+import com.blackbuild.groovy.configdsl.transform.WriteAccess;
+import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class WriteAccessHelper {
+
+    private WriteAccessHelper() {
+        // helper class
+    }
+
+    public static Optional<WriteAccess.Type> getWriteAccessTypeForMethodOrField(AnnotatedNode fieldOrMethod) {
+        if (fieldOrMethod == null) return Optional.empty();
+        return fieldOrMethod.getAnnotations().stream()
+                .map(WriteAccessHelper::getWriteAccessTypeForAnnotation)
+                .filter(Objects::nonNull)
+                .findAny();
+    }
+
+    private static WriteAccess.Type getWriteAccessTypeForAnnotation(AnnotationNode annotation) {
+        if (!DslAstHelper.hasAnnotation(annotation.getClassNode(), WriteAccessMethodsMover.WRITE_ACCESS_ANNOTATION)) return null;
+
+        // We need to use the class explicitly, since we cannot access the members of metaAnnotations directly
+        // This is safe, since annotations are in a different module and thus already compiled
+        Class<?> annotationClass = annotation.getClassNode().getTypeClass();
+        return annotationClass.getAnnotation(WriteAccess.class).value();
+    }
+}

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessHelper.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2023 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.blackbuild.groovy.configdsl.transform.ast.mutators;
 
 import com.blackbuild.groovy.configdsl.transform.WriteAccess;

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodsMover.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodsMover.java
@@ -26,16 +26,13 @@ package com.blackbuild.groovy.configdsl.transform.ast.mutators;
 import com.blackbuild.groovy.configdsl.transform.Mutator;
 import com.blackbuild.groovy.configdsl.transform.WriteAccess;
 import com.blackbuild.groovy.configdsl.transform.ast.DSLASTTransformation;
-import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
 import com.blackbuild.klum.common.CommonAstHelper;
-import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.control.SourceUnit;
 
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.blackbuild.klum.common.CommonAstHelper.assertMethodIsNotPrivate;
@@ -84,7 +81,7 @@ public class WriteAccessMethodsMover {
     }
 
     private void ifMutatorMoveToRWClass(MethodNode method) {
-        Optional<WriteAccess.Type> writeType = getWriteAccessTypeForMethod(method);
+        Optional<WriteAccess.Type> writeType = WriteAccessHelper.getWriteAccessTypeForMethodOrField(method);
 
         if (!writeType.isPresent()) return;
 
@@ -94,22 +91,6 @@ public class WriteAccessMethodsMover {
             downgradeToProtected(method);
         }
         moveMethodFromModelToRWClass(method);
-    }
-
-    static Optional<WriteAccess.Type> getWriteAccessTypeForMethod(MethodNode method) {
-        return method.getAnnotations().stream()
-                .map(WriteAccessMethodsMover::getWriteAccessTypeForAnnotation)
-                .filter(Objects::nonNull)
-                .findAny();
-    }
-
-    private static WriteAccess.Type getWriteAccessTypeForAnnotation(AnnotationNode annotation) {
-        if (!DslAstHelper.hasAnnotation(annotation.getClassNode(), WRITE_ACCESS_ANNOTATION)) return null;
-
-        // We need to use the class explicitly, since we cannot access the members of metaAnnotations directly
-        // This is safe, since annotations are in a different module and thus already compiled
-        Class<?> annotationClass = annotation.getClassNode().getTypeClass();
-        return annotationClass.getAnnotation(WriteAccess.class).value();
     }
 
     //    static class ReplaceDirectAccessWithSettersVisitor extends CodeVisitorSupport {

--- a/wiki/Model-Phases.md
+++ b/wiki/Model-Phases.md
@@ -10,6 +10,9 @@ corresponding phase. Lifecycle annotations are annotations marked with the meta 
 methods must be parameterless and not be private. Their visibility will be downgraded to `protected` and they will be moved to
 the RW class.
 
+In addition to methods, fields of type `Closure` can also be annotated with lifecycle annotations. These closures will be exectued
+in their respective phases, with the RW object as delegate (i.e. will behave as like apply closures).
+
 The lifecycle annotations `@PostCreate` and `@PostApply` are a special case. These are not run as separate phases, but
 instead are part of the creation phase, and run for each object separately. 
 


### PR DESCRIPTION
Closure fields annotated with a lifecycle method will be executed in the respective phase.

Fix #84 