### PR TITLE
Add completed object structure support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,10 @@ This is a breaking release. See the [Builder-first construction migration](https
   duplicates, and map keys. Opaque or precompiled model producers are omitted from generated APIs and matching dynamic calls
   fail with targeted migration guidance ([#437](https://github.com/klum-dsl/klum-ast/issues/437),
   [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md)).
+- Added the Java-first `KlumObjectSupport.of(completedObject)` facade for a completed DSL Object root or subtree. Its
+  provenance getters and composition-only `Structure` helper expose paths, direct ownership, relative paths, and
+  cycle-safe typed traversal without exposing the internal Model companion ([#435](https://github.com/klum-dsl/klum-ast/issues/435),
+  [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md)).
 - Template companion, copy-source, and replay semantics remain tracked by
   [#438](https://github.com/klum-dsl/klum-ast/issues/438).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,14 +77,20 @@ These terms are sourced from the project wiki and consolidated here. Use these c
 - Object support
 
   `KlumObjectSupport<T>.of(object)` is the supported Java-first facade for any completed DSL Object or subtree. It exposes
-  the object, construction breadcrumb, structural model path, grouped composition structure traversal, and stored
-  validation results without exposing the internal companion.
+  the object, construction breadcrumb, structural model path, and grouped composition structure traversal without exposing
+  the internal companion. Its Structure helper is composition-only and identity-cycle-safe; it skips Owner and LINK edges.
+  Completed-model phase traversal uses this helper directly, while Builder phases use a separate internal Builder structure
+  helper. The shared internal composition walker owns only traversal mechanics and is not a client extension seam.
+
+  OS-2 adds the stored-validation helper (`getValidation`) and moves remaining completed-model validation readers away from
+  companion access. It must read existing results only: it never reruns validators or mutates lifecycle issue state.
 
 - Construction API
 
   DSL Objects are constructed only by generated Builders and controlled deserialization logic. Generated constructors are internal implementation details and are not a client construction API.
 
-  `KlumInstanceProxy` compatibility is limited to Builders and construction-time operations. Completed DSL Objects use their Model companion or public utilities; asking `KlumInstanceProxy` for a completed DSL Object is an error with migration guidance.
+  `KlumInstanceProxy` compatibility is limited to Builders and construction-time operations. Completed DSL Objects use
+  `KlumObjectSupport`; asking `KlumInstanceProxy` for a completed DSL Object is an error with migration guidance.
 
   Completed DSL Objects do not expose `apply`; configuration is Builder-only.
 

--- a/docs/adr/0006-completed-object-support.md
+++ b/docs/adr/0006-completed-object-support.md
@@ -6,8 +6,10 @@ Status: Accepted
 
 Tracking issue: [#390 — Stable Entry object for internal methods](https://github.com/klum-dsl/klum-ast/issues/390)
 
-Implementation status: Planned. Current utilities and the public-looking `KlumModelProxy.getProxyFor` expose an incomplete
-and overly powerful boundary. See the [implementation plan](../implementation/adr-0006-completed-object-support.md).
+Implementation status: OS-1 provenance and structure support is implemented in [#435](https://github.com/klum-dsl/klum-ast/issues/435).
+OS-2 validation support and companion lockdown, and OS-3 documentation closure, remain planned. Current utilities and the
+public-looking `KlumModelProxy.getProxyFor` still expose an incomplete and overly powerful boundary. See the
+[implementation plan](../implementation/adr-0006-completed-object-support.md).
 
 Parent decision: [ADR 0003 — Builder-first materialization of DSL Objects](0003-builder-first-materialization.md)
 

--- a/docs/implementation/adr-0006-completed-object-support.md
+++ b/docs/implementation/adr-0006-completed-object-support.md
@@ -19,7 +19,7 @@ become an accidental plugin protocol.
 
 ## Tracer-bullet slices
 
-### [OS-1 — Provenance and structure facade](https://github.com/klum-dsl/klum-ast/issues/435)
+### [OS-1 — Provenance and structure facade](https://github.com/klum-dsl/klum-ast/issues/435) — Implemented
 
 Add `KlumObjectSupport.of(object)` with `getObject`, both path getters, and `getStructure`. Implement direct owners, owner
 hierarchy, composition-only cycle-safe visit/find-all, and relative paths. Make existing `StructureUtil` delegate where

--- a/docs/implementation/issue-curation/architecture-map.md
+++ b/docs/implementation/issue-curation/architecture-map.md
@@ -113,7 +113,8 @@ Compiler-version seams are concentrated in `klum-ast`: [`Groovy3To4MigrationHelp
 - [ADR 0004](../../adr/0004-asbuilder-composition-protocol.md) is **Accepted target behavior but not implemented**. The confirmed failure paths and pending tests are indexed in [`adr-0004-asbuilder-composition.md`](../adr-0004-asbuilder-composition.md).
 - [ADR 0005](../../adr/0005-generated-dsl-support-api.md) accepts `Foo_DSL` and Builder vocabulary; only DSL-G's Gradle
   mirror lifecycle is implemented.
-- [ADR 0006](../../adr/0006-completed-object-support.md) accepts `KlumObjectSupport`; it is not implemented.
+- [ADR 0006](../../adr/0006-completed-object-support.md) accepts `KlumObjectSupport`. OS-1 provenance and composition
+  structure support is implemented; OS-2 stored-validation support and companion lockdown remain planned.
 - [ADR 0007](../../adr/0007-jackson-configuration-replay.md) accepts configuration replay; it is not implemented.
 - [ADR 0008](../../adr/0008-phase-registration.md) accepts a later-4.x registration SPI; it is not implemented.
 
@@ -122,8 +123,9 @@ Confirmed deferred gaps, not current capabilities:
 - `Create.AsBuilder`, Builder-producing collection projections, and hidden Builder twins for source converters/custom factories do not exist yet; reasoned `@PendingFeature` tests record the target. Regular opaque scripts returning completed models remain top-level-only.
 - Template recipe state still resides in `KlumModelProxy`; the ADR 0004 `KlumTemplateProxy`/`TemplateRecipeState` split is a target.
 - The ADR 0004 rule rejecting `applyLater` at phase 40 or later is not enforced by the current scheduler.
-- Generated `Foo_DSL` AST layout (#394), completed-object support (#390), and Jackson configuration replay (#428/#251)
-  are decided but not implemented. The DSL-G Gradle mirror lifecycle is implemented independently. Declarative phase
-  registration (#305) is decided and deferred to later 4.x.
+- Generated `Foo_DSL` AST layout (#394) and Jackson configuration replay (#428/#251) are decided but not implemented.
+  Completed-object support (#390) has its OS-1 provenance/structure slice implemented; OS-2 validation and proxy-lockdown
+  work remains. The DSL-G Gradle mirror lifecycle is implemented independently. Declarative phase registration (#305) is
+  decided and deferred to later 4.x.
 
 **Analyst hypothesis:** issue coupling is highest where generated composition projections (`AlternativesClassBuilder`/`ConverterBuilder`) call model-returning factories (`KlumFactory`/`FactoryHelper`) and then cross `KlumBuilder.normalizeRelationshipValue`. Verify that path for each factory/converter issue; do not assume all converter or script inputs share it.

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/BuilderVisitingPhaseAction.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/BuilderVisitingPhaseAction.java
@@ -25,8 +25,8 @@ package com.blackbuild.klum.ast.process;
 
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.TemplateManager;
+import com.blackbuild.klum.ast.util.layer3.BuilderStructureSupport;
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
-import com.blackbuild.klum.ast.util.layer3.StructureUtil;
 import groovy.lang.Closure;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,7 +45,7 @@ public abstract class BuilderVisitingPhaseAction extends AbstractPhaseAction imp
         Object root = PhaseDriver.getInstance().getRootObject();
         if (!(root instanceof KlumBuilder))
             throw new IllegalStateException("Builder phase " + getPhase().getDisplayName() + " received a completed model");
-        StructureUtil.visitBuilders((KlumBuilder<?>) root, this);
+        BuilderStructureSupport.visit((KlumBuilder<?>) root, this);
     }
 
     @Override

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/ModelVisitingPhaseAction.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/ModelVisitingPhaseAction.java
@@ -24,8 +24,8 @@
 package com.blackbuild.klum.ast.process;
 
 import com.blackbuild.klum.ast.KlumModelObject;
+import com.blackbuild.klum.ast.util.KlumObjectSupport;
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
-import com.blackbuild.klum.ast.util.layer3.StructureUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,7 +43,7 @@ public abstract class ModelVisitingPhaseAction extends AbstractPhaseAction imple
         Object root = PhaseDriver.getInstance().getRootObject();
         if (!(root instanceof KlumModelObject))
             throw new IllegalStateException("Model phase " + getPhase().getDisplayName() + " received a Builder");
-        StructureUtil.visit(root, this);
+        KlumObjectSupport.of(root).getStructure().visit(this);
     }
 
     @Override

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/VisitingPhaseAction.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/VisitingPhaseAction.java
@@ -23,8 +23,11 @@
  */
 package com.blackbuild.klum.ast.process;
 
+import com.blackbuild.klum.ast.KlumModelObject;
+import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.KlumObjectSupport;
+import com.blackbuild.klum.ast.util.layer3.BuilderStructureSupport;
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
-import com.blackbuild.klum.ast.util.layer3.StructureUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +53,12 @@ public abstract class VisitingPhaseAction extends AbstractPhaseAction implements
     @Override
     protected void doExecute() {
         Object root = PhaseDriver.getInstance().getRootObject();
-        StructureUtil.visit(root, this);
+        if (root instanceof KlumBuilder<?> builder)
+            BuilderStructureSupport.visit(builder, this);
+        else if (root instanceof KlumModelObject)
+            KlumObjectSupport.of(root).getStructure().visit(this);
+        else
+            throw new IllegalStateException("Visiting phase received an unsupported root object");
     }
 
     @Override

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
 /**
  * Java-first support for a completed DSL Object or one of its completed subtrees.
@@ -185,12 +186,9 @@ public final class KlumObjectSupport<T> {
         public <R> void visit(Class<R> type, BiConsumer<String, R> visitor) {
             Objects.requireNonNull(type, "type");
             Objects.requireNonNull(visitor, "visitor");
-            visit(new ModelVisitor() {
-                @Override
-                public void visit(String path, Object element, Object container, String nameOfFieldInContainer) {
-                    if (type.isInstance(element))
-                        visitor.accept(path, type.cast(element));
-                }
+            visit((path, element, container, nameOfFieldInContainer) -> {
+                if (type.isInstance(element))
+                    visitor.accept(path, type.cast(element));
             });
         }
 
@@ -206,17 +204,14 @@ public final class KlumObjectSupport<T> {
         public <R> Map<String, R> findAll(Class<R> type, String rootPath) {
             Map<String, R> result = new LinkedHashMap<>();
             Objects.requireNonNull(type, "type");
-            visit(new ModelVisitor() {
-                @Override
-                public void visit(String path, Object element, Object container, String nameOfFieldInContainer) {
-                    if (type.isInstance(element))
-                        result.put(path, type.cast(element));
-                }
+            visit((path, element, container, nameOfFieldInContainer) -> {
+                if (type.isInstance(element))
+                    result.put(path, type.cast(element));
             }, rootPath);
             return result;
         }
 
-        private static String createPath(Object child, java.util.function.Predicate<Object> stopCondition, String rootPath) {
+        private static String createPath(Object child, Predicate<Object> stopCondition, String rootPath) {
             List<Object> hierarchy = KlumObjectSupport.of(child).getStructure().getOwnerHierarchy();
             int ancestorIndex;
             if (stopCondition == null) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -1,0 +1,243 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.util;
+
+import com.blackbuild.klum.ast.util.layer3.CompositionTraversal;
+import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
+import com.blackbuild.klum.ast.util.layer3.StructuralPath;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Java-first support for a completed DSL Object or one of its completed subtrees.
+ *
+ * @param <T> the completed DSL Object type
+ */
+public final class KlumObjectSupport<T> {
+
+    private final T object;
+
+    private KlumObjectSupport(T object) {
+        this.object = object;
+    }
+
+    /**
+     * Creates support for a completed DSL Object.
+     *
+     * @param object a completed DSL Object or subtree
+     * @param <T> the completed DSL Object type
+     * @return support for {@code object}
+     * @throws KlumException if {@code object} is not a completed DSL Object
+     */
+    public static <T> KlumObjectSupport<T> of(T object) {
+        if (object == null)
+            throw new KlumException("KlumObjectSupport requires a non-null completed DSL Object");
+        if (object instanceof KlumModelProxy)
+            throw new KlumException("Object of type " + object.getClass().getName() + " is not a completed DSL Object");
+        KlumModelProxy.getProxyFor(object);
+        return new KlumObjectSupport<>(object);
+    }
+
+    /** Returns the completed DSL Object supplied to {@link #of(Object)}. */
+    public T getObject() {
+        return object;
+    }
+
+    /** Returns the construction breadcrumb path of this completed DSL Object. */
+    public String getBreadcrumbPath() {
+        return DslHelper.getBreadcrumbPath(object);
+    }
+
+    /** Returns the structural model path of this completed DSL Object. */
+    public String getModelPath() {
+        return DslHelper.getModelPath(object);
+    }
+
+    /** Returns composition structure support rooted at this completed DSL Object. */
+    public Structure<T> getStructure() {
+        return new Structure<>(object);
+    }
+
+    /**
+     * Structural support rooted at a completed DSL Object.
+     *
+     * @param <T> the root object type
+     */
+    public static final class Structure<T> {
+
+        private final T object;
+
+        private Structure(T object) {
+            this.object = object;
+        }
+
+        /** Returns the non-transitive, non-root owners directly assigned to this object. */
+        public Set<Object> getDirectOwners() {
+            return Collections.unmodifiableSet(new LinkedHashSet<>(KlumModelProxy.getProxyFor(object).getOwners()));
+        }
+
+        /**
+         * Returns this object's sole direct owner, if it has one.
+         *
+         * @throws KlumModelException if this object has more than one distinct direct owner
+         */
+        public Optional<Object> getSingleOwner() {
+            Set<Object> owners = getDirectOwners();
+            if (owners.size() > 1)
+                throw new KlumModelException("Object has more than one distinct owner");
+            return owners.stream().findFirst();
+        }
+
+        /**
+         * Returns the direct-owner hierarchy from this object to its composition root.
+         *
+         * @throws KlumSchemaException if direct owners form a cycle
+         */
+        public List<Object> getOwnerHierarchy() {
+            List<Object> result = new ArrayList<>();
+            Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            Object current = object;
+            while (DslHelper.isDslObject(current)) {
+                if (!seen.add(current))
+                    throw new KlumSchemaException("Object " + current + " has an owner cycle");
+                result.add(current);
+                current = KlumObjectSupport.of(current).getStructure().getSingleOwner().orElse(null);
+            }
+            return List.copyOf(result);
+        }
+
+        /** Returns the nearest owner-hierarchy member of {@code type}, if present. */
+        public <R> Optional<R> getAncestorOfType(Class<R> type) {
+            Objects.requireNonNull(type, "type");
+            return getOwnerHierarchy().stream().filter(type::isInstance).map(type::cast).findFirst();
+        }
+
+        /** Returns the path from this object to the supplied owned descendant. */
+        public String getRelativePath(Object child) {
+            return getRelativePath(child, null);
+        }
+
+        /** Returns the path from this object to the supplied owned descendant, prefixed by {@code rootPath}. */
+        public String getRelativePath(Object child, String rootPath) {
+            return createPath(child, candidate -> candidate == object, rootPath);
+        }
+
+        /** Returns this object's path relative to its composition root. */
+        public String getFullPath() {
+            return getFullPath(null);
+        }
+
+        /** Returns this object's path relative to its composition root, prefixed by {@code rootPath}. */
+        public String getFullPath(String rootPath) {
+            return createPath(object, null, rootPath);
+        }
+
+        /**
+         * Visits this completed-object composition graph using the established four-argument visitor contract.
+         * Owner and {@code LINK} fields are not followed.
+         */
+        public void visit(ModelVisitor visitor) {
+            visit(visitor, "<root>");
+        }
+
+        /**
+         * Visits this completed-object composition graph using the established four-argument visitor contract.
+         * Owner and {@code LINK} fields are not followed.
+         */
+        public void visit(ModelVisitor visitor, String rootPath) {
+            Objects.requireNonNull(visitor, "visitor");
+            CompositionTraversal.visit(object, visitor, rootPath);
+        }
+
+        /** Visits every composed object assignable to {@code type}. */
+        public <R> void visit(Class<R> type, BiConsumer<String, R> visitor) {
+            Objects.requireNonNull(type, "type");
+            Objects.requireNonNull(visitor, "visitor");
+            visit(new ModelVisitor() {
+                @Override
+                public void visit(String path, Object element, Object container, String nameOfFieldInContainer) {
+                    if (type.isInstance(element))
+                        visitor.accept(path, type.cast(element));
+                }
+            });
+        }
+
+        /** Returns every composed object assignable to {@code type}, indexed by its path from this structure root. */
+        public <R> Map<String, R> findAll(Class<R> type) {
+            return findAll(type, "<root>");
+        }
+
+        /**
+         * Returns every composed object assignable to {@code type}, indexed by paths using {@code rootPath}.
+         * This overload supports compatibility adapters that retain an existing path prefix.
+         */
+        public <R> Map<String, R> findAll(Class<R> type, String rootPath) {
+            Map<String, R> result = new LinkedHashMap<>();
+            Objects.requireNonNull(type, "type");
+            visit(new ModelVisitor() {
+                @Override
+                public void visit(String path, Object element, Object container, String nameOfFieldInContainer) {
+                    if (type.isInstance(element))
+                        result.put(path, type.cast(element));
+                }
+            }, rootPath);
+            return result;
+        }
+
+        private static String createPath(Object child, java.util.function.Predicate<Object> stopCondition, String rootPath) {
+            List<Object> hierarchy = KlumObjectSupport.of(child).getStructure().getOwnerHierarchy();
+            int ancestorIndex;
+            if (stopCondition == null) {
+                ancestorIndex = hierarchy.size() - 1;
+            } else {
+                ancestorIndex = -1;
+                for (int i = 0; i < hierarchy.size(); i++) {
+                    if (stopCondition.test(hierarchy.get(i))) {
+                        ancestorIndex = i;
+                        break;
+                    }
+                }
+                if (ancestorIndex == -1)
+                    throw new IllegalArgumentException("Could not find matching ancestor");
+            }
+
+            Deque<String> elements = StructuralPath.hierarchyToPath(hierarchy.subList(0, ancestorIndex + 1));
+            if (rootPath != null)
+                elements.addFirst(rootPath);
+            return String.join(".", elements);
+        }
+
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/OwnerPhase.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/OwnerPhase.java
@@ -29,7 +29,8 @@ import com.blackbuild.groovy.configdsl.transform.Role;
 import com.blackbuild.klum.ast.process.DefaultKlumPhase;
 import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.process.BuilderVisitingPhaseAction;
-import com.blackbuild.klum.ast.util.layer3.StructureUtil;
+import com.blackbuild.klum.ast.util.layer3.BuilderStructureSupport;
+import com.blackbuild.klum.ast.util.layer3.StructuralPath;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -86,7 +87,7 @@ public class OwnerPhase extends BuilderVisitingPhaseAction {
     }
 
     private void setRole(KlumBuilder<?> builder, Object container, Consumer<@NotNull String> action) {
-        StructureUtil.getPathOfFieldContaining(container, builder).ifPresent(action);
+        StructuralPath.getPathOfFieldContaining(container, builder).ifPresent(action);
     }
 
     private void setTransitiveOwners(KlumBuilder<?> builder) {
@@ -134,12 +135,12 @@ public class OwnerPhase extends BuilderVisitingPhaseAction {
     }
 
     private void setSingleTransitiveOwner(KlumBuilder<?> builder, Field field) {
-        StructureUtil.getAncestorOfType(builder, getOwnerType(field))
+        BuilderStructureSupport.getAncestorOfType(builder, getOwnerType(field))
                 .ifPresent(value -> setOwnerFieldValue(builder, value, field));
     }
 
     private void callTransitiveOwnerMethod(KlumBuilder<?> builder, Method method) {
-        StructureUtil.getAncestorOfType(builder, getOwnerType(method))
+        BuilderStructureSupport.getAncestorOfType(builder, getOwnerType(method))
                 .ifPresent(value -> callOwnerMethod(builder, value, method));
     }
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/BuilderStructureSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/BuilderStructureSupport.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.util.layer3;
+
+import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.KlumSchemaException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/** Internal composition support for mutable Builders before materialization. */
+public final class BuilderStructureSupport {
+
+    private BuilderStructureSupport() {
+        // static only
+    }
+
+    public static void visit(KlumBuilder<?> root, ModelVisitor visitor) {
+        visit(root, visitor, "<root>");
+    }
+
+    public static void visit(KlumBuilder<?> root, ModelVisitor visitor, String rootPath) {
+        CompositionTraversal.visit(root, visitor, rootPath);
+    }
+
+    public static List<Object> getOwnerHierarchy(KlumBuilder<?> leaf) {
+        List<Object> result = new ArrayList<>();
+        Set<Object> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        Object current = leaf;
+        while (current instanceof KlumBuilder<?>) {
+            if (!seen.add(current))
+                throw new KlumSchemaException("Object " + current + " has an owner cycle");
+            result.add(current);
+            current = ((KlumBuilder<?>) current).getSingleOwner();
+        }
+        return List.copyOf(result);
+    }
+
+    public static <T> Optional<T> getAncestorOfType(KlumBuilder<?> child, Class<T> type) {
+        return getOwnerHierarchy(child).stream().filter(type::isInstance).map(type::cast).findFirst();
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/CompositionTraversal.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/CompositionTraversal.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.util.layer3;
+
+import com.blackbuild.klum.ast.util.DslHelper;
+import com.blackbuild.klum.ast.util.KlumException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** Internal identity-cycle-safe traversal of composition fields. */
+public final class CompositionTraversal {
+
+    private CompositionTraversal() {
+        // static only
+    }
+
+    public static void visit(Object root, ModelVisitor visitor, String rootPath) {
+        doVisit(root, visitor, Collections.newSetFromMap(new IdentityHashMap<>()), rootPath, null, null);
+    }
+
+    static Map<String, Object> getCompositionProperties(Object container) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Class<?> type = container.getClass(); type != null; type = type.getSuperclass()) {
+            for (Field field : type.getDeclaredFields()) {
+                if (field.getName().contains("$") || Modifier.isStatic(field.getModifiers()) || field.isSynthetic()
+                        || DslHelper.isOwner(field) || DslHelper.isLink(field))
+                    continue;
+                result.put(field.getName(), DslHelper.getFieldValue(container, field.getName()));
+            }
+        }
+        return result;
+    }
+
+    private static void doVisit(Object element, ModelVisitor visitor, Set<Object> alreadyVisited, String path,
+                                Object container, String nameOfFieldInContainer) {
+        if (element == null)
+            return;
+        if (element instanceof Collection<?> collection) {
+            int index = 0;
+            for (Object member : collection)
+                doVisit(member, visitor, alreadyVisited, path + "[" + index++ + "]", container, nameOfFieldInContainer);
+            return;
+        }
+        if (element instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> entry : map.entrySet())
+                doVisit(entry.getValue(), visitor, alreadyVisited, path + "." + StructuralPath.toGPath(entry.getKey()), container, nameOfFieldInContainer);
+            return;
+        }
+
+        ModelVisitor.Action action = visitor.shouldVisit(path, element, container, nameOfFieldInContainer);
+        if (action == ModelVisitor.Action.SKIP || !alreadyVisited.add(element))
+            return;
+        try {
+            visitor.visit(path, element, container, nameOfFieldInContainer);
+        } catch (KlumVisitorException exception) {
+            throw exception;
+        } catch (KlumException exception) {
+            throw new KlumVisitorException("Error visiting " + path + ": " + exception.getMessage(), element, exception);
+        } catch (Exception exception) {
+            throw new KlumVisitorException("Error visiting " + path, element, exception);
+        }
+        if (action == ModelVisitor.Action.SKIP_SUBTREE)
+            return;
+        getCompositionProperties(element).forEach((name, value) ->
+                doVisit(value, visitor, alreadyVisited, path + "." + name, element, name));
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/LinkHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/LinkHelper.java
@@ -154,7 +154,7 @@ public class LinkHelper {
         if (linkTo.provider() != NoClosure.class)
             return ClosureHelper.invokeClosureWithDelegateAsArgument(linkTo.provider(), builder);
         if (linkTo.providerType() != Object.class)
-            return StructureUtil.getOwnerHierarchy(builder).stream()
+            return BuilderStructureSupport.getOwnerHierarchy(builder).stream()
                     .filter(KlumBuilder.class::isInstance)
                     .map(KlumBuilder.class::cast)
                     .filter(candidate -> linkTo.providerType().isAssignableFrom(candidate.getModelType()))
@@ -180,7 +180,7 @@ public class LinkHelper {
 
         if (owner == providerObject) return null;
 
-        return StructureUtil.getPathOfSingleField(owner, builder)
+        return StructuralPath.getPathOfSingleField(owner, builder)
                 .map(it -> it + linkTo.nameSuffix())
                 .map(it -> getMetaPropertyOrMapKey(providerObject, it))
                 .orElse(null);

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructuralPath.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructuralPath.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.util.layer3;
+
+import groovy.lang.PropertyValue;
+import groovy.lang.Tuple2;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.runtime.StringGroovyMethods;
+import org.codehaus.groovy.tools.Utilities;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Internal GPath-compatible structural path operations shared by state-specific structure modules. */
+public final class StructuralPath {
+
+    private StructuralPath() {
+        // static only
+    }
+
+    public static String toDefaultFieldName(Class<?> type) {
+        return StringGroovyMethods.uncapitalize(type.getSimpleName());
+    }
+
+    public static String toGPath(Object value) {
+        String text = value.toString();
+        return Utilities.isJavaIdentifier(text) ? text : InvokerHelper.inspect(text);
+    }
+
+    public static Optional<String> getPathOfFieldContaining(Object container, @NotNull Object child) {
+        Optional<String> singleValuePath = getPathOfSingleField(container, child);
+        if (singleValuePath.isPresent())
+            return singleValuePath;
+
+        Optional<String> collectionPath = getPathOfCollectionMember(container, child);
+        if (collectionPath.isPresent())
+            return collectionPath;
+
+        return getPathOfMapMember(container, child);
+    }
+
+    public static Optional<String> getPathOfMapMember(Object container, @NotNull Object child) {
+        //noinspection unchecked
+        return ClusterModel.getPropertiesStream(container, Map.class)
+                .filter(it -> ClusterModel.isMapOf(container, it, child.getClass()))
+                .map(it -> new Tuple2<Object, Optional<String>>(it.getName(), findKeyForValue((Map<String, Object>) it.getValue(), child)))
+                .filter(it -> it.getSecond().isPresent())
+                .map(it -> toGPath(it.getFirst()) + "." + toGPath(it.getSecond().get()))
+                .findFirst();
+    }
+
+    public static Optional<String> getPathOfCollectionMember(Object container, @NotNull Object child) {
+        return ClusterModel.getPropertiesStream(container, Collection.class)
+                .filter(it -> ClusterModel.isCollectionOf(container, it, child.getClass()))
+                .map(it -> new Tuple2<>(it.getName(), getIndexInCollection((Collection<?>) it.getValue(), child)))
+                .filter(it -> it.getSecond() != -1)
+                .map(it -> toGPath(it.getFirst()) + "[" + it.getSecond() + "]")
+                .findFirst();
+    }
+
+    public static Optional<String> getPathOfSingleField(Object container, @NotNull Object child) {
+        return ClusterModel.getPropertiesStream(container, Object.class)
+                .filter(it -> it.getValue() == child)
+                .map(PropertyValue::getName)
+                .map(StructuralPath::toGPath)
+                .findFirst();
+    }
+
+    public static Deque<String> hierarchyToPath(List<Object> hierarchy) {
+        Deque<String> result = new ArrayDeque<>();
+        for (int i = hierarchy.size() - 1; i > 0; i--) {
+            Object owner = hierarchy.get(i);
+            Object child = hierarchy.get(i - 1);
+            String path = getPathOfFieldContaining(owner, child)
+                    .orElseThrow(() -> new IllegalStateException("Object " + owner + " does not contain " + child));
+            result.add(path);
+        }
+        return result;
+    }
+
+    static int getIndexInCollection(Collection<?> container, Object child) {
+        if (container instanceof List<?> list)
+            return list.indexOf(child);
+
+        int index = 0;
+        for (Object element : container) {
+            if (element == child)
+                return index;
+            index++;
+        }
+        return -1;
+    }
+
+    static <K, V> Optional<K> findKeyForValue(Map<K, V> map, @NotNull V value) {
+        return map.entrySet().stream()
+                .filter(it -> it.getValue() == value)
+                .map(Map.Entry::getKey)
+                .findFirst();
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructureUtil.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructureUtil.java
@@ -23,32 +23,27 @@
  */
 package com.blackbuild.klum.ast.util.layer3;
 
-import com.blackbuild.klum.ast.util.DslHelper;
 import com.blackbuild.klum.ast.util.KlumException;
 import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.KlumObjectSupport;
 import com.blackbuild.klum.ast.util.KlumModelProxy;
 import com.blackbuild.klum.ast.util.KlumSchemaException;
-import groovy.lang.PropertyValue;
-import groovy.lang.Tuple2;
-import org.codehaus.groovy.runtime.InvokerHelper;
-import org.codehaus.groovy.runtime.StringGroovyMethods;
-import org.codehaus.groovy.tools.Utilities;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Modifier;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static com.blackbuild.klum.ast.util.DslHelper.isDslObject;
-import static java.util.function.Predicate.not;
 
 /**
- * Utility class for working with data structures. Provides methods to iterate through data structures and find
- * specific ancestors or GPath expressions.
+ * Legacy static compatibility adapter for structure traversal and paths.
+ *
+ * @deprecated since 4.0; use {@code KlumObjectSupport.of(completedObject).getStructure()} for completed DSL Objects.
  */
+@Deprecated(since = "4.0", forRemoval = false)
+@SuppressWarnings("java:S1133") // retained as a source-compatible adapter during the completed-object migration
 public class StructureUtil {
 
     private StructureUtil() {
@@ -63,7 +58,7 @@ public class StructureUtil {
      * @return the uncapitalized named of the class.
      */
     public static String toDefaultFieldName(Class<?> type) {
-        return StringGroovyMethods.uncapitalize(type.getSimpleName());
+        return StructuralPath.toDefaultFieldName(type);
     }
 
     /**
@@ -90,7 +85,15 @@ public class StructureUtil {
      * @param visitor The visitor to invoke for each element
      */
     public static void visit(Object root, ModelVisitor visitor) {
-        visit(root, visitor, "<root>");
+        if (isCompletedDslObject(root)) {
+            KlumObjectSupport.of(root).getStructure().visit(visitor);
+            return;
+        }
+        if (root instanceof KlumBuilder<?> builder) {
+            BuilderStructureSupport.visit(builder, visitor);
+            return;
+        }
+        CompositionTraversal.visit(root, visitor, "<root>");
     }
 
     /**
@@ -98,7 +101,7 @@ public class StructureUtil {
      * Sealed wrappers are filtered by {@code BuilderVisitingPhaseAction}.
      */
     public static void visitBuilders(KlumBuilder<?> root, ModelVisitor visitor) {
-        visit(root, visitor, "<root>");
+        BuilderStructureSupport.visit(root, visitor);
     }
 
     /**
@@ -109,45 +112,15 @@ public class StructureUtil {
      * @param path The path representation of the root element.
      */
     public static void visit(Object root, ModelVisitor visitor, String path) {
-        doVisit(root, visitor, new ArrayList<>(), path, null, null);
-    }
-
-    private static void doVisit(Object element, ModelVisitor visitor, List<Object> alreadyVisited, String path, Object container, String nameOfFieldInContainer) {
-        if (element == null) return;
-        if (element instanceof Collection)
-            doVisitCollection((Collection<?>) element, visitor, alreadyVisited, path, container, nameOfFieldInContainer);
-        else if (element instanceof Map)
-            doVisitMap((Map<?, ?>) element, visitor, alreadyVisited, path, container, nameOfFieldInContainer);
-        else
-            doVisitObject(element, visitor, alreadyVisited, path, container, nameOfFieldInContainer);
-    }
-
-    private static void doVisitObject(Object element, ModelVisitor visitor, List<Object> alreadyVisited, String path, Object container, String nameOfFieldInContainer) {
-        ModelVisitor.Action action = visitor.shouldVisit(path, element, container, nameOfFieldInContainer);
-        if (action == ModelVisitor.Action.SKIP) return;
-        if (alreadyVisited.stream().anyMatch(v -> v == element)) return;
-        try {
-            visitor.visit(path, element, container, nameOfFieldInContainer);
-        } catch (KlumVisitorException e) {
-            throw e;
-        } catch (KlumException e) {
-            throw new KlumVisitorException("Error visiting " + path + ": " + e.getMessage(), element, e);
-        } catch (Exception e) {
-            throw new KlumVisitorException("Error visiting " + path, element, e);
+        if (isCompletedDslObject(root)) {
+            KlumObjectSupport.of(root).getStructure().visit(visitor, path);
+            return;
         }
-        alreadyVisited.add(element);
-
-        if (action == ModelVisitor.Action.SKIP_SUBTREE) return;
-        getNonIgnoredProperties(element).forEach((name, value) -> doVisit(value, visitor, alreadyVisited, path + "." + name, element, name));
-    }
-
-    private static void doVisitMap(Map<?, ?> map, ModelVisitor visitor, List<Object> alreadyVisited, String path, Object container, String nameOfFieldInContainer) {
-        map.forEach((key, value) -> doVisit(value, visitor, alreadyVisited,path + "." + toGPath(key), container, nameOfFieldInContainer));
-    }
-
-    private static void doVisitCollection(Collection<?> collection, ModelVisitor visitor, List<Object> alreadyVisited, String path, Object container, String nameOfFieldInContainer) {
-        AtomicInteger index = new AtomicInteger();
-        collection.forEach(member -> doVisit(member, visitor, alreadyVisited, path + "[" + index.getAndIncrement() + "]", container, nameOfFieldInContainer));
+        if (root instanceof KlumBuilder<?> builder) {
+            BuilderStructureSupport.visit(builder, visitor, path);
+            return;
+        }
+        CompositionTraversal.visit(root, visitor, path);
     }
 
     /**
@@ -183,38 +156,15 @@ public class StructureUtil {
      * @return a map of strings to objects
      */
     public static <T> Map<String, T> deepFind(Object container, Class<T> type, List<Class<?>> ignoredTypes, String path) {
+        if (isCompletedDslObject(container) && ignoredTypes.isEmpty())
+            return KlumObjectSupport.of(container).getStructure().findAll(type, path);
         DeepFindVisitor<T> visitor = new DeepFindVisitor<>(type, ignoredTypes);
         visit(container, visitor, path);
         return visitor.result;
     }
 
     static String toGPath(Object value) {
-        String text = value.toString();
-        return Utilities.isJavaIdentifier(text) ? text : InvokerHelper.inspect(text);
-    }
-
-    static Map<String, Object> getNonIgnoredProperties(Object container) {
-        Map<String, Object> result = new HashMap<>();
-        Class<?> type = container.getClass();
-
-        while (type != null) {
-            addNonIgnoredProperties(container, type, result);
-            type = type.getSuperclass();
-        }
-
-        return result;
-    }
-
-    private static void addNonIgnoredProperties(Object container, Class<?> type, Map<String, Object> result) {
-        Arrays.stream(type.getDeclaredFields())
-                .filter(it -> !it.getName().contains("$"))
-                .filter(it -> !Modifier.isStatic(it.getModifiers()))
-                .filter(it -> !it.isSynthetic())
-                .filter(not(DslHelper::isOwner))
-                .filter(not(DslHelper::isLink))
-                .forEach(it -> result.put(
-                        it.getName(),
-                        DslHelper.getFieldValue(container,it.getName())));
+        return StructuralPath.toGPath(value);
     }
 
     /**
@@ -226,63 +176,30 @@ public class StructureUtil {
      * @return The name of the field containing the child object, or an empty Optional if the object is not contained in a field.
      */
     public static Optional<String> getPathOfFieldContaining(Object container, @NotNull Object child) {
-        Optional<String> singleValuePath = getPathOfSingleField(container, child);
-        if (singleValuePath.isPresent()) return singleValuePath;
-
-        Optional<String> collectionPath = getPathOfCollectionMember(container, child);
-        if (collectionPath.isPresent()) return collectionPath;
-
-        return getPathOfMapMember(container, child);
+        return StructuralPath.getPathOfFieldContaining(container, child);
     }
 
     @NotNull
     static Optional<String> getPathOfMapMember(Object container, @NotNull Object child) {
-        //noinspection unchecked
-        return ClusterModel.getPropertiesStream(container, Map.class)
-                .filter(it -> ClusterModel.isMapOf(container, it, child.getClass()))
-                .map(it -> new Tuple2<Object, Optional<String>>(it.getName(), findKeyForValue((Map<String, Object>) it.getValue(), child)))
-                .filter(it -> it.getSecond().isPresent())
-                .map(it -> toGPath(it.getFirst()) + "." + toGPath(it.getSecond().get()))
-                .findFirst();
+        return StructuralPath.getPathOfMapMember(container, child);
     }
 
     @NotNull
     static Optional<String> getPathOfCollectionMember(Object container, @NotNull Object child) {
-        return ClusterModel.getPropertiesStream(container, Collection.class)
-                .filter(it -> ClusterModel.isCollectionOf(container, it, child.getClass()))
-                .map(it -> new Tuple2<>(it.getName(), getIndexInCollection((Collection<?>) it.getValue(), child)))
-                .filter(it -> it.getSecond() != -1)
-                .map(it -> toGPath(it.getFirst()) + "[" + it.getSecond() + "]")
-                .findFirst();
+        return StructuralPath.getPathOfCollectionMember(container, child);
     }
 
     @NotNull
     static Optional<String> getPathOfSingleField(Object container, @NotNull Object child) {
-        return ClusterModel.getPropertiesStream(container, Object.class)
-                .filter(it -> it.getValue() == child)
-                .map(PropertyValue::getName)
-                .map(StructureUtil::toGPath)
-                .findFirst();
+        return StructuralPath.getPathOfSingleField(container, child);
     }
 
     static int getIndexInCollection(Collection<?> container, Object child) {
-        if (container instanceof List)
-            return ((List<?>) container).indexOf(child);
-
-        int index = 0;
-        for (Object element: container) {
-            if (element == child)
-                return index;
-            index++;
-        }
-        return -1;
+        return StructuralPath.getIndexInCollection(container, child);
     }
 
     static <K, V> Optional<K> findKeyForValue(Map<K, V> map, @NotNull V value) {
-        return map.entrySet().stream()
-                .filter(it -> it.getValue() == value)
-                .map(Map.Entry::getKey)
-                .findFirst();
+        return StructuralPath.findKeyForValue(map, value);
     }
 
     /**
@@ -307,6 +224,8 @@ public class StructureUtil {
      * @return The full path of the object.
      */
     public static @NotNull String getFullPath(@NotNull Object leaf, @Nullable String rootPath) {
+        if (isCompletedDslObject(leaf))
+            return KlumObjectSupport.of(leaf).getStructure().getFullPath(rootPath);
         return createPath(leaf, null, rootPath);
     }
 
@@ -354,6 +273,8 @@ public class StructureUtil {
      * @return The path from the container to the child object
      */
     public static String getRelativePath(Object container, Object child, String rootPath) {
+        if (isCompletedDslObject(container) && isCompletedDslObject(child))
+            return KlumObjectSupport.of(container).getStructure().getRelativePath(child, rootPath);
         return createPath(child, container::equals, rootPath);
     }
 
@@ -379,6 +300,11 @@ public class StructureUtil {
      * @return The path from the container to the child object
      */
     public static String getRelativePath(Class<?> containerType, Object child, String rootPath) {
+        if (isCompletedDslObject(child)) {
+            Object container = KlumObjectSupport.of(child).getStructure().getAncestorOfType(containerType)
+                    .orElseThrow(() -> new IllegalArgumentException("Could not find matching ancestor"));
+            return KlumObjectSupport.of(container).getStructure().getRelativePath(child, rootPath);
+        }
         return createPath(child, containerType::isInstance, rootPath);
     }
 
@@ -391,6 +317,8 @@ public class StructureUtil {
      * @param <T> The type of ancestor to be found
      */
     public static <T> Optional<T> getAncestorOfType(Object child, Class<T> type) {
+        if (isCompletedDslObject(child))
+            return KlumObjectSupport.of(child).getStructure().getAncestorOfType(type);
         //noinspection unchecked
         return (Optional<T>) getOwnerHierarchy(child).stream()
                 .filter(type::isInstance)
@@ -398,14 +326,7 @@ public class StructureUtil {
     }
 
     public static Deque<String> hierarchyToPath(List<Object> hierarchy) {
-        Deque<String> result = new ArrayDeque<>();
-        for (int i = hierarchy.size() - 1;  i > 0; i--) {
-            Object owner = hierarchy.get(i);
-            Object child = hierarchy.get(i - 1);
-            String path = getPathOfFieldContaining(owner, child).orElseThrow(() -> new IllegalStateException("Object " + owner + " does not contain " + child));
-            result.add(path);
-        }
-        return result;
+        return StructuralPath.hierarchyToPath(hierarchy);
     }
 
     /**
@@ -415,6 +336,10 @@ public class StructureUtil {
      * @return The owner hierarchy of the leaf object
      */
     public static List<Object> getOwnerHierarchy(Object leaf) {
+        if (isCompletedDslObject(leaf))
+            return KlumObjectSupport.of(leaf).getStructure().getOwnerHierarchy();
+        if (leaf instanceof KlumBuilder<?> builder)
+            return BuilderStructureSupport.getOwnerHierarchy(builder);
         List<Object> result = new ArrayList<>();
         while (leaf instanceof KlumBuilder || isDslObject(leaf)) {
             if (result.contains(leaf))
@@ -427,6 +352,17 @@ public class StructureUtil {
         }
         return result;
      }
+
+    private static boolean isCompletedDslObject(Object value) {
+        if (!isDslObject(value))
+            return false;
+        try {
+            KlumModelProxy.getProxyFor(value);
+            return true;
+        } catch (KlumException ignored) {
+            return false;
+        }
+    }
 
     private static class DeepFindVisitor<T> implements ModelVisitor {
         private final List<Class<?>> ignoredTypes;

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -27,7 +27,6 @@ import com.blackbuild.groovy.configdsl.transform.Validate;
 import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.util.*;
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
-import com.blackbuild.klum.ast.util.layer3.StructureUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,7 +55,7 @@ public class Validator {
      */
     public static List<KlumValidationResult> getValidationResultsFromStructure(Object instance) {
         ValidationResultCollector visitor = new ValidationResultCollector();
-        StructureUtil.visit(instance, visitor);
+        KlumObjectSupport.of(instance).getStructure().visit(visitor);
         return visitor.aggregatedErrors;
     }
 
@@ -82,7 +81,7 @@ public class Validator {
      */
     public static List<KlumValidationResult> verifyStructure(Object instance, Validate.Level failLevel) throws KlumValidationException {
         ValidationResultCollector visitor = new ValidationResultCollector();
-        StructureUtil.visit(instance, visitor);
+        KlumObjectSupport.of(instance).getStructure().visit(visitor);
         KlumValidationResult.throwOn(visitor.aggregatedErrors, failLevel);
         return visitor.aggregatedErrors;
     }

--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/layer3/StructureUtilTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/layer3/StructureUtilTest.groovy
@@ -24,6 +24,7 @@
 package com.blackbuild.klum.ast.util.layer3
 
 import com.blackbuild.klum.ast.util.AbstractRuntimeTest
+import com.blackbuild.klum.ast.util.layer3.ModelVisitor.Action
 import org.jetbrains.annotations.NotNull
 import spock.lang.Issue
 
@@ -182,6 +183,37 @@ import com.blackbuild.klum.ast.KlumModelObject
         then:
         visitor.visited.size() == 1
         visitor.visited[0].is(container.child)
+    }
+
+    def "composition traversal is identity-cycle-safe independently of its state adapter"() {
+        given:
+        createClass '''
+            class Node {
+                Node child
+            }
+        '''
+        def root = newInstanceOf("Node")
+        def child = newInstanceOf("Node")
+        root.child = child
+        child.child = root
+        def paths = []
+        def visitor = new ModelVisitor() {
+            @Override
+            Action shouldVisit(@NotNull String path, @NotNull Object element, Object container, String nameOfFieldInContainer) {
+                return Action.HANDLE
+            }
+
+            @Override
+            void visit(@NotNull String path, @NotNull Object element, Object container, String nameOfFieldInContainer) {
+                paths << path
+            }
+        }
+
+        when:
+        CompositionTraversal.visit(root, visitor, '<root>')
+
+        then:
+        paths == ['<root>', '<root>.child']
     }
     
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -1,0 +1,259 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumObjectSupport
+import com.blackbuild.klum.ast.util.KlumException
+import com.blackbuild.klum.ast.util.layer3.ModelVisitor
+import com.blackbuild.klum.ast.util.layer3.StructureUtil
+import org.jetbrains.annotations.NotNull
+
+import javax.tools.ToolProvider
+import java.lang.reflect.Modifier
+
+class KlumObjectSupportSpec extends AbstractDSLSpec {
+
+    def "Java callers use explicit completed-object getters for a root and subtree without proxy access"() {
+        given:
+        createClass '''
+            import com.blackbuild.groovy.configdsl.transform.Owner
+
+            @DSL class Root {
+                Child child
+            }
+
+            @DSL class Child {
+                @Owner Root root
+            }
+        '''
+
+        when:
+        instance = Root.Create.With {
+            child {}
+        }
+        def rootSupport = KlumObjectSupport.of(instance)
+        def childSupport = KlumObjectSupport.of(instance.child)
+        compileJavaConsumer('''
+            import com.blackbuild.klum.ast.util.KlumObjectSupport;
+
+            public final class JavaObjectSupportConsumer {
+                public static void inspect(Root root, Child child) {
+                    KlumObjectSupport<Root> rootSupport = KlumObjectSupport.of(root);
+                    Root supportedRoot = rootSupport.getObject();
+                    String rootBreadcrumb = rootSupport.getBreadcrumbPath();
+                    String rootModelPath = rootSupport.getModelPath();
+                    KlumObjectSupport.Structure<Child> structure = KlumObjectSupport.of(child).getStructure();
+                }
+            }
+        ''')
+
+        then:
+        rootSupport.getObject().is(instance)
+        childSupport.getObject().is(instance.child)
+        rootSupport.getBreadcrumbPath() == '$/Root.With'
+        childSupport.getBreadcrumbPath() == '$/Root.With/child'
+        rootSupport.getModelPath() == '<root>'
+        childSupport.getModelPath() == '<root>.child'
+        rootSupport.getBreadcrumbPath() != rootSupport.getModelPath()
+        childSupport.getBreadcrumbPath() != childSupport.getModelPath()
+        rootSupport.structure.directOwners.empty
+        rootSupport.structure.singleOwner.empty
+
+        and: "the public facade stores and exposes only its completed-object target"
+        KlumObjectSupport.declaredFields*.type.every { it != KlumModelProxy }
+        KlumObjectSupport.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != KlumModelProxy : true }
+        KlumObjectSupport.Structure.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != KlumModelProxy : true }
+        !Serializable.isAssignableFrom(KlumObjectSupport)
+
+        when: 'the target is not a completed DSL Object'
+        KlumObjectSupport.of(new Object())
+
+        then:
+        def error = thrown(KlumException)
+        error.message.contains('not a completed DSL Object')
+
+        when: 'the internal companion itself is supplied'
+        KlumObjectSupport.of(KlumModelProxy.getProxyFor(instance))
+
+        then:
+        def companionError = thrown(KlumException)
+        companionError.message.contains('not a completed DSL Object')
+    }
+
+    def "structure support exposes composition owners, relative paths, and typed traversal"() {
+        given:
+        createClass '''
+            import com.blackbuild.groovy.configdsl.transform.FieldType
+            import com.blackbuild.groovy.configdsl.transform.Owner
+
+            @DSL class Root {
+                Child primary
+                List<Child> children
+                Map<String, Child> childrenByName
+                @Field(FieldType.LINK) Child linked
+            }
+
+            @DSL class Child {
+                @Key String name
+                @Owner Root root
+                Child loop
+            }
+        '''
+        def existingLink = Child.Create.With('external') {}
+
+        when:
+        instance = Root.Create.With {
+            primary('primary') {}
+            children {
+                child('first') {}
+                child('second') {}
+            }
+            childrenByName('map-key') {}
+            linked existingLink
+        }
+        def support = KlumObjectSupport.of(instance)
+        def primarySupport = KlumObjectSupport.of(instance.primary)
+        def visited = [:]
+        support.structure.visit(new ModelVisitor() {
+            @Override
+            void visit(@NotNull String path, @NotNull Object element, Object container, String nameOfFieldInContainer) {
+                visited[path] = element
+            }
+        })
+        def typedPaths = []
+        support.structure.visit(Child) { path, child -> typedPaths << path }
+        compileJavaConsumer('''
+            import com.blackbuild.klum.ast.util.KlumObjectSupport;
+            import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
+            import java.util.List;
+            import java.util.Map;
+            import java.util.Optional;
+            import java.util.Set;
+            import java.util.function.BiConsumer;
+
+            public final class JavaObjectSupportConsumer {
+                public static void inspect(Root root, Child child) {
+                    KlumObjectSupport.Structure<Root> structure = KlumObjectSupport.of(root).getStructure();
+                    Set<Object> owners = KlumObjectSupport.of(child).getStructure().getDirectOwners();
+                    Optional<Object> owner = KlumObjectSupport.of(child).getStructure().getSingleOwner();
+                    List<Object> hierarchy = KlumObjectSupport.of(child).getStructure().getOwnerHierarchy();
+                    Optional<Root> ancestor = KlumObjectSupport.of(child).getStructure().getAncestorOfType(Root.class);
+                    String relativePath = structure.getRelativePath(child);
+                    structure.visit(new ModelVisitor() {
+                        @Override
+                        public void visit(String path, Object element, Object container, String field) { }
+                    });
+                    structure.visit(Child.class, (String path, Child value) -> { });
+                    Map<String, Child> children = structure.findAll(Child.class);
+                }
+            }
+        ''')
+
+        then:
+        primarySupport.structure.directOwners == [instance] as Set
+        primarySupport.structure.singleOwner.get().is(instance)
+        primarySupport.structure.ownerHierarchy == [instance.primary, instance]
+        primarySupport.structure.getAncestorOfType(instance.class).get().is(instance)
+        support.structure.getRelativePath(instance.primary) == 'primary'
+        support.structure.getRelativePath(instance.children[1]) == 'children[1]'
+        support.structure.getRelativePath(instance.childrenByName['map-key']) == "childrenByName.'map-key'"
+        primarySupport.structure.fullPath == 'primary'
+        primarySupport.structure.getFullPath('<root>') == '<root>.primary'
+        visited == [
+                '<root>': instance,
+                '<root>.primary': instance.primary,
+                '<root>.children[0]': instance.children[0],
+                '<root>.children[1]': instance.children[1],
+                "<root>.childrenByName.'map-key'": instance.childrenByName['map-key'],
+        ]
+        typedPaths == ['<root>.primary', '<root>.children[0]', '<root>.children[1]', "<root>.childrenByName.'map-key'"]
+        support.structure.findAll(Child) == visited.findAll { it.value.class == Child }
+
+        when: 'a corrupt relationship cycle is encountered'
+        def loop = instance.primary.class.getDeclaredField('loop')
+        loop.accessible = true
+        loop.set(instance.primary, instance.primary)
+        def cyclePaths = []
+        support.structure.visit(Child) { path, child -> cyclePaths << path }
+
+        then: 'each completed Object is visited once, while owners and LINKs stay outside composition'
+        cyclePaths == typedPaths
+
+        and: 'the compatibility utility preserves its established completed-model behavior through the facade'
+        StructureUtil.getRelativePath(instance, instance.childrenByName['map-key']) == "childrenByName.'map-key'"
+        StructureUtil.getAncestorOfType(instance.primary, instance.class).get().is(instance)
+    }
+
+    def "structure support separates direct and transitive owners"() {
+        given:
+        createClass '''
+            import com.blackbuild.groovy.configdsl.transform.Owner
+
+            @DSL class Root {
+                Branch branch
+            }
+
+            @DSL class Branch {
+                @Owner Root root
+                Leaf leaf
+            }
+
+            @DSL class Leaf {
+                @Owner Branch branch
+                @Owner(transitive = true) Root root
+            }
+        '''
+
+        when:
+        instance = Root.Create.With {
+            branch {
+                leaf {}
+            }
+        }
+        def leafSupport = KlumObjectSupport.of(instance.branch.leaf)
+
+        then:
+        leafSupport.structure.directOwners == [instance.branch] as Set
+        leafSupport.structure.singleOwner.get().is(instance.branch)
+        leafSupport.structure.ownerHierarchy == [instance.branch.leaf, instance.branch, instance]
+        leafSupport.structure.getAncestorOfType(instance.class).get().is(instance)
+    }
+
+    private void compileJavaConsumer(String source) {
+        File sourceFile = new File(tempFolder.root, 'JavaObjectSupportConsumer.java')
+        sourceFile.text = source.stripIndent()
+        String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
+                .join(File.pathSeparator)
+        int result = ToolProvider.systemJavaCompiler.run(
+                null,
+                null,
+                null,
+                '-classpath', classpath,
+                '-d', compilerConfiguration.targetDirectory.absolutePath,
+                sourceFile.absolutePath
+        )
+        assert result == 0
+    }
+}

--- a/wiki/Completed-Object-Support.md
+++ b/wiki/Completed-Object-Support.md
@@ -1,0 +1,61 @@
+# Completed Object Support
+
+Completed DSL Objects are immutable results of KlumAST construction. Client code may still need to inspect where an
+object came from, navigate its ownership structure, or traverse its composed children. `KlumObjectSupport` is the stable,
+Java-first entry point for those operations without exposing the object's internal Model companion.
+
+The facade accepts either a completed root object or any completed DSL Object in its subtree:
+
+```java
+import com.blackbuild.klum.ast.util.KlumObjectSupport;
+import java.util.Map;
+
+KlumObjectSupport<Deployment> support = KlumObjectSupport.of(deployment);
+
+Deployment object = support.getObject();
+String breadcrumbPath = support.getBreadcrumbPath();
+String modelPath = support.getModelPath();
+
+KlumObjectSupport.Structure<Deployment> structure = support.getStructure();
+Map<String, Service> services = structure.findAll(Service.class);
+```
+
+The Javadoc for `KlumObjectSupport` and its nested `Structure` helper is the source of truth for complete signatures,
+overloads, return types, and exceptional cases.
+
+## Provenance and model paths
+
+`getBreadcrumbPath()` reports construction provenance: the Builder/factory call path through which the object was
+created. `getModelPath()` reports the object's structural location in the completed model. These answer different
+questions and are not interchangeable.
+
+## Ownership, paths, and traversal
+
+`getStructure()` groups operations that inspect the completed composition graph:
+
+- direct and single-owner lookup, owner hierarchy, and nearest ancestors by type;
+- full paths from the composition root and relative paths from one object to an owned descendant; and
+- typed `findAll` and `visit` traversal.
+
+Traversal follows composed DSL values only. Owner and `LINK` edges are not followed, and identity-based cycle protection
+ensures that object graphs remain safe even when DSL types override `equals`.
+
+The facade may also start at a subtree:
+
+```java
+import java.util.Optional;
+
+KlumObjectSupport<Service> serviceSupport = KlumObjectSupport.of(service);
+
+Optional<Object> owner = serviceSupport.getStructure().getSingleOwner();
+String pathFromDeployment = support.getStructure().getRelativePath(service);
+```
+
+## Compatibility APIs
+
+`StructureUtil` remains as a deprecated adapter for existing callers. New completed-object code should use
+`KlumObjectSupport` directly. `KlumModelProxy` and its raw metadata are internal implementation details and are not a
+supported client extension API.
+
+Stored validation results are currently accessed through the supported `Validator` utilities described in
+[[Validation]]. A grouped validation helper on `KlumObjectSupport` belongs to the later completed-object validation slice.

--- a/wiki/Layer3.md
+++ b/wiki/Layer3.md
@@ -315,10 +315,11 @@ assert db.dml.role == "dml"
 assert db.monitoring.role == "monitoring"
 ```
 
-That way some kind of environment checker can, for example, validate that all non ddl users have the correct privileges:
+That way some kind of environment checker can, for example, use [[Completed Object Support]] to validate that all non
+ddl users have the correct privileges:
 
 ```groovy
-StructureUtil.deepFind(model, DbUser).each { path, user ->
+KlumObjectSupport.of(model).getStructure().findAll(DbUser).each { path, user ->
     if (user.role != "ddl")
       assertNoDdlPrivileges(user, path)
 
@@ -326,4 +327,3 @@ StructureUtil.deepFind(model, DbUser).each { path, user ->
 ```
 
 Note that this check should not be done during standard model validation because it requires access to the actual database.
-

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -10,6 +10,7 @@
   * [[Static Models]]
   * [[Javadoc]]
 * Advanced Features
+  * [[Completed Object Support]]
   * [[Convenience Factories]]
   * [[Factory Classes]]
   * [[Templates]]


### PR DESCRIPTION
## Summary

Implements the OS-1 completed-object provenance and structure slice of #435.

- Adds Java-first `KlumObjectSupport<T>` for completed DSL roots and subtrees, including explicit provenance and structure getters.
- Separates completed-model traversal from Builder traversal while sharing composition-only, identity-cycle-safe traversal and structural-path mechanics.
- Retains `StructureUtil` as a deprecated source-compatible adapter; production code now uses state-specific support directly.
- Documents OS-1 as implemented and preserves OS-2 as the future read-only stored-validation/proxy-lockdown slice.

## Validation

- `./gradlew :klum-ast-runtime:test :klum-ast:test :klum-ast-jackson:test`
- `./gradlew groovy4Tests groovy5Tests`
- `git diff --check`