### PR TITLE
Implement active-session Create.AsBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,17 @@ This is a breaking release. See the [Builder-first construction migration](https
   `Foo_DSL` interfaces and refresh their AnnoDocimal IDE source mirrors without compiling, packaging, publishing, or
   propagating the mirrors themselves ([#434](https://github.com/klum-dsl/klum-ast/issues/434)).
 - Provisional Builder validation issues transfer to the completed-model companion, and each `InstanceValidator` is memoized once per completed model.
-- Known compatibility gap: collection-local creator projections, direct `DelegatingScript` collection creation, and DSL Object converters that call model-returning factories currently fail rather than produce owned child Builders. Their target behavior is retained as pending tests and specified by [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md), with implementation tracked by [#431](https://github.com/klum-dsl/klum-ast/issues/431); use generated child closure methods until the `Create.AsBuilder` follow-up lands.
+- Added active-session `Create.AsBuilder.With`, `One`, `FromMap`, and `From(DelegatingScript)` operations. They create an
+  unsealed owned Builder in the current root Construction session, apply active Templates, and run `PostCreate`, explicit
+  configuration, and `PostApply` once without starting a nested lifecycle. Calls outside the session, across root sessions,
+  or after lifecycle completion fail with migration guidance; ordinary materializing Scripts remain root-only
+  ([#436](https://github.com/klum-dsl/klum-ast/issues/436)).
+- Known compatibility gap: collection/Cluster projections, direct `DelegatingScript` collection creation, and DSL Object
+  converters that call model-returning factories still require the generated Builder-producing projections tracked by
+  [#437](https://github.com/klum-dsl/klum-ast/issues/437). Template companion and replay semantics remain tracked by
+  [#438](https://github.com/klum-dsl/klum-ast/issues/438). Their target behavior is specified by
+  [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md); use generated
+  child closure methods where no owning Builder projection is available yet.
 
 ## Templates, serialization, and Jackson
 

--- a/docs/implementation/adr-0004-asbuilder-composition.md
+++ b/docs/implementation/adr-0004-asbuilder-composition.md
@@ -174,6 +174,10 @@ Extract one child-preparation path shared by closure creation and `FactoryHelper
 owned relationship. The slice is complete when the child joins the root lifecycle, `PostCreate`/configuration/`PostApply`
 run once, root factories still return completed models, and outside-session or cross-session calls fail clearly.
 
+**Implemented:** issue #436 provides the shared preparation path, active-session identity/adoption checks, generated
+`Foo_DSL.Builder` return/delegate typing, built-in recipe inputs, and focused executable coverage. It deliberately leaves
+collection/Cluster/custom-factory projections to AB-2 and Template companion/copy-source behavior to AB-3.
+
 ### [AB-2 — Generated projections and hidden twins](https://github.com/klum-dsl/klum-ast/issues/437)
 
 Route collection, map, Cluster, direct delegating-script, converter, and custom factory composition through
@@ -198,6 +202,10 @@ Do not combine all source transformations in one commit. Single-result built-ins
 custom factories, and explicit converter contracts have distinct failure modes and should remain independently revertible.
 
 ## Existing target-contract tests
+
+AB-1 executable coverage lives in `AsBuilderSpec` and `GeneratedDslSupportSpec`. It covers one owned child, callback counts,
+active Templates, ownership and paths, root-return compatibility, built-in inputs, session failures, and concrete generated
+Builder signatures.
 
 The following Groovy 3 features record behavior to restore and carry a reasoned `@PendingFeature` until their slice lands:
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/ConstructionSession.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/ConstructionSession.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.process;
+
+/**
+ * Opaque identity for one root Builder lifecycle.
+ *
+ * <p>The token intentionally exposes no phase, current object, or other
+ * {@link PhaseDriver.Context} authority.</p>
+ */
+public final class ConstructionSession {
+
+    ConstructionSession() {
+        // Created only by PhaseDriver.
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
@@ -56,6 +56,9 @@ public class PhaseDriver {
 
     private Object rootObject;
     private int activeObjectPointer = 0;
+    private ConstructionSession constructionSession;
+    private final Set<KlumBuilder<?>> constructionSessionBuilders =
+            Collections.newSetFromMap(new IdentityHashMap<>());
 
     private PhaseAction currentPhase;
 
@@ -123,23 +126,51 @@ public class PhaseDriver {
 
     /** Runs one complete Builder lifecycle and returns its completed model. */
     public static <T> T withBuilderLifecycle(Supplier<? extends KlumBuilder<T>> generator, Consumer<KlumBuilder<T>> action) {
-        if (PhaseDriver.getInstance().activeObjectPointer > 0)
+        PhaseDriver driver = PhaseDriver.getInstance();
+        if (driver.activeObjectPointer > 0 || driver.constructionSession != null)
             throw new KlumModelException("Cannot start an independent DSL Object factory while a Builder lifecycle is active. "
                     + "Create composition through the owning Builder's generated relationship methods; "
                     + "completed DSL Objects may only be created beforehand and assigned to LINK fields.");
 
-        Object oldInstance = PhaseDriver.getInstance().context.getInstance();
+        Object oldInstance = driver.context.getInstance();
+        driver.constructionSession = new ConstructionSession();
+        boolean entered = false;
         try {
             KlumBuilder<T> builder = generator.get();
-            PhaseDriver.getInstance().context.setInstance(builder);
+            attachToCurrentConstructionSession(builder);
+            driver.context.setInstance(builder);
             PhaseDriver.enter(builder);
+            entered = true;
             action.accept(builder);
             PhaseDriver.executeIfReady();
-            return (T) PhaseDriver.getInstance().rootObject;
+            return (T) driver.rootObject;
         } finally {
-            PhaseDriver.getInstance().context.setInstance(oldInstance);
-            PhaseDriver.leave();
+            driver.context.setInstance(oldInstance);
+            if (entered)
+                PhaseDriver.leave();
+            else {
+                driver.completeConstructionSession();
+                INSTANCE.remove();
+            }
         }
+    }
+
+    /** Associates a newly allocated Builder with the active root lifecycle, if one exists. */
+    public static void attachToCurrentConstructionSession(KlumBuilder<?> builder) {
+        PhaseDriver driver = INSTANCE.get();
+        if (driver == null || driver.constructionSession == null)
+            return;
+        builder.$attachConstructionSession(driver.constructionSession);
+        driver.constructionSessionBuilders.add(builder);
+    }
+
+    /** Rejects Builder-producing factory calls that are not owned by a root lifecycle. */
+    public static void requireActiveConstructionSession() {
+        PhaseDriver driver = INSTANCE.get();
+        if (driver == null || driver.constructionSession == null)
+            throw new KlumModelException("Create.AsBuilder requires an active Construction session. "
+                    + "Call it inside the owning root Builder lifecycle and attach the returned Builder to an owned relationship; "
+                    + "use Create.With, Create.One, or Create.From for a standalone completed DSL Object.");
     }
 
     public static void enter(Object object) {
@@ -157,8 +188,19 @@ public class PhaseDriver {
     public static void leave() {
         PhaseDriver driver = getInstance();
         driver.activeObjectPointer--;
-        if (getInstance().activeObjectPointer == 0)
+        if (driver.activeObjectPointer == 0) {
+            driver.completeConstructionSession();
             INSTANCE.remove();
+        }
+    }
+
+    private void completeConstructionSession() {
+        ConstructionSession completedSession = constructionSession;
+        if (completedSession == null)
+            return;
+        constructionSessionBuilders.forEach(builder -> builder.$completeConstructionSession(completedSession));
+        constructionSessionBuilders.clear();
+        constructionSession = null;
     }
 
     public static void executeIfReady() {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/BreadCrumbVerbInterceptor.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/BreadCrumbVerbInterceptor.java
@@ -32,7 +32,8 @@ public class BreadCrumbVerbInterceptor implements Interceptor {
 
     private static final BreadCrumbVerbInterceptor INSTANCE = new BreadCrumbVerbInterceptor();
 
-    private static final Set<String> IGNORED_METHODS = Set.of("getMethod", "getMetaClass", "setMetaClass", "invokeMethod", "getProperty", "setProperty", "ctor");
+    private static final Set<String> IGNORED_METHODS = Set.of(
+            "getMethod", "getMetaClass", "setMetaClass", "invokeMethod", "getProperty", "setProperty", "getAsBuilder", "ctor");
 
     @Override
     @SuppressWarnings("java:S3516") // only relevant if doInvoke() returns false, which it never does

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
@@ -84,6 +84,8 @@ public class FactoryHelper extends GroovyObjectSupport {
             if (!constructor.trySetAccessible())
                 throw new KlumModelException("Cannot access generated Builder constructor for " + type.getName());
             KlumBuilder<T> builder = (KlumBuilder<T>) constructor.newInstance(key);
+            if (!template)
+                PhaseDriver.attachToCurrentConstructionSession(builder);
             if (breadcrumbPathExtension != null)
                 builder.setBreadcrumbPath(BreadcrumbCollector.getInstance().getFullPath() + "/" + breadcrumbPathExtension);
             else if (BreadcrumbCollector.hasInstance())
@@ -113,10 +115,7 @@ public class FactoryHelper extends GroovyObjectSupport {
         String key = recipeKey(effectiveType, recipe);
         if (key == null && keyHint != null)
             key = keyHint.toString();
-        KlumBuilder<?> builder = createBuilder(effectiveType, key, breadcrumbPathExtension);
-        if (template)
-            builder.markAsTemplate();
-        return builder;
+        return createBuilder(effectiveType, key, breadcrumbPathExtension, template);
     }
 
     private static Class<?> effectiveRecipeType(Class<?> declaredType, Object recipe) {
@@ -154,10 +153,24 @@ public class FactoryHelper extends GroovyObjectSupport {
      * The root Builder traversal will process and materialize it together with its owner.
      */
     public static <T> KlumBuilder<T> createNestedBuilder(Class<T> type, Map<String, ?> values, String key) {
-        KlumBuilder<T> builder = createBuilder(type, key);
+        return prepareNestedBuilder(type, key, false, builder -> builder.applyOnly(values, null));
+    }
+
+    static <T> KlumBuilder<T> prepareNestedBuilder(Class<T> type, String key, boolean template,
+                                                   Consumer<KlumBuilder<T>> configuration) {
+        return prepareBuilder(createBuilder(type, key, null, template), template, configuration);
+    }
+
+    private static <T> KlumBuilder<T> prepareBuilder(KlumBuilder<T> builder, boolean template,
+                                                      Consumer<KlumBuilder<T>> configuration) {
+        if (template)
+            builder.markAsTemplate();
         builder.copyFromTemplate();
-        LifecycleHelper.executeLifecycleMethods(builder, PostCreate.class);
-        builder.apply(values, null);
+        if (!template)
+            LifecycleHelper.executeLifecycleMethods(builder, PostCreate.class);
+        configuration.accept(builder);
+        if (!template)
+            LifecycleHelper.executeLifecycleMethods(builder, PostApply.class);
         return builder;
     }
 
@@ -281,7 +294,6 @@ public class FactoryHelper extends GroovyObjectSupport {
         Consumer<KlumBuilder<T>> apply = builder -> {
             script.setDelegate(builder);
             script.run();
-            LifecycleHelper.executeLifecycleMethods(builder, PostApply.class);
         };
 
         if (DslHelper.isKeyed(type))
@@ -292,15 +304,8 @@ public class FactoryHelper extends GroovyObjectSupport {
 
     private static <T> T doCreate(String key, Supplier<? extends KlumBuilder<T>> createBuilder, Consumer<KlumBuilder<T>> apply) {
         return BreadcrumbCollector.withBreadcrumb(null, null, key,
-                () -> PhaseDriver.withBuilderLifecycle(createBuilder, builder -> postCreate(apply, builder))
+                () -> PhaseDriver.withBuilderLifecycle(createBuilder, builder -> prepareBuilder(builder, false, apply))
         );
-    }
-
-    private static <T> void postCreate(Consumer<KlumBuilder<T>> apply, KlumBuilder<T> builder) {
-        builder.copyFromTemplate();
-        LifecycleHelper.executeLifecycleMethods(builder, PostCreate.class);
-
-        apply.accept(builder);
     }
 
     /**
@@ -319,7 +324,14 @@ public class FactoryHelper extends GroovyObjectSupport {
      * @return The created instance
      */
     public static <T> T create(Class<T> type, Map<String, ?> values, String key, Closure<?> body) {
-        return doCreate(key, () -> createBuilder(type, key), builder -> builder.apply(values, body));
+        return doCreate(key, () -> createBuilder(type, key), builder -> builder.applyOnly(values, body));
+    }
+
+    public static <T> KlumBuilder<T> createAsBuilder(Class<T> type, Map<String, ?> values, String key, Closure<?> body,
+                                                     String operation) {
+        PhaseDriver.requireActiveConstructionSession();
+        return BreadcrumbCollector.withBreadcrumb(DslHelper.shortNameFor(type) + ".AsBuilder." + operation, null, key,
+                () -> prepareNestedBuilder(type, key, false, builder -> builder.applyOnly(values, body)));
     }
 
     /**
@@ -500,6 +512,32 @@ public class FactoryHelper extends GroovyObjectSupport {
         Class<T> effectiveType = deduceClass(type, (String) configMap.get(TYPE_HINT));
         String key = keyFromMap(effectiveType, configMap);
         return doCreate(key, () -> createBuilder(effectiveType, key), builder -> builder.copyFrom(configMap));
+    }
+
+    public static <T> KlumBuilder<T> createFromMapAsBuilder(Class<T> type, Map<String, Object> configMap) {
+        PhaseDriver.requireActiveConstructionSession();
+        Class<T> effectiveType = deduceClass(type, (String) configMap.get(TYPE_HINT));
+        String key = keyFromMap(effectiveType, configMap);
+        return BreadcrumbCollector.withBreadcrumb(DslHelper.shortNameFor(type) + ".AsBuilder.FromMap", null, key,
+                () -> prepareNestedBuilder(effectiveType, key, false, builder -> builder.copyFrom(configMap)));
+    }
+
+    public static <T> KlumBuilder<T> createFromAsBuilder(Class<T> type, Class<? extends Script> scriptType) {
+        PhaseDriver.requireActiveConstructionSession();
+        if (!DelegatingScript.class.isAssignableFrom(scriptType))
+            throw new KlumModelException("Create.AsBuilder.From only accepts DelegatingScript configuration recipes. "
+                    + "A regular Script may materialize a completed DSL Object and cannot join owned composition; "
+                    + "use a DelegatingScript, Create.AsBuilder.With/FromMap, or run the Script as a root with Create.From.");
+
+        String key = DslHelper.isKeyed(type) ? scriptType.getSimpleName() : null;
+        String scriptName = DslHelper.shortNameFor(scriptType);
+        return BreadcrumbCollector.withBreadcrumb(
+                DslHelper.shortNameFor(type) + ".AsBuilder.From", "script", scriptName,
+                () -> prepareNestedBuilder(type, key, false, builder -> {
+                    DelegatingScript script = (DelegatingScript) InvokerHelper.invokeConstructorOf(scriptType, null);
+                    script.setDelegate(builder);
+                    script.run();
+                }));
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
@@ -27,10 +27,10 @@ import com.blackbuild.groovy.configdsl.transform.FieldType;
 import com.blackbuild.groovy.configdsl.transform.NoClosure;
 import com.blackbuild.groovy.configdsl.transform.Owner;
 import com.blackbuild.groovy.configdsl.transform.PostApply;
-import com.blackbuild.groovy.configdsl.transform.PostCreate;
 import com.blackbuild.klum.ast.KlumModelObject;
 import com.blackbuild.klum.ast.KlumRwObject;
 import com.blackbuild.klum.ast.process.BreadcrumbCollector;
+import com.blackbuild.klum.ast.process.ConstructionSession;
 import com.blackbuild.klum.ast.process.DefaultKlumPhase;
 import com.blackbuild.klum.ast.process.KlumPhase;
 import com.blackbuild.klum.ast.process.PhaseDriver;
@@ -89,6 +89,8 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
     private M completedModel;
     private boolean sealed;
     private boolean template;
+    private transient ConstructionSession constructionSession;
+    private transient boolean constructionSessionActive;
 
     private String breadcrumbPath;
     private String modelPath;
@@ -111,6 +113,21 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
 
     protected KlumBuilder(Class<M> modelType) {
         this.modelType = Objects.requireNonNull(modelType);
+    }
+
+    /** Internal hook used by {@link PhaseDriver}; the token remains opaque to clients. */
+    public final void $attachConstructionSession(ConstructionSession session) {
+        Objects.requireNonNull(session);
+        if (constructionSession != null && constructionSession != session)
+            throw crossSessionAdoptionError();
+        constructionSession = session;
+        constructionSessionActive = true;
+    }
+
+    /** Internal hook used by {@link PhaseDriver} when the owning root lifecycle ends. */
+    public final void $completeConstructionSession(ConstructionSession session) {
+        if (constructionSession == session)
+            constructionSessionActive = false;
     }
 
     public final Class<M> getModelType() {
@@ -433,6 +450,8 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
             KlumBuilder<?> builderValue = (KlumBuilder<?>) value;
             if (builderValue.isSealed() && !acceptsCompletedRelationship(schemaField))
                 throw completedRelationshipInputError(schemaField);
+            if (!builderValue.isSealed())
+                assertSameConstructionSession(builderValue);
             return value;
         }
         if (!(value instanceof KlumModelObject))
@@ -452,6 +471,21 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
                 modelType.getName(),
                 schemaField.getName()
         ));
+    }
+
+    private void assertSameConstructionSession(KlumBuilder<?> child) {
+        if (constructionSession == null && child.constructionSession == null)
+            return;
+        assertConstructionSessionActive();
+        child.assertConstructionSessionActive();
+        if (constructionSession != child.constructionSession)
+            throw crossSessionAdoptionError();
+    }
+
+    private static KlumModelException crossSessionAdoptionError() {
+        return new KlumModelException("Cannot adopt a Builder from a different Construction session. "
+                + "Call Create.AsBuilder inside the owning root Builder lifecycle and attach that Builder there; "
+                + "Builders cannot cross root lifecycles.");
     }
 
     private static Collection<Object> newMutableCollectionLike(Collection<?> source) {
@@ -496,8 +530,15 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
     }
 
     private void assertMutable() {
+        assertConstructionSessionActive();
         if (sealed)
             throw new KlumModelException("A sealed Builder cannot be configured");
+    }
+
+    private void assertConstructionSessionActive() {
+        if (constructionSession != null && !constructionSessionActive)
+            throw new KlumModelException("Cannot use a Builder after its Construction session has completed. "
+                    + "Create and attach a fresh child with Create.AsBuilder inside the owning root Builder lifecycle.");
     }
 
     private void applyClosure(Closure<?> body) {
@@ -693,17 +734,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
     }
 
     private KlumBuilder<?> createNewBuilderFromParamsAndClosure(Class<?> type, String key, Map<String, Object> namedParams, Closure<?> body) {
-        KlumBuilder<?> created = FactoryHelper.createBuilder(type, key);
-        if (template)
-            created.markAsTemplate();
-        created.copyFromTemplate();
-        if (template)
-            created.applyOnly(namedParams, body);
-        else {
-            LifecycleHelper.executeLifecycleMethods(created, PostCreate.class);
-            created.apply(namedParams, body);
-        }
-        return created;
+        return FactoryHelper.prepareNestedBuilder(type, key, template, builder -> builder.applyOnly(namedParams, body));
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
@@ -25,6 +25,7 @@ package com.blackbuild.klum.ast.util;
 
 import com.blackbuild.annodocimal.annotations.InlineJavadocs;
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import groovy.lang.Script;
 
 import java.io.File;
@@ -49,6 +50,33 @@ public class KlumFactory<T> {
     protected KlumFactory(Class<T> type) {
         requireDslType(type);
         this.type = FactoryHelper.getTypeOrDefaultType(type);
+    }
+
+    /** Returns the active-session factory used to create owned child Builders. */
+    public BuilderFactory<T, KlumBuilder<T>> getAsBuilder() {
+        return new BuilderFactory<T, KlumBuilder<T>>(type);
+    }
+
+    /** Active-session Builder-producing operations shared by keyed and unkeyed factories. */
+    public static class BuilderFactory<T, B> {
+        protected final Class<T> type;
+
+        protected BuilderFactory(Class<T> type) {
+            this.type = type;
+        }
+
+        public B FromMap(Map<String, Object> configMap) {
+            return asPublicBuilder(FactoryHelper.createFromMapAsBuilder(type, configMap));
+        }
+
+        public B From(Class<? extends Script> configurationScript) {
+            return asPublicBuilder(FactoryHelper.createFromAsBuilder(type, configurationScript));
+        }
+
+        @SuppressWarnings("unchecked")
+        protected final B asPublicBuilder(KlumBuilder<T> builder) {
+            return (B) builder;
+        }
     }
 
     /**
@@ -380,6 +408,11 @@ public class KlumFactory<T> {
             super(requireKeyed(type));
         }
 
+        @Override
+        public KeyedBuilderFactory<T, KlumBuilder<T>> getAsBuilder() {
+            return new KeyedBuilderFactory<T, KlumBuilder<T>>(type);
+        }
+
         /**
          * Creates a new instance of the model by only setting the key, but not applying any configuration (apart from
          * 'postCreate' and 'postApply' methods).
@@ -473,6 +506,11 @@ public class KlumFactory<T> {
             super(DslHelper.requireNotKeyed(type));
         }
 
+        @Override
+        public UnkeyedBuilderFactory<T, KlumBuilder<T>> getAsBuilder() {
+            return new UnkeyedBuilderFactory<T, KlumBuilder<T>>(type);
+        }
+
         /**
          * Convenience methods to allow simply replacing 'X.create' with 'X.Create.With' in scripts, without
          * checking for arguments. This means that empty create calls like 'X.create()' will correctly work afterward.
@@ -544,6 +582,54 @@ public class KlumFactory<T> {
          */
         public T From(String configuration, ClassLoader loader) {
             return FactoryHelper.createFrom(type, null, configuration, loader);
+        }
+    }
+
+    /** Builder-producing operations for keyed model types. */
+    public static final class KeyedBuilderFactory<T, B> extends BuilderFactory<T, B> {
+        private KeyedBuilderFactory(Class<T> type) {
+            super(type);
+        }
+
+        public B One(String key) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, null, key, null, "One"));
+        }
+
+        public B With(Map<String, ?> configMap, String key,
+                      @DelegatesTo(type = "B", strategy = Closure.DELEGATE_ONLY) Closure<?> configuration) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, configMap, key, configuration, "With"));
+        }
+
+        public B With(String key, @DelegatesTo(type = "B", strategy = Closure.DELEGATE_ONLY) Closure<?> configuration) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, null, key, configuration, "With"));
+        }
+
+        public B With(Map<String, ?> configMap, String key) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, configMap, key, null, "With"));
+        }
+    }
+
+    /** Builder-producing operations for unkeyed model types. */
+    public static final class UnkeyedBuilderFactory<T, B> extends BuilderFactory<T, B> {
+        private UnkeyedBuilderFactory(Class<T> type) {
+            super(type);
+        }
+
+        public B One() {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, null, null, null, "One"));
+        }
+
+        public B With(Map<String, ?> configMap,
+                      @DelegatesTo(type = "B", strategy = Closure.DELEGATE_ONLY) Closure<?> configuration) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, configMap, null, configuration, "With"));
+        }
+
+        public B With(@DelegatesTo(type = "B", strategy = Closure.DELEGATE_ONLY) Closure<?> configuration) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, null, null, configuration, "With"));
+        }
+
+        public B With(Map<String, ?> configMap) {
+            return asPublicBuilder(FactoryHelper.createAsBuilder(type, configMap, null, null, "With"));
         }
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -46,6 +46,7 @@ import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.AssertStatement;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
@@ -110,6 +111,9 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     public static final ClassNode KLUM_FACTORY = make(KlumFactory.class);
     public static final ClassNode KEYED_FACTORY = make(KlumFactory.Keyed.class);
     public static final ClassNode UNKEYED_FACTORY = make(KlumFactory.Unkeyed.class);
+    public static final ClassNode BUILDER_FACTORY = make(KlumFactory.BuilderFactory.class);
+    public static final ClassNode KEYED_BUILDER_FACTORY = make(KlumFactory.KeyedBuilderFactory.class);
+    public static final ClassNode UNKEYED_BUILDER_FACTORY = make(KlumFactory.UnkeyedBuilderFactory.class);
     public static final ClassNode KLUM_BUILDER = make(KlumBuilder.class);
     public static final ClassNode MODEL_PROXY = make(KlumModelProxy.class);
     public static final ClassNode EQUALS_HASHCODE_ANNOT = make(EqualsAndHashCode.class);
@@ -1388,6 +1392,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                     ctorSuperS(classX(annotatedClass)));
 
         overrideFactoryMethods(factoryClass, defaultImpl);
+        createAsBuilderFactoryAccessor(defaultImpl);
 
         annotatedClass.getModule().addClass(factoryClass);
 
@@ -1440,6 +1445,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                     .filter(MethodNode::isPublic)
                     .filter(method -> !method.isStatic())
                     .filter(method -> !method.isFinal())
+                    .filter(method -> !method.getName().equals("getAsBuilder"))
                     .map(method -> correctFactoryMethod(currentSpec, method))
                     .forEach(method -> overrideFactoryMethod(factoryClass, defaultImpl, method));
             currentLevel = currentLevel.getUnresolvedSuperClass();
@@ -1478,6 +1484,33 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         String originalDocumentation = ASTExtractor.extractDocumentation(methodNode, null);
         AnnoDocUtil.addDocumentation(override, originalDocumentation);
         factoryClass.addMethod(override);
+    }
+
+    private void createAsBuilderFactoryAccessor(ClassNode defaultImpl) {
+        ClassNode factoryType;
+        if (!isInstantiable(defaultImpl))
+            factoryType = BUILDER_FACTORY;
+        else
+            factoryType = keyField == null ? UNKEYED_BUILDER_FACTORY : KEYED_BUILDER_FACTORY;
+
+        ClassNode specialized = factoryType.getPlainNodeReference();
+        specialized.setUsingGenerics(true);
+        specialized.setGenericsTypes(new GenericsType[] {
+                new GenericsType(defaultImpl.getPlainNodeReference()),
+                new GenericsType(GeneratedDslSupport.of(annotatedClass).getBuilderInterface().getPlainNodeReference())
+        });
+
+        MethodNode accessor = new MethodNode(
+                "getAsBuilder",
+                ACC_PUBLIC | ACC_ABSTRACT,
+                specialized,
+                Parameter.EMPTY_ARRAY,
+                ClassNode.EMPTY_ARRAY,
+                EmptyStatement.INSTANCE
+        );
+        AnnoDocUtil.addDocumentation(accessor,
+                "Returns the active-session factory for creating owned " + annotatedClass.getName() + " Builders.");
+        GeneratedDslSupport.of(annotatedClass).getFactoryInterface().addMethod(accessor);
     }
 
     private void overrideUndelegatedClosureMethod(InnerClassNode factoryClass, ClassNode defaultImpl, MethodNode methodNode) {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AsBuilderSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AsBuilderSpec.groovy
@@ -1,0 +1,419 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import com.blackbuild.klum.ast.process.ConstructionSession
+import com.blackbuild.klum.ast.util.DslHelper
+import com.blackbuild.klum.ast.util.KlumBuilder
+import com.blackbuild.klum.ast.util.KlumModelException
+import com.blackbuild.klum.ast.util.KlumModelProxy
+
+import java.lang.reflect.Modifier
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+class AsBuilderSpec extends AbstractDSLSpec {
+
+    def "AsBuilder child joins the owning root graph"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+        KlumBuilder childBuilder
+
+        when:
+        instance = clazz.Create.With {
+            childBuilder = Child.Create.AsBuilder.With(name: 'owned')
+            ((KlumBuilder) delegate).setSingleField('child', childBuilder)
+        }
+
+        then:
+        instance.child.name == 'owned'
+        childBuilder.completedModel.is(instance.child)
+    }
+
+    def "AsBuilder prepares an owned child exactly once in the active Template scope"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                static int postTreeCalls
+                static int validationCalls
+
+                @Owner Root owner
+                String fromTemplate
+                String configured
+                int postCreateCalls
+                int postApplyCalls
+
+                @PostCreate
+                void initialize() {
+                    postCreateCalls++
+                }
+
+                @PostApply
+                void finishConfiguration() {
+                    postApplyCalls++
+                }
+
+                @PostTree
+                void finishGraph() {
+                    postTreeCalls++
+                }
+
+                @Validate
+                void validateCompletedModel() {
+                    validationCalls++
+                }
+            }
+        '''
+        def Child = getClass('pk.Child')
+        def template = Child.Template.Create(fromTemplate: 'active')
+        def configurationCalls = new AtomicInteger()
+
+        when:
+        Child.Template.With(template) {
+            instance = clazz.Create.With {
+                KlumBuilder child = Child.Create.AsBuilder.With {
+                    configurationCalls.incrementAndGet()
+                    configured 'explicit'
+                }
+                ((KlumBuilder) delegate).setSingleField('child', child)
+            }
+        }
+
+        then:
+        instance.child.fromTemplate == 'active'
+        instance.child.configured == 'explicit'
+        instance.child.postCreateCalls == 1
+        instance.child.postApplyCalls == 1
+        configurationCalls.get() == 1
+        Child.postTreeCalls == 1
+        Child.validationCalls == 1
+        instance.child.owner.is(instance)
+        KlumModelProxy.getProxyFor(instance.child).modelPath == '<root>.child'
+        DslHelper.getBreadcrumbPath(instance.child) == '$/p.Root.With/p.Child.AsBuilder.With'
+    }
+
+    def "AsBuilder rejects calls outside a Construction session"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+
+        when:
+        clazz.Create.AsBuilder.One()
+
+        then:
+        KlumModelException error = thrown()
+        error.message.contains('requires an active Construction session')
+        error.message.contains('inside the owning root Builder lifecycle')
+        error.message.contains('Create.With, Create.One, or Create.From')
+    }
+
+    def "AsBuilder FromMap creates an owned child without a nested lifecycle"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+
+        when:
+        instance = clazz.Create.With {
+            KlumBuilder child = Child.Create.AsBuilder.FromMap(name: 'mapped')
+            ((KlumBuilder) delegate).setSingleField('child', child)
+        }
+
+        then:
+        instance.child.name == 'mapped'
+    }
+
+    def "AsBuilder With and One preserve keyed child configuration"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child configured
+                Child empty
+            }
+
+            @DSL
+            class Child {
+                @Key String id
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+
+        when:
+        instance = clazz.Create.With {
+            KlumBuilder configuredChild = Child.Create.AsBuilder.With([name: 'configured'], 'configured-id')
+            KlumBuilder emptyChild = Child.Create.AsBuilder.One('empty-id')
+            ((KlumBuilder) delegate).setSingleField('configured', configuredChild)
+            ((KlumBuilder) delegate).setSingleField('empty', emptyChild)
+        }
+
+        then:
+        instance.configured.id == 'configured-id'
+        instance.configured.name == 'configured'
+        instance.empty.id == 'empty-id'
+    }
+
+    def "AsBuilder From applies a DelegatingScript to an owned child"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+        def configurationScript = createSecondaryClass '''
+            package pk
+
+            @groovy.transform.BaseScript(DelegatingScript)
+            import groovy.util.DelegatingScript
+
+            name 'scripted'
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            KlumBuilder child = Child.Create.AsBuilder.From(configurationScript)
+            ((KlumBuilder) delegate).setSingleField('child', child)
+        }
+
+        then:
+        instance.child.name == 'scripted'
+    }
+
+    def "AsBuilder result is invalid after its root lifecycle completes"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+        KlumBuilder child
+
+        and:
+        clazz.Create.With {
+            child = Child.Create.AsBuilder.One()
+        }
+
+        when:
+        child.apply(name: 'too late')
+
+        then:
+        KlumModelException error = thrown()
+        error.message.contains('after its Construction session has completed')
+        error.message.contains('Create.AsBuilder inside the owning root Builder lifecycle')
+    }
+
+    def "owned Builders cannot cross Construction sessions"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def Child = getClass('pk.Child')
+        def childFromOtherSession = new AtomicReference<KlumBuilder>()
+        def firstSessionReady = new CountDownLatch(1)
+        def releaseFirstSession = new CountDownLatch(1)
+        def firstSessionFailure = new AtomicReference<Throwable>()
+        Thread firstSession = Thread.start {
+            try {
+                clazz.Create.With {
+                    childFromOtherSession.set(Child.Create.AsBuilder.One())
+                    firstSessionReady.countDown()
+                    releaseFirstSession.await(10, TimeUnit.SECONDS)
+                }
+            } catch (Throwable failure) {
+                firstSessionFailure.set(failure)
+                firstSessionReady.countDown()
+            }
+        }
+        assert firstSessionReady.await(10, TimeUnit.SECONDS)
+
+        when:
+        clazz.Create.With {
+            ((KlumBuilder) delegate).setSingleField('child', childFromOtherSession.get())
+        }
+
+        then:
+        KlumModelException error = thrown()
+        error.message.contains('different Construction session')
+        error.message.contains('Builders cannot cross root lifecycles')
+
+        cleanup:
+        releaseFirstSession.countDown()
+        firstSession?.join(10_000)
+        assert !firstSession?.alive
+        assert firstSessionFailure.get() == null
+    }
+
+    def "AsBuilder rejects ordinary materializing Scripts without running them"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Root {
+            }
+
+            @DSL
+            class Child {
+                String name
+            }
+
+            class MaterializingChildScript extends Script {
+                static boolean ran
+
+                @Override
+                Object run() {
+                    ran = true
+                    return Child.Create.With(name: 'materialized')
+                }
+            }
+        '''
+        def Child = getClass('pk.Child')
+        def MaterializingChildScript = getClass('pk.MaterializingChildScript')
+
+        when:
+        clazz.Create.With {
+            Child.Create.AsBuilder.From(MaterializingChildScript)
+        }
+
+        then:
+        KlumModelException error = thrown()
+        error.message.contains('only accepts DelegatingScript configuration recipes')
+        error.message.contains('cannot join owned composition')
+        error.message.contains('run the Script as a root with Create.From')
+        !MaterializingChildScript.ran
+    }
+
+    def "root factories retain completed-model return behavior"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Child {
+                String name
+            }
+        '''
+        def configurationScript = createSecondaryClass '''
+            package pk
+
+            @groovy.transform.BaseScript(DelegatingScript)
+            import groovy.util.DelegatingScript
+
+            name 'from script'
+        '''
+
+        when:
+        def withResult = clazz.Create.With(name: 'with')
+        def oneResult = clazz.Create.One()
+        def fromResult = clazz.Create.From(configurationScript)
+        def fromMapResult = clazz.Create.FromMap(name: 'from map')
+
+        then:
+        [withResult, oneResult, fromResult, fromMapResult].every {
+            clazz.isInstance(it) && !(it instanceof KlumBuilder)
+        }
+        withResult.name == 'with'
+        fromResult.name == 'from script'
+        fromMapResult.name == 'from map'
+    }
+
+    def "ConstructionSession is only an opaque identity token"() {
+        expect:
+        ConstructionSession.declaredFields.findAll { !it.synthetic }.empty
+        ConstructionSession.declaredMethods.findAll { !it.synthetic }.empty
+        ConstructionSession.declaredConstructors.size() == 1
+        !Modifier.isPublic(ConstructionSession.declaredConstructors.first().modifiers)
+        !KlumBuilder.methods*.name.contains('getConstructionSession')
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/GeneratedDslSupportSpec.groovy
@@ -148,6 +148,41 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         consumer.create().primary.name == 'cluster child'
     }
 
+    def "AsBuilder projects the concrete public Builder return and closure delegate types"() {
+        when:
+        compileJavaConsumer('''
+            package sample;
+
+            import java.util.Map;
+
+            public final class JavaDslConsumer {
+                public static Child_DSL.Builder childBuilder() {
+                    return Child.Create.getAsBuilder().With(Map.of("name", "java child"));
+                }
+            }
+        ''')
+
+        createSecondaryClass('''
+            package sample
+
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticAsBuilderConsumer {
+                static void compileAsBuilderClosure() {
+                    Foo.Create.With {
+                        Child_DSL.Builder child = Child.Create.AsBuilder.With {
+                            name 'groovy child'
+                        }
+                    }
+                }
+            }
+        ''', 'sample/StaticAsBuilderConsumer.groovy')
+
+        then:
+        noExceptionThrown()
+    }
+
     def "AnnoDocimal source mirror matches the bytecode namespace and nested documentation"() {
         given:
         File mirrorRoot = new File(tempFolder.root, 'mirrors')

--- a/wiki/Builder-First-Migration.md
+++ b/wiki/Builder-First-Migration.md
@@ -23,10 +23,20 @@ The closure receivers, child values, mutators, and lifecycle callbacks through `
   `getDSLInstance()` or `getRwInstance()` identity aliases. [ADR 0005](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0005-generated-dsl-support-api.md)
   removes RW vocabulary in favor of the generated `Foo_DSL.Builder` interface and `@DelegatesToBuilder`; implementation is
   tracked by [issue #394](https://github.com/klum-dsl/klum-ast/issues/394).
-- Build all owned children through the parent Builder lifecycle. Do not call `Child.Create.With` from inside a parent construction callback or from a nested converter: that starts a second lifecycle. Use the generated child method on the parent Builder instead.
+- Build all owned children through the parent Builder lifecycle. Do not call `Child.Create.With` from inside a parent construction callback or from a nested converter: that starts a second lifecycle. Use the generated child method on the parent Builder instead. Builder-producing extension paths can use `Child.Create.AsBuilder.With`, `One`, `FromMap`, or `From(DelegatingScript)` while the root lifecycle is active, then attach the returned Builder to its owning relationship in that same session.
 - Pass an existing completed DSL Object only to a `FieldType.LINK` relationship. Completed objects cannot become newly owned composition. Use a Template when an existing object is intended as a reusable recipe; applying it rehydrates fresh Builders.
 
-Standalone root factories still return completed models. A custom factory or converter that creates a completed model remains suitable only where that model is the root result or an aggregation `LINK` target. The `Create.AsBuilder` composition protocol and Builder-producing collection projections are recorded in [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md) and tracked by [issue #431](https://github.com/klum-dsl/klum-ast/issues/431). Until that follow-up is available, collection-local creator methods, direct `DelegatingScript` collection creation, and owned DSL Object converters that call a root factory fail with nested-lifecycle guidance; use generated child closure methods instead.
+Standalone root factories still return completed models. `Create.AsBuilder` is valid only during an active root Construction
+session; using its result after that lifecycle, or adopting it into another root lifecycle, is rejected. Its `From` operation
+accepts `DelegatingScript` recipes but deliberately rejects ordinary Scripts that materialize a completed model. A custom
+factory or converter that creates a completed model therefore remains suitable only where that model is the root result or
+an aggregation `LINK` target.
+
+The remaining Builder-producing collection/Cluster and custom-factory projections are tracked by
+[issue #437](https://github.com/klum-dsl/klum-ast/issues/437). Until those projections are available, collection-local creator
+methods, direct `DelegatingScript` collection creation, and owned DSL Object converters that call a root factory still fail
+with nested-lifecycle guidance; use generated child closure methods instead. The complete protocol is recorded in
+[ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md).
 
 ## Schema and lifecycle changes
 

--- a/wiki/Convenience-Factories.md
+++ b/wiki/Convenience-Factories.md
@@ -38,10 +38,13 @@ For DSL element maps and collections, there is also a convenience method for cre
 from a couple of scripts, each element in a single script. The generated method has the form
 `<fieldName>(Class<? extends Script>...)` for both maps and collections.
 
-The current 4.0 Builder-first implementation rejects these calls during the owning lifecycle. ADR 0004 will restore
-`DelegatingScript` inputs as Builder-producing recipes through `Create.AsBuilder`. A regular Script that returns a completed
-model is an opaque materializing program and remains top-level-only. Until the ADR 0004 follow-up lands, express collection
-composition through generated element closure methods. See
+`Element.Create.AsBuilder.From(MyDelegatingScript)` now applies a `DelegatingScript` recipe to an unsealed Builder in the
+active root Construction session. It is intended for owning relationship machinery and does not start or complete a nested
+lifecycle. A regular Script that returns a completed model is an opaque materializing program and remains top-level-only.
+
+The generated collection/map overloads shown below do not yet route through that primitive and remain rejected during the
+owning lifecycle. Express collection composition through generated element closure methods until the projections tracked by
+[#437](https://github.com/klum-dsl/klum-ast/issues/437) land. See
 [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md).
 
 The intended `DelegatingScript` behavior allows splitting a bigger model into separate files:
@@ -177,6 +180,10 @@ the base type's package. Additionally, the type can be a stripped name as define
 
 Owner and Role fields are not set during the creation, but since FromMap is a regular creator method, objects created
 by it undergo the regular lifecycle phases, including setting of owner, role and default values.
+
+Builder-producing extension paths can use `Create.AsBuilder.FromMap(map)` during an active root Construction session. The
+result must be attached to an owned relationship in that same session; the outer graph performs ownership, materialization,
+and validation.
 
 Special features of libraries such as renamed fields etc. can be simulated by overriding the FromMap method in a custom 
 factory and adjusting the effective map before calling the super method.

--- a/wiki/Factory-Classes.md
+++ b/wiki/Factory-Classes.md
@@ -41,11 +41,13 @@ This allows creating instances of `MyClass` via `MyClass.Create.Baker("Klaus")`.
 When using the collection factory closure methods (as opposed to calling the element methods directly), all creator class methods are available as well. This is a more powerful alternative to the regular
 [Alternatives Syntax](Alternatives-Syntax.md), especially when using abstract classes.
 
-In the current 4.0 Builder-first implementation, model-returning creator methods are still projected but fail when invoked
-inside the owning Builder lifecycle. The intended compatibility behavior is specified by
-[ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md): the local method
-will retain its familiar name while producing an unsealed child Builder through `Create.AsBuilder`. Until that follow-up
-lands, use the generated element closure method instead of a projected creator method.
+The 4.0 Builder-first runtime provides active-session `Create.AsBuilder.With`, `One`, `FromMap`, and
+`From(DelegatingScript)` operations for code that already owns the relationship sink. Model-returning custom creator methods
+are still projected as their root form and therefore fail when invoked inside the owning Builder lifecycle. The generated
+Builder-producing twins and collection/Cluster projections are tracked by
+[#437](https://github.com/klum-dsl/klum-ast/issues/437) and specified by
+[ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md). Until that slice
+lands, use the generated element closure method instead of a projected custom creator method.
 
 
 ```groovy


### PR DESCRIPTION
## Summary

- introduce one opaque `ConstructionSession` identity per root Builder lifecycle and enforce same-session adoption
- add active-session `Create.AsBuilder.With`, `One`, `FromMap`, and `From(DelegatingScript)`
- share child preparation so active Templates and `PostCreate` → configuration → `PostApply` run exactly once
- generate concrete `Foo_DSL.Builder` return and closure-delegate types
- retain completed-model root factories and reject ordinary materializing Scripts
- update ADR implementation status, migration guidance, factory/convenience docs, and `CHANGES.md`

## Why

Builder-first materialization requires every owned child to join the root Builder graph. Calling an ordinary root factory from an active lifecycle either starts a forbidden nested lifecycle or returns a completed model that cannot become owned composition. AB-1 adds the narrow Builder-producing primitive without exposing `PhaseDriver.Context` authority or broadening into projection and Template-protocol work.

## Impact

Builder-producing extension paths can now create one owned child inside the active root lifecycle. Calls outside a session, across sessions, or after lifecycle completion fail with actionable `KlumModelException` guidance. Root `With`/`One`/`From` behavior remains unchanged.

Collection/Cluster projections and hidden twins remain in #437. Template companion/copy-source semantics remain in #438.

## Validation

- focused `AsBuilderSpec` and generated API compilation coverage
- `./gradlew :klum-ast-runtime:check :klum-ast:check`
- Groovy 3, 4, and 5 compatibility lanes
- `./gradlew check`
- `git diff --check`

Closes #436
