### PR TITLE
Replay resolved Jackson properties through one Builder lifecycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,10 +40,16 @@ This is a breaking release. See the [Builder-first construction migration](https
 
 - Templates remain DSL Object recipes and rehydrate into fresh Builder graphs on every application. Template `applyLater` recipes are detached from their defining Builder; captured values must be serializable and captured Builders are rejected.
 - Completed-model companion state is serializable. Technical metadata rejects non-serializable values immediately.
-- Jackson now restores fields into Builders through the module's internal `KlumDeserializer` and runs the normal lifecycle,
-  materialization, and validation pipeline. The former public `KlumValueInstantiator` and `SettableKlumBeanProperty`
-  extension classes have been removed. This raw-state implementation is transitional; [ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md)
-  records configuration replay as the accepted #428/#251 target.
+- Jackson now replays resolved public configuration properties into root and owned child Builders between `PostCreate` and
+  `PostApply`, then runs one normal lifecycle, materialization, validation, and verification pipeline. Missing input keeps
+  initializer/default behavior; present values, `null`, and containers replace authoritatively. Resolved `@JsonProperty`,
+  `@JsonAlias`, naming strategies, mixins, access/ignore rules, and unknown-property policy are honored without ambient
+  Templates or copy/overwrite semantics ([#439](https://github.com/klum-dsl/klum-ast/issues/439),
+  [#251](https://github.com/klum-dsl/klum-ast/issues/251),
+  [ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md)).
+  Explicit type-level custom deserializers remain the opt-out. Template rejection remains blocked by
+  [#438](https://github.com/klum-dsl/klum-ast/issues/438), and LINK identity remains #440 scope. The former public
+  `KlumValueInstantiator` and `SettableKlumBeanProperty` extension classes remain removed.
 
 # 3.0.1
 - New annodocimal version, ignores irrelevant inner class entries in class files

--- a/docs/adr/0007-jackson-configuration-replay.md
+++ b/docs/adr/0007-jackson-configuration-replay.md
@@ -9,8 +9,9 @@ Tracking issues:
 - [#428 — Decide deserialization lifecycle semantics](https://github.com/klum-dsl/klum-ast/issues/428)
 - [#251 — Jackson deserialization does not work with renamed properties](https://github.com/klum-dsl/klum-ast/issues/251)
 
-Implementation status: Planned. The current deserializer binds a raw Map and restores all serializable fields. See the
-[implementation plan](../implementation/adr-0007-jackson-configuration-replay.md).
+Implementation status: JSON-1 property-aware configuration replay is implemented by
+[#439](https://github.com/klum-dsl/klum-ast/issues/439). LINK identity and the advanced customization boundary remain
+planned as JSON-2. See the [implementation plan](../implementation/adr-0007-jackson-configuration-replay.md).
 
 Parent decisions:
 

--- a/docs/implementation/adr-0007-jackson-configuration-replay.md
+++ b/docs/implementation/adr-0007-jackson-configuration-replay.md
@@ -5,10 +5,14 @@ This plan implements [ADR 0007](../adr/0007-jackson-configuration-replay.md) for
 
 ## Current behavior and failure
 
-`KlumDeserializer` reads an object into `Map<String,Object>` and calls `FactoryHelper.createFromSerializedState`. That path
-replays all serializable fields through Builder copy semantics, so renamed/aliased properties are not resolved through
-Jackson metadata and lifecycle-derived values can be restored then transformed again. `KlumAnnotationIntrospector` ignores
-framework fields but does not define the full writable-configuration contract. `LINK` identity behavior is not explicit.
+Before JSON-1, `KlumDeserializer` read an object into `Map<String,Object>` and called
+`FactoryHelper.createFromSerializedState`. That path replayed all serializable fields through Builder copy semantics, so
+renamed/aliased properties were not resolved through Jackson metadata and lifecycle-derived values could be restored then
+transformed again.
+
+JSON-1 now buffers JSON object tokens, resolves effective `BeanPropertyDefinition` metadata, and binds only the public
+configurable Builder surface between `PostCreate` and `PostApply`. Owned values recursively allocate Builders in the same
+Construction session. `LINK` identity behavior remains JSON-2 scope.
 
 ## Affected seams
 
@@ -21,10 +25,14 @@ framework fields but does not define the full writable-configuration contract. `
 
 ### [JSON-1 — Property-aware configuration replay](https://github.com/klum-dsl/klum-ast/issues/439)
 
+Status: Implemented.
+
 For one DSL Object with a renamed scalar, alias, initializer, derived lifecycle value, and owned child, resolve
 `BeanPropertyDefinition`s, allocate one Builder graph, bind only present public configuration inputs between PostCreate and
 PostApply, and run the lifecycle once. Prove missing/present/null/empty replacement semantics, unknown-property policy, and
-Template rejection. This resolves #251's core renamed-property failure.
+Template rejection. This resolves #251's core renamed-property failure. The property replay behavior is implemented;
+completed Template rejection remains executable pending coverage blocked by
+[#438](https://github.com/klum-dsl/klum-ast/issues/438), because completed models do not yet retain stable Template identity.
 
 ### [JSON-2 — Identity-safe LINK and advanced property customization](https://github.com/klum-dsl/klum-ast/issues/440)
 
@@ -42,7 +50,8 @@ replay and the breaking JSON boundary, update migration navigation and `CHANGES.
 ## Compatibility
 
 Existing serialized JSON is not guaranteed to deserialize identically. There is no per-instance provenance migration.
-Templates and inline LINK graphs fail loudly. A type-level custom deserializer remains the explicit escape hatch.
+Inline LINK graphs remain unsupported pending JSON-2. Templates remain unsupported Jackson values, but reliable rejection
+is blocked by #438's companion separation. A type-level custom deserializer remains the explicit escape hatch.
 
 ## Acceptance map
 

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumAnnotationIntrospector.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumAnnotationIntrospector.java
@@ -23,8 +23,11 @@
  */
 package com.blackbuild.klum.ast.jackson;
 
+import com.blackbuild.groovy.configdsl.transform.FieldType;
 import com.blackbuild.groovy.configdsl.transform.Owner;
 import com.blackbuild.groovy.configdsl.transform.Role;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
@@ -37,9 +40,23 @@ public class KlumAnnotationIntrospector extends JacksonAnnotationIntrospector {
         if (m.hasAnnotation(Role.class))
             return true;
 
+        com.blackbuild.groovy.configdsl.transform.Field field =
+                m.getAnnotation(com.blackbuild.groovy.configdsl.transform.Field.class);
+        if (field != null && (field.value() == FieldType.IGNORED || field.value() == FieldType.BUILDER))
+            return true;
+
         if (m.getName().contains("$"))
             return true;
 
         return super.hasIgnoreMarker(m);
+    }
+
+    @Override
+    public JsonProperty.Access findPropertyAccess(Annotated annotated) {
+        com.blackbuild.groovy.configdsl.transform.Field field =
+                annotated.getAnnotation(com.blackbuild.groovy.configdsl.transform.Field.class);
+        if (field != null && field.value() == FieldType.PROTECTED)
+            return JsonProperty.Access.READ_ONLY;
+        return super.findPropertyAccess(annotated);
     }
 }

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumAnnotationIntrospector.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumAnnotationIntrospector.java
@@ -23,6 +23,7 @@
  */
 package com.blackbuild.klum.ast.jackson;
 
+import com.blackbuild.groovy.configdsl.transform.Field;
 import com.blackbuild.groovy.configdsl.transform.FieldType;
 import com.blackbuild.groovy.configdsl.transform.Owner;
 import com.blackbuild.groovy.configdsl.transform.Role;
@@ -40,8 +41,7 @@ public class KlumAnnotationIntrospector extends JacksonAnnotationIntrospector {
         if (m.hasAnnotation(Role.class))
             return true;
 
-        com.blackbuild.groovy.configdsl.transform.Field field =
-                m.getAnnotation(com.blackbuild.groovy.configdsl.transform.Field.class);
+        Field field = m.getAnnotation(Field.class);
         if (field != null && (field.value() == FieldType.IGNORED || field.value() == FieldType.BUILDER))
             return true;
 
@@ -53,8 +53,7 @@ public class KlumAnnotationIntrospector extends JacksonAnnotationIntrospector {
 
     @Override
     public JsonProperty.Access findPropertyAccess(Annotated annotated) {
-        com.blackbuild.groovy.configdsl.transform.Field field =
-                annotated.getAnnotation(com.blackbuild.groovy.configdsl.transform.Field.class);
+        Field field = annotated.getAnnotation(Field.class);
         if (field != null && field.value() == FieldType.PROTECTED)
             return JsonProperty.Access.READ_ONLY;
         return super.findPropertyAccess(annotated);

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -25,6 +25,8 @@ package com.blackbuild.klum.ast.jackson;
 
 import com.blackbuild.groovy.configdsl.transform.FieldType;
 import com.blackbuild.groovy.configdsl.transform.Owner;
+import com.blackbuild.groovy.configdsl.transform.PostApply;
+import com.blackbuild.groovy.configdsl.transform.PostCreate;
 import com.blackbuild.groovy.configdsl.transform.Role;
 import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.util.DslHelper;
@@ -40,16 +42,17 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,6 +61,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -88,8 +92,8 @@ final class KlumDeserializer extends StdDeserializer<Object> {
         ObjectNode configuration = readObject(parser, context);
         try {
             return replay(configuration, parser, context);
-        } catch (ReplayFailure failure) {
-            throw failure.getIOException();
+        } catch (UncheckedIOException failure) {
+            throw failure.getCause();
         } catch (RuntimeException exception) {
             throw JsonMappingException.from(parser, "Could not replay configuration for " + modelType.getName()
                     + " through its Builder lifecycle", exception);
@@ -97,10 +101,7 @@ final class KlumDeserializer extends StdDeserializer<Object> {
     }
 
     private static ObjectNode readObject(JsonParser parser, DeserializationContext context) throws IOException {
-        com.fasterxml.jackson.databind.JsonNode node = context.readTree(parser);
-        if (node.getNodeType() != JsonNodeType.OBJECT)
-            return (ObjectNode) context.handleUnexpectedToken(ObjectNode.class, parser);
-        return (ObjectNode) node;
+        return (ObjectNode) context.readTree(parser);
     }
 
     private Object replay(ObjectNode configuration, JsonParser source, DeserializationContext context) {
@@ -115,13 +116,13 @@ final class KlumDeserializer extends StdDeserializer<Object> {
     private void configure(KlumBuilder<?> builder, ObjectNode configuration, ResolvedProperties properties,
                            JsonParser source, DeserializationContext context) {
         builder.setCurrentTemplates(Collections.emptyMap());
-        LifecycleHelper.executeLifecycleMethods(builder, com.blackbuild.groovy.configdsl.transform.PostCreate.class);
+        LifecycleHelper.executeLifecycleMethods(builder, PostCreate.class);
         configuration.fields()
                 .forEachRemaining(entry -> bind(builder, entry.getKey(), entry.getValue(), properties, source, context));
-        LifecycleHelper.executeLifecycleMethods(builder, com.blackbuild.groovy.configdsl.transform.PostApply.class);
+        LifecycleHelper.executeLifecycleMethods(builder, PostApply.class);
     }
 
-    private void bind(KlumBuilder<?> builder, String externalName, com.fasterxml.jackson.databind.JsonNode node,
+    private void bind(KlumBuilder<?> builder, String externalName, JsonNode node,
                       ResolvedProperties properties, JsonParser source, DeserializationContext context) {
         ResolvedProperty property = properties.bindable().get(externalName);
         if (property == null) {
@@ -130,28 +131,30 @@ final class KlumDeserializer extends StdDeserializer<Object> {
             handleUnknown(builder, externalName, node, source, context);
             return;
         }
-        try (JsonParser valueParser = node.traverse(source.getCodec())) {
-            valueParser.nextToken();
+        try {
             Object value = DslHelper.isRelationship(property.schemaField())
                     && !DslHelper.isLink(property.schemaField())
                     ? readOwnedValue(node, property, source, context)
-                    : readSimpleValue(valueParser, property, context);
+                    : readSimpleValue(node, source, property, context);
             builder.setSingleField(property.internalName(), value);
         } catch (IOException exception) {
-            throw new ReplayFailure(exception);
+            throw new UncheckedIOException(exception);
         }
     }
 
-    private static Object readSimpleValue(JsonParser valueParser, ResolvedProperty property,
+    private static Object readSimpleValue(JsonNode node, JsonParser source, ResolvedProperty property,
                                           DeserializationContext context) throws IOException {
-        JsonDeserializer<Object> valueDeserializer = context.findContextualValueDeserializer(
-                property.type(), property.beanProperty());
-        return valueParser.currentToken() == JsonToken.VALUE_NULL
-                ? valueDeserializer.getNullValue(context)
-                : valueDeserializer.deserialize(valueParser, context);
+        try (JsonParser valueParser = node.traverse(source.getCodec())) {
+            valueParser.nextToken();
+            JsonDeserializer<Object> valueDeserializer = context.findContextualValueDeserializer(
+                    property.type(), property.beanProperty());
+            return valueParser.currentToken() == JsonToken.VALUE_NULL
+                    ? valueDeserializer.getNullValue(context)
+                    : valueDeserializer.deserialize(valueParser, context);
+        }
     }
 
-    private Object readOwnedValue(com.fasterxml.jackson.databind.JsonNode node, ResolvedProperty property,
+    private Object readOwnedValue(JsonNode node, ResolvedProperty property,
                                   JsonParser source, DeserializationContext context) throws IOException {
         if (node.isNull())
             return null;
@@ -162,7 +165,7 @@ final class KlumDeserializer extends StdDeserializer<Object> {
         return readOwnedBuilder(node, property.type().getRawClass(), null, source, context);
     }
 
-    private Map<Object, Object> readOwnedMap(com.fasterxml.jackson.databind.JsonNode node, ResolvedProperty property,
+    private Map<Object, Object> readOwnedMap(JsonNode node, ResolvedProperty property,
                                              JsonParser source, DeserializationContext context) throws IOException {
         if (!node.isObject())
             throw JsonMappingException.from(source, "Expected an object for owned map property "
@@ -181,7 +184,7 @@ final class KlumDeserializer extends StdDeserializer<Object> {
         return result;
     }
 
-    private Collection<Object> readOwnedCollection(com.fasterxml.jackson.databind.JsonNode node,
+    private Collection<Object> readOwnedCollection(JsonNode node,
                                                    ResolvedProperty property, JsonParser source,
                                                    DeserializationContext context) throws IOException {
         if (!node.isArray())
@@ -193,12 +196,12 @@ final class KlumDeserializer extends StdDeserializer<Object> {
                 ? new LinkedHashSet<>()
                 : new ArrayList<>();
         Class<?> childType = property.type().getContentType().getRawClass();
-        for (com.fasterxml.jackson.databind.JsonNode element : node)
+        for (JsonNode element : node)
             result.add(readOwnedBuilder(element, childType, null, source, context));
         return result;
     }
 
-    private KlumBuilder<?> readOwnedBuilder(com.fasterxml.jackson.databind.JsonNode node, Class<?> childType,
+    private KlumBuilder<?> readOwnedBuilder(JsonNode node, Class<?> childType,
                                             Object keyHint, JsonParser source,
                                             DeserializationContext context) throws IOException {
         if (node.isNull())
@@ -213,13 +216,13 @@ final class KlumDeserializer extends StdDeserializer<Object> {
         return child;
     }
 
-    private void handleUnknown(KlumBuilder<?> builder, String externalName, com.fasterxml.jackson.databind.JsonNode node,
+    private void handleUnknown(KlumBuilder<?> builder, String externalName, JsonNode node,
                                JsonParser source, DeserializationContext context) {
         try (JsonParser valueParser = node.traverse(source.getCodec())) {
             valueParser.nextToken();
             context.handleUnknownProperty(valueParser, this, builder, externalName);
         } catch (IOException exception) {
-            throw new ReplayFailure(exception);
+            throw new UncheckedIOException(exception);
         }
     }
 
@@ -235,7 +238,7 @@ final class KlumDeserializer extends StdDeserializer<Object> {
                     : Optional.empty();
             Stream<String> names = Stream.concat(
                     Stream.of(definition.getName()),
-                    aliasesFor(definition, context).map(com.fasterxml.jackson.databind.PropertyName::getSimpleName)
+                    aliasesFor(definition, context).map(PropertyName::getSimpleName)
             );
             if (resolved.isPresent())
                 names.forEach(name -> bindable.put(name, resolved.get()));
@@ -263,13 +266,13 @@ final class KlumDeserializer extends StdDeserializer<Object> {
                 : namingStrategy.nameForField(context.getConfig(), field, field.getName()));
     }
 
-    private static Stream<com.fasterxml.jackson.databind.PropertyName> aliasesFor(
+    private static Stream<PropertyName> aliasesFor(
             BeanPropertyDefinition property, DeserializationContext context) {
         return Stream.of(property.getPrimaryMember(), property.getField(), property.getGetter(), property.getSetter())
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .distinct()
                 .flatMap(member -> Optional.ofNullable(context.getAnnotationIntrospector().findPropertyAliases(member)).stream())
-                .flatMap(java.util.Collection::stream);
+                .flatMap(Collection::stream);
     }
 
     private Optional<ResolvedProperty> toResolvedProperty(Class<?> currentType, BeanPropertyDefinition property) {
@@ -325,16 +328,4 @@ final class KlumDeserializer extends StdDeserializer<Object> {
                                       boolean ignoreUnknown) {
     }
 
-    private static final class ReplayFailure extends RuntimeException {
-        private final IOException ioException;
-
-        private ReplayFailure(IOException ioException) {
-            super(ioException);
-            this.ioException = ioException;
-        }
-
-        private IOException getIOException() {
-            return ioException;
-        }
-    }
 }

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -23,28 +23,53 @@
  */
 package com.blackbuild.klum.ast.jackson;
 
+import com.blackbuild.groovy.configdsl.transform.FieldType;
+import com.blackbuild.groovy.configdsl.transform.Owner;
+import com.blackbuild.groovy.configdsl.transform.Role;
+import com.blackbuild.klum.ast.process.PhaseDriver;
+import com.blackbuild.klum.ast.util.DslHelper;
 import com.blackbuild.klum.ast.util.FactoryHelper;
+import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.LifecycleHelper;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Stream;
 
 /**
- * Restores JSON object state through the generated Builder lifecycle.
- *
- * <p>The map-shaped binding policy is provisional pending issue #428. It keeps
- * construction state out of completed models while that issue decides the
- * eventual interaction with advanced Jackson property customization.</p>
+ * Replays resolved Jackson configuration properties through the generated Builder lifecycle.
  */
 final class KlumDeserializer extends StdDeserializer<Object> {
-
-    private static final TypeReference<LinkedHashMap<String, Object>> STATE_TYPE = new TypeReference<>() { };
 
     private final Class<?> modelType;
 
@@ -60,11 +85,256 @@ final class KlumDeserializer extends StdDeserializer<Object> {
         if (!parser.isExpectedStartObjectToken())
             return context.handleUnexpectedToken(modelType, parser);
 
-        Map<String, Object> state = parser.readValueAs(STATE_TYPE);
+        ObjectNode configuration = readObject(parser, context);
         try {
-            return FactoryHelper.createFromSerializedState(modelType, state);
+            return replay(configuration, parser, context);
+        } catch (ReplayFailure failure) {
+            throw failure.getIOException();
         } catch (RuntimeException exception) {
-            throw JsonMappingException.from(parser, "Could not restore " + modelType.getName() + " through its Builder lifecycle", exception);
+            throw JsonMappingException.from(parser, "Could not replay configuration for " + modelType.getName()
+                    + " through its Builder lifecycle", exception);
+        }
+    }
+
+    private static ObjectNode readObject(JsonParser parser, DeserializationContext context) throws IOException {
+        com.fasterxml.jackson.databind.JsonNode node = context.readTree(parser);
+        if (node.getNodeType() != JsonNodeType.OBJECT)
+            return (ObjectNode) context.handleUnexpectedToken(ObjectNode.class, parser);
+        return (ObjectNode) node;
+    }
+
+    private Object replay(ObjectNode configuration, JsonParser source, DeserializationContext context) {
+        ResolvedProperties properties = resolveProperties(modelType, context);
+        String key = resolveKey(modelType, configuration, null, properties);
+        return PhaseDriver.withBuilderLifecycle(
+                () -> FactoryHelper.createBuilder(modelType, key),
+                builder -> configure(builder, configuration, properties, source, context)
+        );
+    }
+
+    private void configure(KlumBuilder<?> builder, ObjectNode configuration, ResolvedProperties properties,
+                           JsonParser source, DeserializationContext context) {
+        builder.setCurrentTemplates(Collections.emptyMap());
+        LifecycleHelper.executeLifecycleMethods(builder, com.blackbuild.groovy.configdsl.transform.PostCreate.class);
+        configuration.fields()
+                .forEachRemaining(entry -> bind(builder, entry.getKey(), entry.getValue(), properties, source, context));
+        LifecycleHelper.executeLifecycleMethods(builder, com.blackbuild.groovy.configdsl.transform.PostApply.class);
+    }
+
+    private void bind(KlumBuilder<?> builder, String externalName, com.fasterxml.jackson.databind.JsonNode node,
+                      ResolvedProperties properties, JsonParser source, DeserializationContext context) {
+        ResolvedProperty property = properties.bindable().get(externalName);
+        if (property == null) {
+            if (properties.ignored().contains(externalName) || properties.ignoreUnknown())
+                return;
+            handleUnknown(builder, externalName, node, source, context);
+            return;
+        }
+        try (JsonParser valueParser = node.traverse(source.getCodec())) {
+            valueParser.nextToken();
+            Object value = DslHelper.isRelationship(property.schemaField())
+                    && !DslHelper.isLink(property.schemaField())
+                    ? readOwnedValue(node, property, source, context)
+                    : readSimpleValue(valueParser, property, context);
+            builder.setSingleField(property.internalName(), value);
+        } catch (IOException exception) {
+            throw new ReplayFailure(exception);
+        }
+    }
+
+    private static Object readSimpleValue(JsonParser valueParser, ResolvedProperty property,
+                                          DeserializationContext context) throws IOException {
+        JsonDeserializer<Object> valueDeserializer = context.findContextualValueDeserializer(
+                property.type(), property.beanProperty());
+        return valueParser.currentToken() == JsonToken.VALUE_NULL
+                ? valueDeserializer.getNullValue(context)
+                : valueDeserializer.deserialize(valueParser, context);
+    }
+
+    private Object readOwnedValue(com.fasterxml.jackson.databind.JsonNode node, ResolvedProperty property,
+                                  JsonParser source, DeserializationContext context) throws IOException {
+        if (node.isNull())
+            return null;
+        if (property.type().isMapLikeType())
+            return readOwnedMap(node, property, source, context);
+        if (property.type().isCollectionLikeType())
+            return readOwnedCollection(node, property, source, context);
+        return readOwnedBuilder(node, property.type().getRawClass(), null, source, context);
+    }
+
+    private Map<Object, Object> readOwnedMap(com.fasterxml.jackson.databind.JsonNode node, ResolvedProperty property,
+                                             JsonParser source, DeserializationContext context) throws IOException {
+        if (!node.isObject())
+            throw JsonMappingException.from(source, "Expected an object for owned map property "
+                    + property.externalName());
+        Map<Object, Object> result = SortedMap.class.isAssignableFrom(property.type().getRawClass())
+                ? new TreeMap<>()
+                : new LinkedHashMap<>();
+        KeyDeserializer keyDeserializer = context.findKeyDeserializer(property.type().getKeyType(), property.beanProperty());
+        Class<?> childType = property.type().getContentType().getRawClass();
+        var fields = node.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            Object key = keyDeserializer.deserializeKey(entry.getKey(), context);
+            result.put(key, readOwnedBuilder(entry.getValue(), childType, key, source, context));
+        }
+        return result;
+    }
+
+    private Collection<Object> readOwnedCollection(com.fasterxml.jackson.databind.JsonNode node,
+                                                   ResolvedProperty property, JsonParser source,
+                                                   DeserializationContext context) throws IOException {
+        if (!node.isArray())
+            throw JsonMappingException.from(source, "Expected an array for owned collection property "
+                    + property.externalName());
+        Collection<Object> result = SortedSet.class.isAssignableFrom(property.type().getRawClass())
+                ? new TreeSet<>()
+                : Set.class.isAssignableFrom(property.type().getRawClass())
+                ? new LinkedHashSet<>()
+                : new ArrayList<>();
+        Class<?> childType = property.type().getContentType().getRawClass();
+        for (com.fasterxml.jackson.databind.JsonNode element : node)
+            result.add(readOwnedBuilder(element, childType, null, source, context));
+        return result;
+    }
+
+    private KlumBuilder<?> readOwnedBuilder(com.fasterxml.jackson.databind.JsonNode node, Class<?> childType,
+                                            Object keyHint, JsonParser source,
+                                            DeserializationContext context) throws IOException {
+        if (node.isNull())
+            return null;
+        if (!node.isObject())
+            throw JsonMappingException.from(source, "Expected an object for owned DSL value " + childType.getName());
+        ObjectNode object = (ObjectNode) node;
+        ResolvedProperties properties = resolveProperties(childType, context);
+        String key = resolveKey(childType, object, keyHint, properties);
+        KlumBuilder<?> child = FactoryHelper.createBuilder(childType, key);
+        configure(child, object, properties, source, context);
+        return child;
+    }
+
+    private void handleUnknown(KlumBuilder<?> builder, String externalName, com.fasterxml.jackson.databind.JsonNode node,
+                               JsonParser source, DeserializationContext context) {
+        try (JsonParser valueParser = node.traverse(source.getCodec())) {
+            valueParser.nextToken();
+            context.handleUnknownProperty(valueParser, this, builder, externalName);
+        } catch (IOException exception) {
+            throw new ReplayFailure(exception);
+        }
+    }
+
+    private ResolvedProperties resolveProperties(Class<?> currentType, DeserializationContext context) {
+        JavaType type = context.constructType(currentType);
+        BeanDescription description = context.getConfig().introspect(type);
+        Map<String, ResolvedProperty> bindable = new LinkedHashMap<>();
+        Set<String> ignored = new HashSet<>(description.getIgnoredPropertyNames());
+        description.getClassInfo().fields().forEach(field -> addIgnoredFieldName(field, ignored, context));
+        description.findProperties().forEach(definition -> {
+            Optional<ResolvedProperty> resolved = definition.couldDeserialize()
+                    ? toResolvedProperty(currentType, definition)
+                    : Optional.empty();
+            Stream<String> names = Stream.concat(
+                    Stream.of(definition.getName()),
+                    aliasesFor(definition, context).map(com.fasterxml.jackson.databind.PropertyName::getSimpleName)
+            );
+            if (resolved.isPresent())
+                names.forEach(name -> bindable.put(name, resolved.get()));
+            else
+                names.forEach(ignored::add);
+        });
+        JsonIgnoreProperties.Value ignorals = context.getConfig()
+                .getDefaultPropertyIgnorals(currentType, description.getClassInfo());
+        ignored.addAll(ignorals.findIgnoredForDeserialization());
+        return new ResolvedProperties(bindable, ignored, ignorals.getIgnoreUnknown());
+    }
+
+    private static void addIgnoredFieldName(AnnotatedField field, Set<String> ignored,
+                                            DeserializationContext context) {
+        if (!context.getAnnotationIntrospector().hasIgnoreMarker(field))
+            return;
+        PropertyName explicitName = context.getAnnotationIntrospector().findNameForDeserialization(field);
+        if (explicitName != null && explicitName.hasSimpleName()) {
+            ignored.add(explicitName.getSimpleName());
+            return;
+        }
+        PropertyNamingStrategy namingStrategy = context.getConfig().getPropertyNamingStrategy();
+        ignored.add(namingStrategy == null
+                ? field.getName()
+                : namingStrategy.nameForField(context.getConfig(), field, field.getName()));
+    }
+
+    private static Stream<com.fasterxml.jackson.databind.PropertyName> aliasesFor(
+            BeanPropertyDefinition property, DeserializationContext context) {
+        return Stream.of(property.getPrimaryMember(), property.getField(), property.getGetter(), property.getSetter())
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .flatMap(member -> Optional.ofNullable(context.getAnnotationIntrospector().findPropertyAliases(member)).stream())
+                .flatMap(java.util.Collection::stream);
+    }
+
+    private Optional<ResolvedProperty> toResolvedProperty(Class<?> currentType, BeanPropertyDefinition property) {
+        Optional<Field> schemaField = DslHelper.getField(currentType, property.getInternalName());
+        if (schemaField.isEmpty() || !isConfigurable(schemaField.get()))
+            return Optional.empty();
+        BeanProperty beanProperty = new BeanProperty.Std(
+                property.getFullName(),
+                property.getPrimaryType(),
+                property.getWrapperName(),
+                property.getPrimaryMember(),
+                property.getMetadata()
+        );
+        return Optional.of(new ResolvedProperty(
+                property.getName(),
+                schemaField.get().getName(),
+                property.getPrimaryType(),
+                beanProperty,
+                schemaField.get()
+        ));
+    }
+
+    private static String resolveKey(Class<?> currentType, ObjectNode configuration, Object keyHint,
+                                     ResolvedProperties properties) {
+        Optional<Field> keyField = DslHelper.getKeyField(currentType);
+        if (keyField.isEmpty())
+            return null;
+        Optional<String> externalKey = properties.bindable().entrySet().stream()
+                .filter(entry -> entry.getValue().internalName().equals(keyField.get().getName()))
+                .map(Map.Entry::getKey)
+                .filter(configuration::has)
+                .findFirst();
+        if (externalKey.isPresent() && !configuration.get(externalKey.get()).isNull())
+            return configuration.get(externalKey.get()).asText();
+        return keyHint == null ? null : keyHint.toString();
+    }
+
+    private static boolean isConfigurable(Field field) {
+        FieldType fieldType = DslHelper.getKlumFieldType(field);
+        return !field.isSynthetic()
+                && !field.isAnnotationPresent(Owner.class)
+                && !field.isAnnotationPresent(Role.class)
+                && fieldType != FieldType.PROTECTED
+                && fieldType != FieldType.IGNORED
+                && fieldType != FieldType.BUILDER;
+    }
+
+    private record ResolvedProperty(String externalName, String internalName, JavaType type,
+                                    BeanProperty beanProperty, Field schemaField) {
+    }
+
+    private record ResolvedProperties(Map<String, ResolvedProperty> bindable, Set<String> ignored,
+                                      boolean ignoreUnknown) {
+    }
+
+    private static final class ReplayFailure extends RuntimeException {
+        private final IOException ioException;
+
+        private ReplayFailure(IOException ioException) {
+            super(ioException);
+            this.ioException = ioException;
+        }
+
+        private IOException getIOException() {
+            return ioException;
         }
     }
 }

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/ConfigurationReplaySpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/ConfigurationReplaySpec.groovy
@@ -1,0 +1,455 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//file:noinspection GrPackage
+package com.blackbuild.klum.ast.jackson
+
+import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
+import spock.lang.PendingFeature
+
+class ConfigurationReplaySpec extends AbstractDSLSpec {
+
+    ObjectMapper mapper = new ObjectMapper().findAndRegisterModules()
+
+    def "resolved JsonProperty name is shared by serialization and configuration replay"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class RenamedValue {
+                @JsonProperty("display_name")
+                String name
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue('{"display_name":"Ada"}', clazz)
+
+        then:
+        deserialized.name == "Ada"
+        mapper.writeValueAsString(deserialized) == '{"display_name":"Ada"}'
+    }
+
+    def "JsonAlias is accepted as configuration input without changing the serialization name"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonAlias
+
+            @DSL
+            class AliasedValue {
+                @JsonAlias("legacy_name")
+                String name
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue('{"legacy_name":"Ada"}', clazz)
+
+        then:
+        deserialized.name == "Ada"
+        mapper.writeValueAsString(deserialized) == '{"name":"Ada"}'
+    }
+
+    def "configured naming strategy and mixin names are replayed from resolved metadata"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class NamedValue {
+                String givenName
+                String familyName
+            }
+
+            abstract class NamedValueMixin {
+                @JsonProperty("surname")
+                abstract String getFamilyName()
+            }
+        ''')
+        def configuredMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .addMixIn(clazz, getClass("pk.NamedValueMixin"))
+                .findAndRegisterModules()
+
+        when:
+        def deserialized = configuredMapper.readValue('{"given_name":"Ada","surname":"Lovelace"}', clazz)
+
+        then:
+        deserialized.givenName == "Ada"
+        deserialized.familyName == "Lovelace"
+        configuredMapper.writeValueAsString(deserialized) == '{"given_name":"Ada","surname":"Lovelace"}'
+    }
+
+    def "missing configuration leaves the source initializer intact"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class InitializedValue {
+                String name = "initializer"
+            }
+        ''')
+
+        expect:
+        mapper.readValue('{}', clazz).name == "initializer"
+    }
+
+    def "present null clears an initialized nullable scalar"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class NullableValue {
+                String name = "initializer"
+            }
+        ''')
+
+        expect:
+        mapper.readValue('{"name":null}', clazz).name == null
+    }
+
+    def "present container authoritatively replaces initialized state for #json"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.blackbuild.klum.ast.util.copy.Overwrite
+            import com.blackbuild.klum.ast.util.copy.OverwriteStrategy
+
+            @DSL
+            class ContainerValue {
+                @Overwrite.Collection(OverwriteStrategy.Collection.ADD)
+                List<String> tags = ["initializer"]
+            }
+        ''')
+
+        expect:
+        mapper.readValue(json, clazz).tags == expected
+
+        where:
+        json                | expected
+        '{"tags":[]}'       | []
+        '{"tags":["json"]}' | ["json"]
+    }
+
+    def "ignored and read-only properties are not configuration inputs"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonIgnore
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class InputBoundary {
+                @JsonIgnore
+                String ignored = "ignored-default"
+
+                @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+                String derived = "derived-default"
+
+                String accepted = "accepted-default"
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue(
+                '{"ignored":"input","derived":"input","accepted":"json"}', clazz)
+
+        then:
+        deserialized.ignored == "ignored-default"
+        deserialized.derived == "derived-default"
+        deserialized.accepted == "json"
+
+        and:
+        mapper.readTree(mapper.writeValueAsString(deserialized)) == mapper.readTree(
+                '{"derived":"derived-default","accepted":"json"}')
+    }
+
+    def "unknown configuration follows the ObjectMapper policy"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class UnknownBoundary {
+                String name = "initializer"
+            }
+        ''')
+
+        when:
+        mapper.readValue('{"unknown":"value"}', clazz)
+
+        then:
+        thrown(UnrecognizedPropertyException)
+
+        when:
+        def lenient = mapper.copy().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        def deserialized = lenient.readValue('{"unknown":"value"}', clazz)
+
+        then:
+        deserialized.name == "initializer"
+    }
+
+    def "configuration replay recomputes a non-idempotent derived value in one lifecycle"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class LifecycleValue {
+                static List<String> events = []
+                static int postApplyCount
+
+                String input = "initializer"
+
+                @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+                String derived = ""
+
+                @PostCreate
+                void afterCreate() {
+                    events << "postCreate:$input".toString()
+                }
+
+                @PostApply
+                void derive() {
+                    postApplyCount++
+                    events << "postApply:$input".toString()
+                    derived += "[$input]"
+                }
+
+                @PostTree
+                void afterTree() {
+                    events << "postTree:$derived".toString()
+                }
+
+                @Validate
+                void validateModel() {
+                    events << "validate:$derived".toString()
+                }
+            }
+        ''')
+        def original = clazz.Create.With {
+            input "json"
+        }
+        def json = mapper.writeValueAsString(original)
+        clazz.events.clear()
+        clazz.postApplyCount = 0
+
+        when:
+        def deserialized = mapper.readValue(json, clazz)
+
+        then:
+        deserialized.input == "json"
+        deserialized.derived == "[json]"
+        clazz.postApplyCount == 1
+        clazz.events == [
+                "postCreate:initializer",
+                "postApply:json",
+                "postTree:[json]",
+                "validate:[json]"
+        ]
+    }
+
+    def "owned child configuration is replayed as a Builder in the root Construction session"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.blackbuild.klum.ast.util.KlumBuilder
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class OwnedRoot {
+                static List<String> events = []
+
+                OwnedChild child
+
+                @PostTree
+                void afterTree() {
+                    events << "root-postTree:${child instanceof KlumBuilder}".toString()
+                }
+            }
+
+            @DSL
+            class OwnedChild {
+                @JsonProperty("child_name")
+                String name = "child-initializer"
+
+                @Owner
+                OwnedRoot owner
+
+                @PostCreate
+                void afterCreate() {
+                    OwnedRoot.events << "child-postCreate:$name".toString()
+                }
+
+                @PostApply
+                void afterApply() {
+                    OwnedRoot.events << "child-postApply:$name".toString()
+                }
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue('{"child":{"child_name":"nested"}}', clazz)
+
+        then:
+        deserialized.child.name == "nested"
+        deserialized.child.owner.is(deserialized)
+        clazz.events == [
+                "child-postCreate:child-initializer",
+                "child-postApply:nested",
+                "root-postTree:true"
+        ]
+    }
+
+    def "explicit type-level custom deserializer opts out of Klum configuration replay"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.core.JsonParser
+            import com.fasterxml.jackson.databind.DeserializationContext
+            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+            import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+            @JsonDeserialize(using = OptOutDeserializer)
+            @DSL
+            class OptOutValue {
+                String value
+            }
+
+            class OptOutDeserializer extends StdDeserializer<OptOutValue> {
+                OptOutDeserializer() {
+                    super(OptOutValue)
+                }
+
+                @Override
+                OptOutValue deserialize(JsonParser parser, DeserializationContext context) {
+                    def tree = parser.codec.readTree(parser)
+                    return OptOutValue.Create.With {
+                        value "custom:${tree.get('value').asText()}"
+                    }
+                }
+            }
+        ''')
+
+        expect:
+        mapper.readValue('{"value":"json"}', clazz).value == "custom:json"
+    }
+
+    @PendingFeature(reason = "Blocked by #438: completed Templates have no stable identity before companion separation")
+    def "marked Templates are rejected as Jackson values"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class TemplateValue {
+                String value
+            }
+        ''')
+        def template = clazz.Template.Create {
+            value "recipe"
+        }
+
+        when:
+        mapper.writeValueAsString(template)
+
+        then:
+        thrown(com.fasterxml.jackson.databind.JsonMappingException)
+    }
+
+    def "Klum field types define the configurable persistence surface"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.blackbuild.groovy.configdsl.transform.FieldType
+
+            @DSL
+            class FieldSurface {
+                String input = "input-default"
+
+                @Field(FieldType.PROTECTED)
+                String derived = "derived-default"
+
+                @Field(FieldType.IGNORED)
+                String hidden = "hidden-default"
+
+                @Field(FieldType.BUILDER)
+                String scratch = "scratch-default"
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue('{"input":"json","derived":"attempt"}', clazz)
+
+        then:
+        deserialized.input == "json"
+        deserialized.derived == "derived-default"
+
+        and:
+        mapper.readTree(mapper.writeValueAsString(deserialized)) == mapper.readTree(
+                '{"input":"json","derived":"derived-default"}')
+    }
+
+    def "ambient Templates do not participate in configuration replay"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class AmbientTemplateValue {
+                String value = "initializer"
+            }
+        ''')
+        def template = clazz.Template.Create {
+            value "template"
+        }
+
+        when:
+        def deserialized = clazz.Template.With(template) {
+            mapper.readValue('{}', clazz)
+        }
+
+        then:
+        deserialized.value == "initializer"
+    }
+}

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/ConfigurationReplaySpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/ConfigurationReplaySpec.groovy
@@ -25,9 +25,10 @@
 package com.blackbuild.klum.ast.jackson
 
 import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import spock.lang.PendingFeature
 
@@ -339,6 +340,93 @@ class ConfigurationReplaySpec extends AbstractDSLSpec {
         ]
     }
 
+    def "owned collection and map configuration preserves declared container semantics"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class OwnedContainers {
+                List<ContainedValue> values
+                Set<ContainedValue> valueSet
+                SortedSet<ContainedValue> sortedValues
+                SortedMap<String, KeyedValue> keyedValues
+            }
+
+            @DSL
+            class ContainedValue {
+                String value
+
+                @Owner
+                OwnedContainers owner
+            }
+
+            @DSL
+            class KeyedValue {
+                @Key
+                String id
+
+                String value
+
+                @Owner
+                OwnedContainers owner
+            }
+        ''')
+
+        when:
+        def deserialized = mapper.readValue('''{
+            "values":[{"value":"list"}],
+            "valueSet":[{"value":"set"}],
+            "sortedValues":[],
+            "keyedValues":{"alpha":{"value":"map"}}
+        }''', clazz)
+
+        then:
+        deserialized.values*.value == ["list"]
+        deserialized.values.every { it.owner.is(deserialized) }
+        deserialized.valueSet*.value as Set == ["set"] as Set
+        deserialized.valueSet.every { it.owner.is(deserialized) }
+        deserialized.sortedValues instanceof SortedSet
+        deserialized.sortedValues.empty
+        deserialized.keyedValues instanceof SortedMap
+        deserialized.keyedValues.alpha.id == "alpha"
+        deserialized.keyedValues.alpha.value == "map"
+        deserialized.keyedValues.alpha.owner.is(deserialized)
+    }
+
+    def "owned containers reject a JSON #shape shape"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class ShapedContainers {
+                List<ShapedValue> values
+                Map<String, ShapedValue> keyedValues
+            }
+
+            @DSL
+            class ShapedValue {
+                @Key
+                String id
+
+                String value
+            }
+        ''')
+
+        when:
+        mapper.readValue(json, clazz)
+
+        then:
+        thrown(JsonMappingException)
+
+        where:
+        shape                | json
+        "object for a list"  | '{"values":{}}'
+        "array for a map"    | '{"keyedValues":[]}'
+        "scalar list member" | '{"values":["not-an-object"]}'
+    }
+
     def "explicit type-level custom deserializer opts out of Klum configuration replay"() {
         given:
         createClass('''
@@ -393,7 +481,7 @@ class ConfigurationReplaySpec extends AbstractDSLSpec {
         mapper.writeValueAsString(template)
 
         then:
-        thrown(com.fasterxml.jackson.databind.JsonMappingException)
+        thrown(JsonMappingException)
     }
 
     def "Klum field types define the configurable persistence surface"() {

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JsonExportSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JsonExportSpec.groovy
@@ -179,14 +179,14 @@ class JsonExportSpec extends AbstractDSLSpec {
         def deserialized = mapper.readValue('{"name":"json","child":{"value":"nested"}}', Root)
 
         then:
-        deserialized.name == "json-post-apply"
+        deserialized.name == "json-apply"
         deserialized.child.value == "nested"
         deserialized.child.parent.is(deserialized)
         Root.events == [
-                "postCreate:json",
-                "postApply:json-post",
-                "postTree:json-post-apply:true",
-                "validate:json-post-apply:Root"
+                "postCreate:initializer",
+                "postApply:json",
+                "postTree:json-apply:true",
+                "validate:json-apply:Root"
         ]
         !deserialized.metaClass.respondsTo(deserialized, "apply", Closure)
     }

--- a/wiki/Builder-First-Migration.md
+++ b/wiki/Builder-First-Migration.md
@@ -122,7 +122,15 @@ accepts `KlumObjectSupport.of(object)` as the future Java-first path/structure/v
 `KlumModelProxy` plus raw metadata internal. Until #390 implements that boundary, do not build new integrations on direct
 proxy or metadata access.
 
-The current Jackson implementation restores raw serialized state into Builders. [ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md)
-accepts configuration replay as the 4.0 target: persist public Builder inputs, bind resolved Jackson properties, and run
-one normal lifecycle so derived values are recomputed. #428/#251 track implementation; existing JSON remains beta and may
-change.
+Jackson now replays public Builder configuration through resolved property metadata. Missing input preserves source
+initializers and later defaults; present values, `null`, and containers replace current Builder state authoritatively between
+`PostCreate` and `PostApply`. Derived output must be `PROTECTED`, ignored, or explicitly Jackson read-only so the single
+normal lifecycle recomputes it instead of restoring it.
+
+Rename migrated JSON with `@JsonAlias` while keeping the new `@JsonProperty` name canonical. Configured naming strategies,
+mixins, ignore/access rules, and unknown-property policy are resolved by Jackson. Ambient Templates, `@Overwrite`, and
+`copyFrom` no longer affect JSON input. See [[Jackson Integration]] and
+[ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md).
+
+`LINK` identity/forward references remain #440 scope. Marked Templates remain unsupported Jackson values, but reliable
+rejection depends on #438's stable completed Template identity; do not serialize Templates in the interim.

--- a/wiki/Jackson-Integration.md
+++ b/wiki/Jackson-Integration.md
@@ -8,15 +8,17 @@ KlumAST provides optional integration for Jackson in the optional `klum-ast-jack
 This provides helpers for serialization and deserialization of Klum objects:
 
 - Using `KlumAnnotationIntrospector`, Owner fields, `@Role`-annotated members and members whose name contains `$` are automatically ignored during serialization (they are _not_ converted into back references, since this would usually be done during deserialization anyway)
-- the module's internal `KlumDeserializer` reads JSON object state and restores it through generated Builders rather than partially initialized DSL Objects
+- the module's internal `KlumDeserializer` replays resolved Jackson properties into generated Builders rather than partially initialized DSL Objects
+- owned nested DSL values are populated as Builders in the same Construction session
 - after binding, the normal lifecycle, graph materialization, validation, and verification pipeline produces the completed DSL Object
 - All enhancements are packaged into a Jackson module (KlumAstModule)
 
-The current raw-state implementation is transitional. [ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md)
-accepts configuration replay as the stable target: persisted public Builder inputs are bound through resolved Jackson
-properties and one normal lifecycle recomputes derived values. [Issue #428](https://github.com/klum-dsl/klum-ast/issues/428)
-tracks that implementation, including renamed properties from #251 and explicit `LINK` identity. Until it lands, mutating
-lifecycle callbacks should remain idempotent and existing JSON may change.
+[ADR 0007](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0007-jackson-configuration-replay.md)
+defines this as configuration replay: JSON persists public Builder configuration intent, not a snapshot of every completed
+field. [Issue #439](https://github.com/klum-dsl/klum-ast/issues/439) implements the property-aware JSON-1 slice, including
+renamed and aliased properties from #251. Existing beta JSON may change when moving from the earlier raw-state behavior.
+
+> JSON serialized by different KlumAST versions is not guaranteed to be mutually compatible.
 
 # Usage
 
@@ -52,6 +54,57 @@ It is also possible to register the module explicitly:
 ```java
 ObjectMapper mapper = new ObjectMapper().registerModule(new KlumAstModule());
 ```
+
+# Configuration replay
+
+Jackson allocates each root and owned child Builder with its source initializers, then executes this order:
+
+1. `PostCreate`
+2. bind properties that are present in JSON
+3. `PostApply`
+4. the normal graph phases, materialization, validation, and verification
+
+Missing properties leave initializer, default, auto-create, or lifecycle behavior intact. A present scalar replaces the
+current value; present `null` clears a nullable value; and a present container replaces the initialized container, with an
+empty container clearing it. JSON binding does not apply ambient Templates, `@Overwrite`, or `copyFrom` merge behavior.
+
+The persistence input surface is the public configurable Builder surface. Owner, Role, synthetic, `PROTECTED`, `IGNORED`,
+and `BUILDER` state is not input. `PROTECTED` state is read-only output; other lifecycle-derived output should be marked
+read-only explicitly:
+
+```groovy
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@DSL
+class Person {
+    @JsonProperty("display_name")
+    @JsonAlias("name")
+    String configuredName
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    String normalizedName
+
+    @PostApply
+    void normalize() {
+        normalizedName = configuredName?.trim()
+    }
+}
+```
+
+Resolved `@JsonProperty` names, `@JsonAlias`, configured naming strategies, mixins, ignore/access rules, and the mapper's
+unknown-property policy are honored. Serialization uses the same external property metadata. An explicit type-level custom
+deserializer opts that DSL type out of Klum configuration replay.
+
+# Current boundaries
+
+JSON-1 does not implement `LINK` identity or forward references, `@JsonCreator`, direct model setters, Jackson Builder
+construction, completed-model owned deserializers, managed/back-reference ownership replacement, or polymorphic owned DSL
+subtypes. Those boundaries remain with [#440](https://github.com/klum-dsl/klum-ast/issues/440).
+
+Marked Templates are unsupported Jackson values. Reliable rejection is blocked until
+[#438](https://github.com/klum-dsl/klum-ast/issues/438) gives completed Templates stable identity separate from ordinary
+models; until then, do not pass Templates to an `ObjectMapper`.
 
 # Extend
 

--- a/wiki/Migration.md
+++ b/wiki/Migration.md
@@ -5,7 +5,7 @@ Migration Guide
 
 4.0 replaces the generated mutable RW object with a true Builder and materializes a completed, structurally immutable DSL Object graph before validation. Completed models no longer expose generated `apply`, owned composition cannot adopt already completed objects, lifecycle extensions are split at the new `INSTANTIATE` phase, and collection declarations now have explicit snapshot-safe limits.
 
-See the dedicated [[Builder First Migration]] guide for the complete migration checklist, compatibility breaks, Template behavior, and the explicitly provisional Jackson policy.
+See the dedicated [[Builder First Migration]] guide for the complete migration checklist, compatibility breaks, Template behavior, and Jackson configuration-replay migration.
 
 # to 2.2
 


### PR DESCRIPTION
## Summary

Implements the JSON-1 property-aware configuration replay slice from #439 and ADR 0007.

- Replaces raw serialized-state key copying with resolved Jackson property metadata for the public configurable Builder surface.
- Allocates source-initialized root and owned child Builders in one Construction session, runs `PostCreate`, binds present input authoritatively, runs `PostApply`, then executes one normal graph lifecycle, materialization, validation, and verification.
- Defines deterministic missing versus present/`null`/empty replacement behavior.
- Honors resolved `@JsonProperty`, `@JsonAlias`, naming strategies, mixins, access/ignore rules, serialization names, and unknown-property policy.
- Preserves explicit type-level custom-deserializer opt-out behavior.
- Synchronizes ADR status, implementation guidance, Jackson documentation, migration navigation, and `CHANGES.md`.

## Compatibility and scope

This intentionally changes the beta JSON behavior from completed-state restoration to configuration replay. JSON produced by different KlumAST versions is not guaranteed to be mutually compatible.

`LINK` identity and forward references remain #440 scope. Marked Templates remain unsupported Jackson values, but reliable completed-Template rejection is retained as executable pending coverage blocked by #438. JSON format/version metadata is tracked separately in #447.

## Validation

- `./gradlew :klum-ast-jackson:test`
- `./gradlew check groovy4Tests groovy5Tests`
- `git diff --check origin/master...HEAD`
- Final two-axis review: no documented-standard violations and no actionable spec discrepancies

Closes #439
Addresses #251
Part of #428
