### PR TITLE
Generate public DSL support API (DSL-1)

### DIFF
--- a/klum-ast/build.gradle
+++ b/klum-ast/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     api libs.annodocimal.global.ast
     api libs.klum.cast.compile
 
+    sharedTests libs.annodocimal.gradle.plugin
     testFixturesCompileOnly libs.bundles.spock.groovy.v3
     testFixturesCompileOnly libs.jb.anno
 }
@@ -29,4 +30,3 @@ publishing {
         }
     }
 }
-

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AbstractFactoryBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AbstractFactoryBuilder.java
@@ -68,7 +68,17 @@ public abstract class AbstractFactoryBuilder {
 
     public abstract void invoke();
 
-    protected void createInnerClass(String name) {
+    protected void createCollectionFactoryClass(String name) {
+        createInnerClass(name);
+        GeneratedDslSupport.registerCollectionFactory(targetClass, collectionFactory, name);
+    }
+
+    protected void createClusterFactoryClass(String name) {
+        createInnerClass(name);
+        GeneratedDslSupport.registerClusterFactory(targetClass, collectionFactory, name);
+    }
+
+    private void createInnerClass(String name) {
         collectionFactory = new InnerClassNode(targetClass, targetClass.getName() + "$_" + name, ACC_PUBLIC | ACC_STATIC, OBJECT_TYPE);
         ClassNode builderType = rwClass.getPlainNodeReference();
         collectionFactory.addField("rw", ACC_PRIVATE | ACC_SYNTHETIC | ACC_FINAL, builderType, null);

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AlternativesClassBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AlternativesClassBuilder.java
@@ -128,7 +128,7 @@ class AlternativesClassBuilder extends AbstractFactoryBuilder {
 
     @Override
     public void invoke() {
-        createInnerClass(fieldNode.getName());
+        createCollectionFactoryClass(fieldNode.getName());
         createClosureForOuterClass();
         delegateDefaultCreationMethodsToOuterInstance();
         if (fieldNodeIsNoLink()) {

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -178,6 +178,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         makeClassSerializable();
 
         runDelayedActions(annotatedClass);
+        GeneratedDslSupport.complete(annotatedClass);
 
         new VariableScopeVisitor(sourceUnit, true).visitClass(annotatedClass);
         new VariableScopeVisitor(sourceUnit, true).visitClass(rwClass);
@@ -248,9 +249,17 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     @SuppressWarnings({"deprecation", "removal"}) // direct legacy marker preserves the generated shape until #394
     private void createRWClass() {
         ClassNode parentRW = getRwClassOfDslParent();
-        ClassNode builderBase = parentRW != null
-                ? parentRW.getPlainNodeReference()
-                : makeClassSafeWithGenerics(KLUM_BUILDER, new GenericsType(annotatedClass));
+        ClassNode builderBase;
+        if (parentRW != null) {
+            builderBase = parentRW.getPlainNodeReference();
+            GenericsType[] parentGenerics = annotatedClass.getUnresolvedSuperClass(false).getGenericsTypes();
+            if (parentGenerics != null) {
+                builderBase.setGenericsTypes(parentGenerics);
+                builderBase.setUsingGenerics(true);
+            }
+        } else {
+            builderBase = makeClassSafeWithGenerics(KLUM_BUILDER, new GenericsType(annotatedClass));
+        }
 
         rwClass = new InnerClassNode(
                 annotatedClass,
@@ -262,6 +271,8 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         AnnoDocUtil.addDocumentation(rwClass, "The generated Builder for " + annotatedClass.getName() + ".");
 
         DslAstHelper.registerAsVerbProvider(rwClass);
+        if (annotatedClass.getGenericsTypes() != null)
+            rwClass.setGenericsTypes(annotatedClass.getGenericsTypes());
 
         annotatedClass.getModule().addClass(rwClass);
         if (dslParent == null)
@@ -274,6 +285,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             parentProxy.setRedirect(rwClass);
 
         rwClass.addAnnotation(createGeneratedAnnotation(DSLASTTransformation.class));
+        GeneratedDslSupport.create(annotatedClass, rwClass);
     }
 
     private static final Set<String> SUPPORTED_COLLECTION_TYPES = Set.of(
@@ -1375,7 +1387,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             factoryClass.addConstructor(0, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY,
                     ctorSuperS(classX(annotatedClass)));
 
-        overrideClosureMethods(factoryClass, defaultImpl);
+        overrideFactoryMethods(factoryClass, defaultImpl);
 
         annotatedClass.getModule().addClass(factoryClass);
 
@@ -1390,6 +1402,8 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         AnnoDocUtil.addDocumentation(factoryField, "The factory for creating instances of " + annotatedClass.getName());
         factoryField.addAnnotation(createGeneratedAnnotation(DSLASTTransformation.class));
         factoryClass.addAnnotation(createGeneratedAnnotation(DSLASTTransformation.class));
+        GeneratedDslSupport.linkFactory(annotatedClass, factoryClass);
+        factoryField.setType(GeneratedDslSupport.of(annotatedClass).getFactoryInterface());
         annotatedClass.addField(factoryField);
     }
 
@@ -1413,15 +1427,57 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         return factoryBase;
     }
 
-    private void overrideClosureMethods(InnerClassNode factoryClass, ClassNode defaultImpl) {
-        ClassNode currentLevel = factoryClass.getSuperClass();
+    private void overrideFactoryMethods(InnerClassNode factoryClass, ClassNode defaultImpl) {
+        Map<String, ClassNode> genericsSpec = new LinkedHashMap<>();
+        ClassNode currentLevel = factoryClass;
 
-        while (currentLevel != null && factoryClass.isDerivedFrom(KLUM_FACTORY)) {
-            for (MethodNode methodNode : currentLevel.getMethods()) {
-                overrideUndelegatedClosureMethod(factoryClass, defaultImpl, methodNode);
-            }
-            currentLevel = currentLevel.getSuperClass();
+        while (currentLevel != null && (currentLevel.equals(KLUM_FACTORY) || currentLevel.isDerivedFrom(KLUM_FACTORY))) {
+            genericsSpec = createGenericsSpec(currentLevel, genericsSpec);
+            ClassNode declaringClass = currentLevel;
+            Map<String, ClassNode> currentSpec = genericsSpec;
+            currentLevel.getMethods().stream()
+                    .filter(method -> method.getDeclaringClass().redirect().equals(declaringClass.redirect()))
+                    .filter(MethodNode::isPublic)
+                    .filter(method -> !method.isStatic())
+                    .filter(method -> !method.isFinal())
+                    .map(method -> correctFactoryMethod(currentSpec, method))
+                    .forEach(method -> overrideFactoryMethod(factoryClass, defaultImpl, method));
+            currentLevel = currentLevel.getUnresolvedSuperClass();
         }
+    }
+
+    private static MethodNode correctFactoryMethod(Map<String, ClassNode> genericsSpec, MethodNode source) {
+        MethodNode corrected = correctToGenericsSpec(genericsSpec, source);
+        AnnoDocUtil.addDocumentation(corrected, ASTExtractor.extractDocumentation(source, null));
+        return corrected;
+    }
+
+    private void overrideFactoryMethod(InnerClassNode factoryClass, ClassNode defaultImpl, MethodNode methodNode) {
+        Parameter[] sourceParameters = methodNode.getParameters();
+        if (sourceParameters.length > 0 && sourceParameters[sourceParameters.length - 1].getType().equals(CLOSURE_TYPE)) {
+            overrideUndelegatedClosureMethod(factoryClass, defaultImpl, methodNode);
+            return;
+        }
+
+        Parameter[] parameters = cloneFactoryParameters(methodNode);
+        if (factoryClass.getDeclaredMethod(methodNode.getName(), parameters) != null)
+            return;
+
+        Statement body = methodNode.getReturnType().equals(VOID_TYPE)
+                ? stmt(callSuperX(methodNode.getName(), args(parameters)))
+                : returnS(callSuperX(methodNode.getName(), args(parameters)));
+        MethodNode override = new MethodNode(
+                methodNode.getName(),
+                methodNode.getModifiers(),
+                methodNode.getReturnType(),
+                parameters,
+                methodNode.getExceptions(),
+                body
+        );
+        override.setGenericsTypes(methodNode.getGenericsTypes());
+        String originalDocumentation = ASTExtractor.extractDocumentation(methodNode, null);
+        AnnoDocUtil.addDocumentation(override, originalDocumentation);
+        factoryClass.addMethod(override);
     }
 
     private void overrideUndelegatedClosureMethod(InnerClassNode factoryClass, ClassNode defaultImpl, MethodNode methodNode) {
@@ -1443,11 +1499,12 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             return;
         }
 
-        Parameter[] parameters = AstReflectionBridge.cloneParamsWithAdjustedNames(methodNode);
+        Parameter[] parameters = cloneFactoryParameters(methodNode);
         Parameter closureParam = parameters[parameters.length - 1];
 
         AnnotationNode delegatesTo = new AnnotationNode(DELEGATES_TO_ANNOTATION);
-        delegatesTo.setMember("value", classX(rwClass));
+        ClassNode publicBuilder = GeneratedDslSupport.of(annotatedClass).getBuilderInterface();
+        delegatesTo.setMember("value", classX(publicBuilder));
         delegatesTo.setMember("strategy", constX(Closure.DELEGATE_ONLY));
         closureParam.addAnnotation(delegatesTo);
 
@@ -1464,6 +1521,18 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         MethodNode existing = factoryClass.getDeclaredMethod(methodNode.getName(), parameters);
         if (existing == null)
             factoryClass.addMethod(newMethod);
+    }
+
+    private static Parameter[] cloneFactoryParameters(MethodNode source) {
+        Parameter[] sourceParameters = source.getParameters();
+        Parameter[] result = new Parameter[sourceParameters.length];
+        for (int index = 0; index < sourceParameters.length; index++) {
+            Parameter parameter = sourceParameters[index];
+            Parameter clone = new Parameter(parameter.getType(), parameter.getName(), parameter.getInitialExpression());
+            copyAnnotationsFromSourceToTarget(parameter, clone, Collections.emptyList());
+            result[index] = clone;
+        }
+        return result;
     }
 
 

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupport.java
@@ -1,0 +1,399 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform.ast;
+
+import com.blackbuild.annodocimal.ast.formatting.AnnoDocUtil;
+import com.blackbuild.groovy.configdsl.transform.KlumGenerated;
+import groovy.lang.DelegatesTo;
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.GenericsType;
+import org.codehaus.groovy.ast.InnerClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.MixinNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.expr.ClassExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ListExpression;
+import org.codehaus.groovy.ast.stmt.EmptyStatement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.copyAnnotationsFromSourceToTarget;
+import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.createGeneratedAnnotation;
+import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.getRwClassOf;
+import static com.blackbuild.klum.common.CommonAstHelper.getAnnotation;
+import static groovyjarjarasm.asm.Opcodes.ACC_ABSTRACT;
+import static groovyjarjarasm.asm.Opcodes.ACC_INTERFACE;
+import static groovyjarjarasm.asm.Opcodes.ACC_PUBLIC;
+import static groovyjarjarasm.asm.Opcodes.ACC_STATIC;
+
+/** Builds and links the public {@code Foo_DSL} contract for one transformed DSL Object. */
+public final class GeneratedDslSupport {
+
+    public static final String SUPPORT_METADATA_KEY = GeneratedDslSupport.class.getName() + ".support";
+    public static final String PUBLIC_INTERFACE_METADATA_KEY = GeneratedDslSupport.class.getName() + ".publicInterface";
+    public static final String API_TAG = "dsl-support-api";
+    public static final String INTERFACE_LINK_TAG = "dsl-support-interface:";
+
+    private static final ClassNode KLUM_GENERATED = ClassHelper.make(KlumGenerated.class);
+    private static final ClassNode DELEGATES_TO = ClassHelper.make(DelegatesTo.class);
+
+    private final ClassNode model;
+    private final ClassNode namespace;
+    private final InnerClassNode factoryInterface;
+    private final InnerClassNode builderInterface;
+    private final Map<ClassNode, ClassNode> implementations = new LinkedHashMap<>();
+
+    private GeneratedDslSupport(ClassNode model, ClassNode builderImplementation) {
+        this.model = model;
+        namespace = new ClassNode(
+                model.getName() + "_DSL",
+                ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE,
+                ClassHelper.OBJECT_TYPE
+        );
+        namespace.setSourcePosition(model);
+        AnnoDocUtil.addDocumentation(namespace, "The generated DSL support namespace for " + model.getName() + ".");
+        namespace.addAnnotation(createGeneratedAnnotation(GeneratedDslSupport.class, List.of(API_TAG, "dsl-support-role:namespace")));
+        model.getModule().addClass(namespace);
+
+        factoryInterface = createNestedInterface(namespace, "Factory", "The public factory contract for " + model.getName() + ".");
+        builderInterface = createNestedInterface(namespace, "Builder", "The public Builder contract for " + model.getName() + ".");
+        copyTypeParameters(model, builderInterface);
+        addParentBuilderInterface();
+        link(builderImplementation, parameterizedForModel(builderInterface, model));
+    }
+
+    public static GeneratedDslSupport create(ClassNode model, ClassNode builderImplementation) {
+        GeneratedDslSupport support = new GeneratedDslSupport(model, builderImplementation);
+        model.setNodeMetaData(SUPPORT_METADATA_KEY, support);
+        return support;
+    }
+
+    public static GeneratedDslSupport of(ClassNode model) {
+        GeneratedDslSupport support = model.getNodeMetaData(SUPPORT_METADATA_KEY);
+        if (support == null)
+            throw new IllegalStateException("No generated DSL support namespace registered for " + model.getName());
+        return support;
+    }
+
+    public ClassNode getFactoryInterface() {
+        return factoryInterface;
+    }
+
+    public ClassNode getBuilderInterface() {
+        return parameterizedForModel(builderInterface, model);
+    }
+
+    public static ClassNode registerCollectionFactory(ClassNode model, ClassNode implementation, String fieldName) {
+        return of(model).registerNestedFactory(implementation, "CollectionFactory_" + fieldName,
+                "The public collection factory contract for " + model.getName() + "." + fieldName + ".");
+    }
+
+    public static ClassNode registerClusterFactory(ClassNode model, ClassNode implementation, String fieldName) {
+        return of(model).registerNestedFactory(implementation, "ClusterFactory_" + fieldName,
+                "The public Cluster factory contract for " + model.getName() + "." + fieldName + ".");
+    }
+
+    public static void linkFactory(ClassNode model, ClassNode implementation) {
+        GeneratedDslSupport support = of(model);
+        support.link(implementation, support.factoryInterface);
+    }
+
+    public static void complete(ClassNode model) {
+        GeneratedDslSupport support = of(model);
+        support.implementations.forEach(support::projectImplementation);
+    }
+
+    /** Resolves the public API type through an explicit generated {@code implements} link. */
+    public static ClassNode publicType(ClassNode type) {
+        if (type == null) return null;
+        if (type.isArray()) return publicType(type.getComponentType()).makeArray();
+        if (type.isGenericsPlaceHolder()) return type;
+        if (hasGeneratedApiTag(type)) return type;
+
+        String linkedInterface = generatedLink(type);
+        if (linkedInterface != null) {
+            for (ClassNode candidate : type.getInterfaces()) {
+                if (candidate.redirect().getName().equals(linkedInterface))
+                    return copyGenerics(type, candidate);
+            }
+        }
+
+        for (ClassNode candidate : type.getInterfaces()) {
+            if (hasGeneratedApiTag(candidate))
+                return copyGenerics(type, candidate);
+        }
+
+        ClassNode direct = type.getNodeMetaData(PUBLIC_INTERFACE_METADATA_KEY);
+        if (direct != null)
+            return copyGenerics(type, direct);
+
+        direct = type.redirect().getNodeMetaData(PUBLIC_INTERFACE_METADATA_KEY);
+        if (direct != null)
+            return copyGenerics(type, direct);
+
+        GenericsType[] generics = type.getGenericsTypes();
+        if (generics == null || generics.length == 0)
+            return type;
+
+        ClassNode result = type.getPlainNodeReference();
+        result.setGenericsTypes(Arrays.stream(generics).map(GeneratedDslSupport::projectGenericsType).toArray(GenericsType[]::new));
+        return result;
+    }
+
+    private ClassNode registerNestedFactory(ClassNode implementation, String name, String documentation) {
+        ClassNode api = createNestedInterface(builderInterface, name, documentation);
+        link(implementation, api);
+        return api;
+    }
+
+    private void addParentBuilderInterface() {
+        ClassNode parent = model.getUnresolvedSuperClass(false);
+        if (!DslAstHelper.isDSLObject(parent)) return;
+
+        ClassNode parentModel = parent.redirect();
+        GeneratedDslSupport parentSupport = parentModel.getNodeMetaData(SUPPORT_METADATA_KEY);
+        if (parentSupport == null && !parentModel.isResolved()) {
+            DslAstHelper.addDelayedAction(parentModel, () -> addParentBuilderInterface(parent));
+            return;
+        }
+        addParentBuilderInterface(parent);
+    }
+
+    private void addParentBuilderInterface(ClassNode parent) {
+        ClassNode parentBuilder = publicType(getRwClassOf(parent.redirect())).redirect();
+        builderInterface.setUsingGenerics(true);
+        builderInterface.setInterfaces(new ClassNode[] { parameterizedForModel(parentBuilder, parent) });
+    }
+
+    private void link(ClassNode implementation, ClassNode publicInterface) {
+        implementation.addInterface(publicInterface);
+        implementation.setNodeMetaData(PUBLIC_INTERFACE_METADATA_KEY, publicInterface);
+        implementations.put(implementation, publicInterface.redirect());
+        appendGeneratedTag(implementation, INTERFACE_LINK_TAG + publicInterface.redirect().getName());
+    }
+
+    private void projectImplementation(ClassNode implementation, ClassNode publicInterface) {
+        implementation.getFields().stream()
+                .filter(field -> field.getOwner().redirect().equals(implementation.redirect()))
+                .forEach(field -> field.setType(publicType(field.getType())));
+        List<MethodNode> methods = new ArrayList<>(implementation.getMethods());
+        methods.stream()
+                .filter(method -> method.getDeclaringClass().redirect().equals(implementation.redirect()))
+                .filter(MethodNode::isPublic)
+                .filter(method -> !method.isStatic())
+                .filter(method -> !method.isSynthetic())
+                .filter(method -> !shadowsPackagePrivateSuperMethod(implementation, method))
+                .forEach(method -> addProjectedMethod(publicInterface, method));
+    }
+
+    private static boolean shadowsPackagePrivateSuperMethod(ClassNode implementation, MethodNode method) {
+        ClassNode current = implementation.getSuperClass();
+        while (current != null) {
+            MethodNode inherited = current.getDeclaredMethod(method.getName(), method.getParameters());
+            if (inherited != null) {
+                int visibility = inherited.getModifiers() & (groovyjarjarasm.asm.Opcodes.ACC_PUBLIC
+                        | groovyjarjarasm.asm.Opcodes.ACC_PROTECTED
+                        | groovyjarjarasm.asm.Opcodes.ACC_PRIVATE);
+                return visibility == 0;
+            }
+            current = current.getSuperClass();
+        }
+        return false;
+    }
+
+    private void addProjectedMethod(ClassNode publicInterface, MethodNode implementationMethod) {
+        projectMethodSignature(implementationMethod);
+        Parameter[] parameters = cloneParameters(implementationMethod.getParameters());
+        if (publicInterface.getDeclaredMethod(implementationMethod.getName(), parameters) != null) return;
+
+        MethodNode apiMethod = new MethodNode(
+                implementationMethod.getName(),
+                ACC_PUBLIC | ACC_ABSTRACT,
+                publicType(implementationMethod.getReturnType()),
+                parameters,
+                Arrays.stream(implementationMethod.getExceptions()).map(GeneratedDslSupport::publicType).toArray(ClassNode[]::new),
+                EmptyStatement.INSTANCE
+        );
+        apiMethod.setGenericsTypes(projectGenericsTypes(implementationMethod.getGenericsTypes()));
+        copyAnnotationsFromSourceToTarget(implementationMethod, apiMethod, Collections.emptyList());
+        publicInterface.addMethod(apiMethod);
+    }
+
+    private static void projectMethodSignature(MethodNode method) {
+        method.setReturnType(publicType(method.getReturnType()));
+        for (Parameter parameter : method.getParameters()) {
+            parameter.setType(publicType(parameter.getType()));
+            projectDelegatesTo(parameter);
+        }
+        method.setGenericsTypes(projectGenericsTypes(method.getGenericsTypes()));
+    }
+
+    private static Parameter[] cloneParameters(Parameter[] source) {
+        Parameter[] result = new Parameter[source.length];
+        for (int index = 0; index < source.length; index++) {
+            Parameter parameter = source[index];
+            Parameter clone = new Parameter(publicType(parameter.getType()), parameter.getName(), parameter.getInitialExpression());
+            copyAnnotationsFromSourceToTarget(parameter, clone, Collections.emptyList());
+            projectDelegatesTo(clone);
+            result[index] = clone;
+        }
+        return result;
+    }
+
+    private static void projectDelegatesTo(AnnotatedNode target) {
+        AnnotationNode delegatesTo = getAnnotation(target, DELEGATES_TO);
+        if (delegatesTo == null) return;
+        Expression value = delegatesTo.getMember("value");
+        if (value instanceof ClassExpression) {
+            ClassNode projected = publicType(((ClassExpression) value).getType());
+            AnnotationNode replacement = new AnnotationNode(DELEGATES_TO);
+            delegatesTo.getMembers().forEach(replacement::setMember);
+            replacement.setMember("value", new ClassExpression(projected));
+            target.getAnnotations().remove(delegatesTo);
+            target.addAnnotation(replacement);
+        }
+    }
+
+    private static GenericsType[] projectGenericsTypes(GenericsType[] source) {
+        if (source == null) return null;
+        return Arrays.stream(source).map(GeneratedDslSupport::projectGenericsType).toArray(GenericsType[]::new);
+    }
+
+    private static GenericsType projectGenericsType(GenericsType source) {
+        GenericsType result = new GenericsType(
+                publicType(source.getType()),
+                source.getUpperBounds() == null
+                        ? null
+                        : Arrays.stream(source.getUpperBounds()).map(GeneratedDslSupport::publicType).toArray(ClassNode[]::new),
+                publicType(source.getLowerBound())
+        );
+        result.setName(source.getName());
+        result.setPlaceholder(source.isPlaceholder());
+        result.setWildcard(source.isWildcard());
+        return result;
+    }
+
+    private static ClassNode parameterizedForModel(ClassNode api, ClassNode modelType) {
+        GenericsType[] modelGenerics = modelType.getGenericsTypes();
+        if (modelGenerics == null || modelGenerics.length == 0)
+            return api.getPlainNodeReference();
+        return withGenerics(api, projectGenericsTypes(modelGenerics));
+    }
+
+    private static ClassNode copyGenerics(ClassNode source, ClassNode target) {
+        GenericsType[] sourceGenerics = source.getGenericsTypes();
+        if (sourceGenerics == null || sourceGenerics.length == 0)
+            return target.getPlainNodeReference();
+        return withGenerics(target, projectGenericsTypes(sourceGenerics));
+    }
+
+    private static ClassNode withGenerics(ClassNode target, GenericsType[] generics) {
+        ClassNode result = target.getPlainNodeReference();
+        result.setGenericsTypes(generics);
+        result.setUsingGenerics(true);
+        return result;
+    }
+
+    private static void copyTypeParameters(ClassNode source, ClassNode target) {
+        GenericsType[] generics = source.getGenericsTypes();
+        if (generics != null)
+            target.setGenericsTypes(projectGenericsTypes(generics));
+    }
+
+    private static InnerClassNode createNestedInterface(ClassNode owner, String name, String documentation) {
+        InnerClassNode result = new InnerClassNode(
+                owner,
+                owner.getName() + "$" + name,
+                ACC_PUBLIC | ACC_STATIC | ACC_ABSTRACT | ACC_INTERFACE,
+                ClassHelper.OBJECT_TYPE,
+                ClassNode.EMPTY_ARRAY,
+                MixinNode.EMPTY_ARRAY
+        );
+        result.setSourcePosition(owner);
+        AnnoDocUtil.addDocumentation(result, documentation);
+        result.addAnnotation(createGeneratedAnnotation(GeneratedDslSupport.class, List.of(API_TAG, "dsl-support-role:" + name)));
+        owner.getModule().addClass(result);
+        return result;
+    }
+
+    private static void appendGeneratedTag(ClassNode implementation, String tag) {
+        AnnotationNode generated = getAnnotation(implementation, KLUM_GENERATED);
+        if (generated == null)
+            throw new IllegalStateException("Generated implementation has no @KlumGenerated metadata: " + implementation.getName());
+
+        List<Expression> tags = new ArrayList<>();
+        Expression existing = generated.getMember("tags");
+        if (existing instanceof ListExpression)
+            tags.addAll(((ListExpression) existing).getExpressions());
+        else if (existing != null)
+            tags.add(existing);
+        tags.add(new ConstantExpression(tag));
+        generated.setMember("tags", new ListExpression(tags));
+    }
+
+    private static boolean hasGeneratedApiTag(ClassNode candidate) {
+        AnnotationNode generated = getAnnotation(candidate, KLUM_GENERATED);
+        if (generated == null) return false;
+        Expression tags = generated.getMember("tags");
+        if (tags instanceof ListExpression)
+            return ((ListExpression) tags).getExpressions().stream()
+                    .filter(ConstantExpression.class::isInstance)
+                    .map(ConstantExpression.class::cast)
+                    .map(ConstantExpression::getText)
+                    .anyMatch(API_TAG::equals);
+        return tags instanceof ConstantExpression && Objects.equals(((ConstantExpression) tags).getText(), API_TAG);
+    }
+
+    private static String generatedLink(ClassNode implementation) {
+        AnnotationNode generated = getAnnotation(implementation, KLUM_GENERATED);
+        if (generated == null) return null;
+        Expression tags = generated.getMember("tags");
+        if (tags instanceof ListExpression)
+            return ((ListExpression) tags).getExpressions().stream()
+                    .filter(ConstantExpression.class::isInstance)
+                    .map(ConstantExpression.class::cast)
+                    .map(ConstantExpression::getText)
+                    .filter(tag -> tag.startsWith(INTERFACE_LINK_TAG))
+                    .map(tag -> tag.substring(INTERFACE_LINK_TAG.length()))
+                    .findFirst()
+                    .orElse(null);
+        if (tags instanceof ConstantExpression) {
+            String tag = ((ConstantExpression) tags).getText();
+            if (tag.startsWith(INTERFACE_LINK_TAG))
+                return tag.substring(INTERFACE_LINK_TAG.length());
+        }
+        return null;
+    }
+}

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupport.java
@@ -223,6 +223,7 @@ public final class GeneratedDslSupport {
         while (current != null) {
             MethodNode inherited = current.getDeclaredMethod(method.getName(), method.getParameters());
             if (inherited != null) {
+                // Groovy resolves shadowing against the nearest superclass declaration.
                 int visibility = inherited.getModifiers() & (groovyjarjarasm.asm.Opcodes.ACC_PUBLIC
                         | groovyjarjarasm.asm.Opcodes.ACC_PROTECTED
                         | groovyjarjarasm.asm.Opcodes.ACC_PRIVATE);
@@ -278,6 +279,7 @@ public final class GeneratedDslSupport {
         Expression value = delegatesTo.getMember("value");
         if (value instanceof ClassExpression) {
             ClassNode projected = publicType(((ClassExpression) value).getType());
+            // Cloned parameters can share this AnnotationNode; replace it instead of mutating shared metadata.
             AnnotationNode replacement = new AnnotationNode(DELEGATES_TO);
             delegatesTo.getMembers().forEach(replacement::setMember);
             replacement.setMember("value", new ClassExpression(projected));

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/ClusterFactoryBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/ClusterFactoryBuilder.java
@@ -93,7 +93,7 @@ public class ClusterFactoryBuilder extends AbstractFactoryBuilder {
 
         if (fieldsToInclude.isEmpty()) return;
 
-        createInnerClass(fieldName);
+        createClusterFactoryClass(fieldName);
         for (FieldNode fieldNode : fieldsToInclude)
             addMethodsForField(fieldNode);
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupportSpec.groovy
@@ -1,0 +1,226 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform.ast
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc
+import com.blackbuild.annodocimal.generator.AnnoDocGenerator
+import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.blackbuild.groovy.configdsl.transform.KlumGenerated
+import groovy.lang.DelegatesTo
+import org.intellij.lang.annotations.Language
+
+import javax.tools.ToolProvider
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+class GeneratedDslSupportSpec extends AbstractDSLSpec {
+
+    def setup() {
+        createRepresentativeSchema()
+    }
+
+    def "generates the complete public namespace and explicitly links hidden implementations"() {
+        given:
+        Class<?> foo = getClass('sample.Foo')
+        Class<?> namespace = getClass('sample.Foo_DSL')
+        Class<?> factory = getClass('sample.Foo_DSL$Factory')
+        Class<?> builder = getClass('sample.Foo_DSL$Builder')
+        Class<?> collectionFactory = getClass('sample.Foo_DSL$Builder$CollectionFactory_kids')
+        Class<?> clusterFactory = getClass('sample.Foo_DSL$Builder$ClusterFactory_services')
+
+        expect:
+        namespace.interface && Modifier.isPublic(namespace.modifiers)
+        factory.interface && builder.interface && collectionFactory.interface && clusterFactory.interface
+        foo.getField('Create').type == factory
+
+        and: 'implementation linkage is carried by generated metadata and JVM interfaces'
+        factory.isAssignableFrom(getClass('sample.Foo$_Factory'))
+        builder.isAssignableFrom(getClass('sample.Foo$_RW'))
+        collectionFactory.isAssignableFrom(getClass('sample.Foo$_kids'))
+        clusterFactory.isAssignableFrom(getClass('sample.Foo$_services'))
+        generatedLink(getClass('sample.Foo$_RW')) == builder.name
+        generatedLink(getClass('sample.Foo$_Factory')) == factory.name
+    }
+
+    def "public signatures traverse Builder collection and Cluster APIs without implementation types"() {
+        given:
+        Class<?> builder = getClass('sample.Foo_DSL$Builder')
+        Class<?> childBuilder = getClass('sample.Child_DSL$Builder')
+        Class<?> collectionFactory = getClass('sample.Foo_DSL$Builder$CollectionFactory_kids')
+        Class<?> clusterFactory = getClass('sample.Foo_DSL$Builder$ClusterFactory_services')
+
+        expect:
+        closureDelegate(builder.getMethod('kids', Closure)) == collectionFactory
+        closureDelegate(builder.getMethod('services', Closure)) == clusterFactory
+        Method kid = collectionFactory.getMethod('kid', Map, Closure)
+        Method primary = clusterFactory.getMethod('primary', Map, Closure)
+        closureDelegate(kid) == childBuilder
+        kid.returnType == childBuilder
+        primary.returnType == childBuilder
+
+        and: 'no public support signature leaks a generated implementation class'
+        [builder, collectionFactory, clusterFactory].every { publicSignatures(it).every { !it.contains('\$_') } }
+    }
+
+    def "preserves inherited and generic Builder typing"() {
+        given:
+        Class<?> baseBuilder = getClass('sample.Base_DSL$Builder')
+        Class<?> fooBuilder = getClass('sample.Foo_DSL$Builder')
+
+        expect:
+        baseBuilder.typeParameters*.name == ['T']
+        fooBuilder.genericInterfaces*.typeName.contains('sample.Base_DSL$Builder<java.lang.String>')
+        baseBuilder.getMethod('label', Object).genericParameterTypes*.typeName == ['T']
+        fooBuilder.getMethod('label', Object).declaringClass == baseBuilder
+    }
+
+    def "Java and statically compiled Groovy consume only the public namespace"() {
+        when:
+        compileJavaConsumer('''
+            package sample;
+
+            import groovy.lang.Closure;
+            import java.util.Map;
+
+            public final class JavaDslConsumer {
+                public static Foo_DSL.Factory factory() {
+                    return Foo.Create;
+                }
+
+                public static Child_DSL.Builder addChild(
+                        Foo_DSL.Builder owner,
+                        Foo_DSL.Builder.CollectionFactory_kids kids) {
+                    owner.kids((Closure<?>) null);
+                    return kids.kid(Map.of(), (Closure<?>) null);
+                }
+
+                public static Child_DSL.Builder addPrimary(
+                        Foo_DSL.Builder.ClusterFactory_services services) {
+                    return services.primary(Map.of(), (Closure<?>) null);
+                }
+            }
+        ''')
+
+        Class<?> consumer = createSecondaryClass('''
+            package sample
+
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticDslConsumer {
+                static Foo create() {
+                    Foo.Create.With {
+                        label 'root'
+                        kids {
+                            kid { name 'list child' }
+                        }
+                        services {
+                            primary { name 'cluster child' }
+                        }
+                    }
+                }
+            }
+        ''', 'sample/StaticDslConsumer.groovy')
+
+        then:
+        consumer.create().kids*.name == ['list child']
+        consumer.create().primary.name == 'cluster child'
+    }
+
+    def "AnnoDocimal source mirror matches the bytecode namespace and nested documentation"() {
+        given:
+        File mirrorRoot = new File(tempFolder.root, 'mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'sample/Foo_DSL.class')
+
+        when:
+        AnnoDocGenerator.generate(namespaceClass, mirrorRoot)
+        String mirror = new File(mirrorRoot, 'sample/Foo_DSL.java').text
+
+        then:
+        mirror.contains('interface Foo_DSL')
+        mirror.contains('interface Factory')
+        mirror.contains('interface Builder')
+        mirror.contains('interface CollectionFactory_kids')
+        mirror.contains('interface ClusterFactory_services')
+        mirror.contains('The generated DSL support namespace for sample.Foo.')
+        mirror.contains('Creates a new')
+        getClass('sample.Foo_DSL$Builder').getAnnotation(AnnoDoc).value().contains('public Builder contract')
+    }
+
+    private void createRepresentativeSchema() {
+        createClass '''
+            package sample
+
+            import com.blackbuild.groovy.configdsl.transform.DSL
+            import com.blackbuild.klum.ast.util.layer3.annotations.Cluster
+
+            @DSL abstract class Base<T> {
+                T label
+            }
+
+            @DSL class Child {
+                String name
+            }
+
+            @DSL class Foo extends Base<String> {
+                List<Child> kids
+                Child primary
+                Child secondary
+                @Cluster Map<String, Child> services
+            }
+        '''
+    }
+
+    private static Class<?> closureDelegate(Method method) {
+        method.parameters.last().getAnnotation(DelegatesTo).value()
+    }
+
+    private static String generatedLink(Class<?> implementation) {
+        implementation.getAnnotation(KlumGenerated).tags().find { it.startsWith('dsl-support-interface:') }
+                ?.substring('dsl-support-interface:'.length())
+    }
+
+    private static List<String> publicSignatures(Class<?> type) {
+        type.methods.collect { Method method ->
+            ([method.genericReturnType.typeName] + method.genericParameterTypes*.typeName).join(' ')
+        }
+    }
+
+    private void compileJavaConsumer(@Language('JAVA') String source) {
+        File sourceFile = new File(tempFolder.root, 'sample/JavaDslConsumer.java')
+        sourceFile.parentFile.mkdirs()
+        sourceFile.text = source.stripIndent()
+        String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
+                .join(File.pathSeparator)
+        int result = ToolProvider.systemJavaCompiler.run(
+                null,
+                null,
+                null,
+                '-classpath', classpath,
+                '-d', compilerConfiguration.targetDirectory.absolutePath,
+                sourceFile.absolutePath
+        )
+        assert result == 0
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/util/FactoryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/util/FactoryTest.groovy
@@ -53,7 +53,8 @@ abstract class AbstractWithDefaultImpl {}
         def factoryField = getClass(className).getField("Create")
 
         then:
-        factoryType.isAssignableFrom(factoryField.type)
+        factoryField.type == getClass(className + '_DSL$Factory')
+        factoryType.isAssignableFrom(factoryField.get(null).class)
 
         when:
         KlumFactory factory = getClass(className).Create


### PR DESCRIPTION
## Summary

- generate real top-level `Foo_DSL` bytecode namespaces with public nested `Factory`, `Builder`, collection-factory, and Cluster-factory interfaces
- type `Foo.Create` and generated implementations against those interfaces using explicit generated linkage metadata
- preserve inherited and generic Builder contracts without leaking legacy `$_*` implementation names
- attach AnnoDoc metadata so #434's IDE-only mirror mechanism emits matching source mirrors
- add executable Java, statically compiled Groovy, traversal, inheritance, linkage, and mirror-parity coverage

## Impact

Java and statically compiled Groovy consumers can compile against stable generated DSL interfaces. IDE source mirrors remain metadata-only and are not added to compiler, packaging, publication, or downstream inputs.

## Scope

Closes #433.

This builds on #434 as the authoritative mirror-generation seam. DSL-2 capability splitting, DSL-3 release documentation/distribution work, and ADR 0004 projection work remain out of scope.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- focused DSL-G Gradle mirror and isolation scenarios
- `./gradlew check`
- `git diff --check`
