### PR TITLE
Add stored validation support and internalize model companions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,9 @@ This is a breaking release. See the [Builder-first construction migration](https
 - Added the Java-first `KlumObjectSupport.of(completedObject)` facade for a completed DSL Object root or subtree. Its
   provenance getters and composition-only `Structure` helper expose paths, direct ownership, relative paths, and
   cycle-safe typed traversal. Its `Validation` helper reads and verifies stored target/subtree results without rerunning
-  validators. The Model companion and generic metadata access are now internal ([#435](https://github.com/klum-dsl/klum-ast/issues/435),
+  validators. Subtree result lists include every stored result, including results without issues; the deprecated
+  `Validator.getValidationResultsFromStructure` and `verifyStructure` adapters now inherit that broader list contract.
+  The Model companion and generic metadata access are now internal ([#435](https://github.com/klum-dsl/klum-ast/issues/435),
   [#390](https://github.com/klum-dsl/klum-ast/issues/390),
   [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md)).
 - Split the generated internal companion into sealed Model and Template variants. Ordinary models retain no deferred

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,9 @@ This is a breaking release. See the [Builder-first construction migration](https
   [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md)).
 - Added the Java-first `KlumObjectSupport.of(completedObject)` facade for a completed DSL Object root or subtree. Its
   provenance getters and composition-only `Structure` helper expose paths, direct ownership, relative paths, and
-  cycle-safe typed traversal without exposing the internal Model companion ([#435](https://github.com/klum-dsl/klum-ast/issues/435),
+  cycle-safe typed traversal. Its `Validation` helper reads and verifies stored target/subtree results without rerunning
+  validators. The Model companion and generic metadata access are now internal ([#435](https://github.com/klum-dsl/klum-ast/issues/435),
+  [#390](https://github.com/klum-dsl/klum-ast/issues/390),
   [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md)).
 - Split the generated internal companion into sealed Model and Template variants. Ordinary models retain no deferred
   actions; every owned Template node carries persistent recipe identity and paths, while pre-existing ordinary `LINK`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,8 +82,8 @@ These terms are sourced from the project wiki and consolidated here. Use these c
   Completed-model phase traversal uses this helper directly, while Builder phases use a separate internal Builder structure
   helper. The shared internal composition walker owns only traversal mechanics and is not a client extension seam.
 
-  OS-2 adds the stored-validation helper (`getValidation`) and moves remaining completed-model validation readers away from
-  companion access. It must read existing results only: it never reruns validators or mutates lifecycle issue state.
+  Its Validation helper (`getValidation`) reads stored target/subtree results and verifies them without rerunning validators
+  or mutating lifecycle issue state. Completed-model validation readers do not access the companion directly.
 
 - Construction API
 

--- a/docs/adr/0006-completed-object-support.md
+++ b/docs/adr/0006-completed-object-support.md
@@ -7,9 +7,8 @@ Status: Accepted
 Tracking issue: [#390 — Stable Entry object for internal methods](https://github.com/klum-dsl/klum-ast/issues/390)
 
 Implementation status: OS-1 provenance and structure support is implemented in [#435](https://github.com/klum-dsl/klum-ast/issues/435).
-OS-2 validation support and companion lockdown, and OS-3 documentation closure, remain planned. Current utilities and the
-public-looking `KlumModelProxy.getProxyFor` still expose an incomplete and overly powerful boundary. See the
-[implementation plan](../implementation/adr-0006-completed-object-support.md).
+OS-2 validation support and companion lockdown are implemented. OS-3 documentation and compatibility closure remains
+planned. See the [implementation plan](../implementation/adr-0006-completed-object-support.md).
 
 Parent decision: [ADR 0003 — Builder-first materialization of DSL Objects](0003-builder-first-materialization.md)
 

--- a/docs/implementation/adr-0006-completed-object-support.md
+++ b/docs/implementation/adr-0006-completed-object-support.md
@@ -3,7 +3,7 @@
 This plan implements [ADR 0006](../adr/0006-completed-object-support.md) for canonical issue
 [#390](https://github.com/klum-dsl/klum-ast/issues/390).
 
-## Current behavior and failure
+## Original behavior and failure
 
 `KlumModelProxy.getProxyFor` is publicly callable and exposes breadcrumb/model paths, raw metadata, validation state, and
 Template-era deferred closures. `DslHelper`, `StructureUtil`, and validation handlers expose only fragments of the intended
@@ -25,7 +25,7 @@ Add `KlumObjectSupport.of(object)` with `getObject`, both path getters, and `get
 hierarchy, composition-only cycle-safe visit/find-all, and relative paths. Make existing `StructureUtil` delegate where
 compatible. Demonstrate Java use against both a root and subtree without exposing the companion.
 
-### OS-2 — Stored validation facade and proxy lockdown
+### OS-2 — Stored validation facade and proxy lockdown — Implemented
 
 Add `getValidation()` with target/subtree result access and non-rerunning `verify` operations. Move supported callers off
 `KlumModelProxy`, internalize its lookup and raw metadata, and add migration diagnostics/deprecations where source

--- a/docs/implementation/issue-curation/architecture-map.md
+++ b/docs/implementation/issue-curation/architecture-map.md
@@ -45,7 +45,7 @@ The accepted target client interface is the schema annotations plus generated `F
 and nested Collection/Cluster factories), with `Foo.Create` typed to `Foo_DSL.Factory`. Clients may name but not implement
 these interfaces. Current `$_RW`, `KlumRwObject`, `@DelegatesToRW`, and `KlumInstanceProxy` remain compatibility details
 pending ADR 0005 implementation. Completed objects use `KlumObjectSupport`; direct `KlumModelProxy` access is not supported
-by ADR 0006, although current source still exposes it.
+by ADR 0006 and the Model companion is package-internal.
 
 ADR 0005 also requires AnnoDocimal `Foo_DSL` source mirrors to be IDE-only metadata. DSL-G adds a cacheable
 `createKlumDslSourceMirrors` task and registers its output only as an IDEA generated source root. Developers run the task
@@ -76,9 +76,11 @@ Additional invariants:
 - Source initializers execute once when a Builder is allocated. `FieldType.BUILDER` state is omitted from the model. Non-transient, non-relationship model fields become final.
 - Builder relationship storage contains Builders. A pre-existing completed DSL Object is wrapped by a sealed Builder and accepted only for `FieldType.LINK`; owned composition must be created in the owner's session. Nested root factories are rejected.
 - Materialization publishes independent read-only snapshots for `List`, `Set`, `SortedSet`/`NavigableSet`, `Map`, `SortedMap`/`NavigableMap`; comparators are retained. `EnumSet` is defensive. Unsupported concrete/custom collection declarations fail schema compilation. Simple Values are retained, not deep-copied.
-- Generated models retain a sealed internal `KlumObjectCompanion`. `KlumModelProxy` stores ordinary completed-model paths,
-  metadata, validation results, and validator memoization without deferred actions; `KlumTemplateProxy` stores graph-wide
+- Generated models retain a sealed internal `KlumObjectCompanion`. The package-internal Model companion stores ordinary
+  completed-model paths, metadata, validation results, and validator memoization without deferred actions; `KlumTemplateProxy` stores graph-wide
   Template identity and immutable serializable `TemplateRecipeState`. Neither retains the creating Builder.
+- `KlumObjectSupport.Validation` reads stored target/subtree results and verifies them without executing validators or
+  mutating lifecycle issue state. Generic Builder/Model metadata access is internal lifecycle linkage, not an extension seam.
 - Templates copy values/composition and replay cloned recipe actions into fresh Builders. Every owned Template node is
   marked, pre-existing ordinary `LINK` targets retain identity, and no Template may be a relationship or JSON value.
 - `StructureUtil.visit` is identity-cycle-safe and follows composition only: declared fields are traversed, while owner and `LINK` fields are skipped. Builder phase traversal also skips sealed aggregation wrappers. Paths use GPath-like field, index, and map-key segments.
@@ -116,8 +118,8 @@ Compiler-version seams are concentrated in `klum-ast`: [`Groovy3To4MigrationHelp
 - [ADR 0004](../../adr/0004-asbuilder-composition-protocol.md) is **Accepted target behavior but not implemented**. The confirmed failure paths and pending tests are indexed in [`adr-0004-asbuilder-composition.md`](../adr-0004-asbuilder-composition.md).
 - [ADR 0005](../../adr/0005-generated-dsl-support-api.md) accepts `Foo_DSL` and Builder vocabulary; only DSL-G's Gradle
   mirror lifecycle is implemented.
-- [ADR 0006](../../adr/0006-completed-object-support.md) accepts `KlumObjectSupport`. OS-1 provenance and composition
-  structure support is implemented; OS-2 stored-validation support and companion lockdown remain planned.
+- [ADR 0006](../../adr/0006-completed-object-support.md) accepts `KlumObjectSupport`. OS-1 provenance/composition support
+  and OS-2 stored-validation support/companion lockdown are implemented; OS-3 compatibility closure remains planned.
 - [ADR 0007](../../adr/0007-jackson-configuration-replay.md) accepts configuration replay; it is not implemented.
 - [ADR 0008](../../adr/0008-phase-registration.md) accepts a later-4.x registration SPI; it is not implemented.
 

--- a/docs/implementation/issue-curation/architecture-map.md
+++ b/docs/implementation/issue-curation/architecture-map.md
@@ -128,8 +128,8 @@ Confirmed deferred gaps, not current capabilities:
 - ADR 0004 AB-1/AB-2/AB-3 are implemented. Regular opaque scripts returning completed models remain top-level-only, and
   #431 retains final compatibility closure.
 - Generated `Foo_DSL` AST layout (#394) and Jackson configuration replay (#428/#251) are decided but not implemented.
-  Completed-object support (#390) has its OS-1 provenance/structure slice implemented; OS-2 validation and proxy-lockdown
-  work remains. The DSL-G Gradle mirror lifecycle is implemented independently. Declarative phase registration (#305) is
-  decided and deferred to later 4.x.
+  Completed-object support (#390) has its OS-1 provenance/structure and OS-2 validation/proxy-lockdown slices implemented;
+  OS-3 compatibility closure remains. The DSL-G Gradle mirror lifecycle is implemented independently. Declarative phase
+  registration (#305) is decided and deferred to later 4.x.
 
 **Analyst hypothesis:** issue coupling is highest where generated composition projections (`AlternativesClassBuilder`/`ConverterBuilder`) call model-returning factories (`KlumFactory`/`FactoryHelper`) and then cross `KlumBuilder.normalizeRelationshipValue`. Verify that path for each factory/converter issue; do not assume all converter or script inputs share it.

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
@@ -25,7 +25,7 @@ package com.blackbuild.klum.ast.process;
 
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumModelException;
-import com.blackbuild.klum.ast.util.KlumModelProxy;
+import com.blackbuild.klum.ast.util.InternalKlumObjectSupport;
 import groovy.lang.Closure;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -180,7 +180,7 @@ public class PhaseDriver {
             if (object instanceof KlumBuilder)
                 ((KlumBuilder<?>) object).setModelPath("<root>");
             else
-                KlumModelProxy.getProxyFor(object).setModelPathIfAbsent("<root>");
+                InternalKlumObjectSupport.setModelPathIfAbsent(object, "<root>");
         }
         driver.activeObjectPointer++;
     }

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumObjectSupport.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.util;
+
+import com.blackbuild.klum.ast.validation.KlumValidationResult;
+
+/**
+ * Internal cross-package lifecycle linkage for completed DSL Object state.
+ *
+ * <p>This class is public only because validation and process implementations live in sibling runtime packages.
+ * It is not supported client API and deliberately exposes no companion or generic metadata operations.</p>
+ */
+public final class InternalKlumObjectSupport {
+
+    private InternalKlumObjectSupport() {
+        // static only
+    }
+
+    /** Returns stored validation state for a Builder or completed model without creating it. */
+    public static KlumValidationResult getValidationResult(Object instance) {
+        if (instance instanceof KlumBuilder<?> builder)
+            return builder.getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+        return KlumModelProxy.getProxyFor(instance)
+                .getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+    }
+
+    /** Returns lifecycle validation state for a Builder or completed model, creating it when absent. */
+    public static KlumValidationResult getOrCreateValidationResult(Object instance) {
+        KlumValidationResult existing = getValidationResult(instance);
+        if (existing != null)
+            return existing;
+
+        KlumValidationResult created = new KlumValidationResult(DslHelper.getModelAndBreadcrumbPath(instance));
+        if (instance instanceof KlumBuilder<?> builder)
+            builder.setMetaData(KlumValidationResult.METADATA_KEY, created);
+        else
+            KlumModelProxy.getProxyFor(instance).setMetaData(KlumValidationResult.METADATA_KEY, created);
+        return created;
+    }
+
+    /** Marks one completed-model validator implementation as executed. */
+    public static boolean markValidatorExecuted(Object instance, Class<?> validatorType) {
+        return KlumModelProxy.getProxyFor(instance).markValidatorExecuted(validatorType);
+    }
+
+    /** Initializes a completed root's model path when materialization has not supplied one. */
+    public static void setModelPathIfAbsent(Object instance, String path) {
+        KlumModelProxy.getProxyFor(instance).setModelPathIfAbsent(path);
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
@@ -1192,7 +1192,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
         currentTemplates = Collections.emptyMap();
     }
 
-    public boolean hasMetaData(String key) {
+    boolean hasMetaData(String key) {
         return metadata.containsKey(key);
     }
 
@@ -1206,7 +1206,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
      * @return the stored value, or {@code null} if no value is stored
      * @throws KlumException if the stored value is not of the requested type
      */
-    public <T> T getMetaData(String key, Class<T> type) {
+    <T> T getMetaData(String key, Class<T> type) {
         Object value = metadata.get(key);
         if (value == null)
             return null;
@@ -1222,7 +1222,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
      * @param value a value whose complete object graph is serializable, or {@code null}
      * @throws KlumException if {@code value} or anything reachable from it is not serializable
      */
-    public void setMetaData(String key, Object value) {
+    void setMetaData(String key, Object value) {
         metadata.put(key, KlumModelProxy.requireSerializableMetadataValue(key, value));
     }
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumBuilder.java
@@ -349,7 +349,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
         return Collections.unmodifiableMap(copy);
     }
 
-    public final ModelState exportModelState() {
+    final ModelState exportModelState() {
         return new ModelState(getBreadcrumbPath(), modelPath, metadata);
     }
 
@@ -368,7 +368,7 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
         return new KlumModelProxy(model, exportModelState());
     }
 
-    public static final class ModelState implements Serializable {
+    static final class ModelState implements Serializable {
         private final String breadcrumbPath;
         private final String modelPath;
         private final Map<String, Serializable> metadata;
@@ -379,15 +379,15 @@ public abstract class KlumBuilder<M> extends GroovyObjectSupport implements Klum
             this.metadata = new HashMap<>(metadata);
         }
 
-        public String getBreadcrumbPath() {
+        String getBreadcrumbPath() {
             return breadcrumbPath;
         }
 
-        public String getModelPath() {
+        String getModelPath() {
             return modelPath;
         }
 
-        public Map<String, Serializable> getMetadata() {
+        Map<String, Serializable> getMetadata() {
             return metadata;
         }
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumInstanceProxy.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumInstanceProxy.java
@@ -33,11 +33,11 @@ import java.util.Map;
 /**
  * Builder-only compatibility adapter for code written against the former RW proxy.
  *
- * <p>New runtime code belongs on {@link KlumBuilder} or {@link KlumModelProxy}.
+ * <p>New construction code belongs on {@link KlumBuilder}; completed-model inspection uses {@link KlumObjectSupport}.
  * Looking up this adapter for a completed model is intentionally rejected.</p>
  *
  * @deprecated since 4.0; use {@link KlumBuilder} for construction state and
- * {@link KlumModelProxy} for completed-model companion state
+ * {@link KlumObjectSupport} for completed-model inspection
  */
 @Deprecated(since = "4.0", forRemoval = true)
 @SuppressWarnings({"unused", "java:S1133", "java:S1452"}) // compatibility adapter until its documented 4.x removal
@@ -77,7 +77,7 @@ public final class KlumInstanceProxy {
     private static KlumException completedModelLookupFailure(Object target) {
         return new KlumException("KlumInstanceProxy is Builder-only; completed DSL Object "
                 + target.getClass().getName()
-                + " must use KlumModelProxy for model metadata or a generated factory for construction");
+                + " must use KlumObjectSupport for supported inspection or a generated factory for construction");
     }
 
     protected GroovyObject getRwInstance() {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumModelProxy.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumModelProxy.java
@@ -47,9 +47,9 @@ import static java.lang.String.format;
  * <p>This companion deliberately contains no construction-time mutation API and
  * never retains the Builder that created the model.</p>
  */
-public final class KlumModelProxy implements KlumObjectCompanion {
+final class KlumModelProxy implements KlumObjectCompanion {
 
-    public static final String NAME_IN_MODEL = "$proxy";
+    static final String NAME_IN_MODEL = KlumObjectCompanion.NAME_IN_MODEL;
 
     @SuppressWarnings("java:S1948") // generated DSL model implementations are always Serializable
     private final GroovyObject model;
@@ -58,7 +58,7 @@ public final class KlumModelProxy implements KlumObjectCompanion {
     private final Map<String, Serializable> metadata;
     private final Set<Class<?>> executedValidators = new HashSet<>();
 
-    public KlumModelProxy(GroovyObject model, KlumBuilder.ModelState state) {
+    KlumModelProxy(GroovyObject model, KlumBuilder.ModelState state) {
         this.model = model;
         this.breadcrumbPath = state.getBreadcrumbPath();
         this.modelPath = state.getModelPath();
@@ -68,7 +68,7 @@ public final class KlumModelProxy implements KlumObjectCompanion {
     /**
      * Returns the companion for a completed DSL Object.
      */
-    public static KlumModelProxy getProxyFor(Object target) {
+    static KlumModelProxy getProxyFor(Object target) {
         KlumObjectCompanion companion = KlumTemplateProxy.companionFor(target);
         if (companion instanceof KlumModelProxy modelProxy)
             return modelProxy;
@@ -97,12 +97,12 @@ public final class KlumModelProxy implements KlumObjectCompanion {
         return modelPath;
     }
 
-    public void setModelPathIfAbsent(String path) {
+    void setModelPathIfAbsent(String path) {
         if (modelPath == null)
             modelPath = path;
     }
 
-    public boolean hasMetaData(String key) {
+    boolean hasMetaData(String key) {
         return metadata.containsKey(key);
     }
 
@@ -116,7 +116,7 @@ public final class KlumModelProxy implements KlumObjectCompanion {
      * @return the stored value, or {@code null} if no value is stored
      * @throws KlumException if the stored value is not of the requested type
      */
-    public <T> T getMetaData(String key, Class<T> type) {
+    <T> T getMetaData(String key, Class<T> type) {
         Object value = metadata.get(key);
         if (value == null)
             return null;
@@ -132,7 +132,7 @@ public final class KlumModelProxy implements KlumObjectCompanion {
      * @param value a value whose complete object graph is serializable, or {@code null}
      * @throws KlumException if {@code value} or anything reachable from it is not serializable
      */
-    public void setMetaData(String key, Object value) {
+    void setMetaData(String key, Object value) {
         metadata.put(key, requireSerializableMetadataValue(key, value));
     }
 
@@ -159,18 +159,18 @@ public final class KlumModelProxy implements KlumObjectCompanion {
      *
      * @return true only for the first execution of the validator type
      */
-    public boolean markValidatorExecuted(Class<?> validatorType) {
+    boolean markValidatorExecuted(Class<?> validatorType) {
         return executedValidators.add(validatorType);
     }
 
-    public Object getSingleOwner() {
+    Object getSingleOwner() {
         Set<Object> owners = getOwners();
         if (owners.size() > 1)
             throw new KlumModelException("Object has more than one distinct owner");
         return owners.stream().findFirst().orElse(null);
     }
 
-    public Set<Object> getOwners() {
+    Set<Object> getOwners() {
         return DslHelper.getFieldsAnnotatedWith(model.getClass(), Owner.class)
                 .filter(field -> field.getAnnotation(Owner.class).converter() == NoClosure.class)
                 .filter(field -> !field.getAnnotation(Owner.class).transitive())

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectCompanion.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectCompanion.java
@@ -35,6 +35,9 @@ import java.io.Serializable;
  */
 public sealed interface KlumObjectCompanion extends Serializable permits KlumModelProxy, KlumTemplateProxy {
 
+    /** Generated private field name; public only for compiler/runtime linkage. */
+    String NAME_IN_MODEL = "$proxy";
+
     GroovyObject getObject();
 
     String getBreadcrumbPath();

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -117,8 +117,7 @@ public final class KlumObjectSupport<T> {
 
         /** Returns the validation result stored for this object, or {@code null} when no result was recorded. */
         public KlumValidationResult getResult() {
-            return KlumModelProxy.getProxyFor(object)
-                    .getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+            return InternalKlumObjectSupport.getValidationResult(object);
         }
 
         /**
@@ -128,7 +127,7 @@ public final class KlumObjectSupport<T> {
         public List<KlumValidationResult> getResults() {
             List<KlumValidationResult> results = new ArrayList<>();
             KlumObjectSupport.of(object).getStructure().visit((path, element, container, nameOfFieldInContainer) -> {
-                KlumValidationResult result = KlumObjectSupport.of(element).getValidation().getResult();
+                KlumValidationResult result = InternalKlumObjectSupport.getValidationResult(element);
                 if (result != null)
                     results.add(result);
             });

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -23,9 +23,12 @@
  */
 package com.blackbuild.klum.ast.util;
 
+import com.blackbuild.groovy.configdsl.transform.Validate;
 import com.blackbuild.klum.ast.util.layer3.CompositionTraversal;
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
 import com.blackbuild.klum.ast.util.layer3.StructuralPath;
+import com.blackbuild.klum.ast.validation.KlumValidationResult;
+import com.blackbuild.klum.ast.validation.Validator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,6 +92,61 @@ public final class KlumObjectSupport<T> {
     /** Returns composition structure support rooted at this completed DSL Object. */
     public Structure<T> getStructure() {
         return new Structure<>(object);
+    }
+
+    /** Returns stored validation support rooted at this completed DSL Object. */
+    public Validation<T> getValidation() {
+        return new Validation<>(object);
+    }
+
+    /**
+     * Stored validation support rooted at a completed DSL Object.
+     *
+     * <p>This helper only reads results recorded by the construction lifecycle. It never executes validators,
+     * creates validation results, or mutates recorded issues.</p>
+     *
+     * @param <T> the root object type
+     */
+    public static final class Validation<T> {
+
+        private final T object;
+
+        private Validation(T object) {
+            this.object = object;
+        }
+
+        /** Returns the validation result stored for this object, or {@code null} when no result was recorded. */
+        public KlumValidationResult getResult() {
+            return KlumModelProxy.getProxyFor(object)
+                    .getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+        }
+
+        /**
+         * Returns stored validation results containing issues for this object and its owned composition subtree.
+         * Owner and {@code LINK} fields are not followed.
+         */
+        public List<KlumValidationResult> getResults() {
+            List<KlumValidationResult> results = new ArrayList<>();
+            KlumObjectSupport.of(object).getStructure().visit((path, element, container, nameOfFieldInContainer) -> {
+                KlumValidationResult result = KlumObjectSupport.of(element).getValidation().getResult();
+                if (result != null && result.has(Validate.Level.INFO))
+                    results.add(result);
+            });
+            return List.copyOf(results);
+        }
+
+        /** Verifies stored subtree results using the configured validation failure level. */
+        public List<KlumValidationResult> verify() throws KlumValidationException {
+            return verify(Validator.getFailLevel());
+        }
+
+        /** Verifies stored subtree results using {@code failLevel}. */
+        public List<KlumValidationResult> verify(Validate.Level failLevel) throws KlumValidationException {
+            Objects.requireNonNull(failLevel, "failLevel");
+            List<KlumValidationResult> results = getResults();
+            KlumValidationResult.throwOn(results, failLevel);
+            return results;
+        }
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -122,14 +122,14 @@ public final class KlumObjectSupport<T> {
         }
 
         /**
-         * Returns stored validation results containing issues for this object and its owned composition subtree.
+         * Returns stored validation results for this object and its owned composition subtree.
          * Owner and {@code LINK} fields are not followed.
          */
         public List<KlumValidationResult> getResults() {
             List<KlumValidationResult> results = new ArrayList<>();
             KlumObjectSupport.of(object).getStructure().visit((path, element, container, nameOfFieldInContainer) -> {
                 KlumValidationResult result = KlumObjectSupport.of(element).getValidation().getResult();
-                if (result != null && result.has(Validate.Level.INFO))
+                if (result != null)
                     results.add(result);
             });
             return List.copyOf(results);

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/VerifyPhase.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/VerifyPhase.java
@@ -26,7 +26,6 @@ package com.blackbuild.klum.ast.util;
 import com.blackbuild.klum.ast.process.AbstractPhaseAction;
 import com.blackbuild.klum.ast.process.DefaultKlumPhase;
 import com.blackbuild.klum.ast.process.PhaseDriver;
-import com.blackbuild.klum.ast.validation.Validator;
 
 /**
  * Phase Action that validates the model.
@@ -41,7 +40,7 @@ public class VerifyPhase extends AbstractPhaseAction {
 
     @Override
     protected void doExecute() {
-        Validator.verifyStructure(PhaseDriver.getInstance().getRootObject());
+        KlumObjectSupport.of(PhaseDriver.getInstance().getRootObject()).getValidation().verify();
     }
 
     @Override

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructureUtil.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/layer3/StructureUtil.java
@@ -26,7 +26,6 @@ package com.blackbuild.klum.ast.util.layer3;
 import com.blackbuild.klum.ast.util.KlumException;
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumObjectSupport;
-import com.blackbuild.klum.ast.util.KlumModelProxy;
 import com.blackbuild.klum.ast.util.KlumSchemaException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -348,7 +347,7 @@ public class StructureUtil {
             if (leaf instanceof KlumBuilder)
                 leaf = ((KlumBuilder<?>) leaf).getSingleOwner();
             else
-                leaf = KlumModelProxy.getProxyFor(leaf).getSingleOwner();
+                leaf = KlumObjectSupport.of(leaf).getStructure().getSingleOwner().orElse(null);
         }
         return result;
      }
@@ -357,7 +356,7 @@ public class StructureUtil {
         if (!isDslObject(value))
             return false;
         try {
-            KlumModelProxy.getProxyFor(value);
+            KlumObjectSupport.of(value);
             return true;
         } catch (KlumException ignored) {
             return false;

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/SingleObjectValidationHandler.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/SingleObjectValidationHandler.java
@@ -24,8 +24,7 @@
 package com.blackbuild.klum.ast.validation;
 
 import com.blackbuild.klum.ast.process.PhaseDriver;
-import com.blackbuild.klum.ast.util.DslHelper;
-import com.blackbuild.klum.ast.util.KlumModelProxy;
+import com.blackbuild.klum.ast.util.InternalKlumObjectSupport;
 
 import java.util.ServiceLoader;
 
@@ -46,16 +45,7 @@ class SingleObjectValidationHandler {
     }
 
     public KlumValidationResult getOrCreateValidationResult() {
-        KlumValidationResult existingResult = KlumModelProxy.getProxyFor(instance).getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
-
-        if (existingResult != null) {
-            return existingResult;
-        }
-
-        String breadcrumbPath = DslHelper.getModelAndBreadcrumbPath(instance);
-        KlumValidationResult validationIssues = new KlumValidationResult(breadcrumbPath);
-        KlumModelProxy.getProxyFor(instance).setMetaData(KlumValidationResult.METADATA_KEY, validationIssues);
-        return validationIssues;
+        return InternalKlumObjectSupport.getOrCreateValidationResult(instance);
     }
 
     public KlumValidationResult execute() {
@@ -69,9 +59,8 @@ class SingleObjectValidationHandler {
 
     private KlumValidationResult validateInstance() {
         KlumValidationResult validationResult = getOrCreateValidationResult();
-        KlumModelProxy modelProxy = KlumModelProxy.getProxyFor(instance);
         ServiceLoader.load(InstanceValidator.class).forEach(handler -> {
-            if (modelProxy.markValidatorExecuted(handler.getClass()))
+            if (InternalKlumObjectSupport.markValidatorExecuted(instance, handler.getClass()))
                 handler.validateInstance(instance, validationResult);
         });
         return validationResult;

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -233,21 +233,12 @@ public class Validator {
 
     private static KlumValidationResult doGetValidationResult(Object instance) {
         if (instance instanceof KlumBuilder)
-            return ((KlumBuilder<?>) instance).getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+            return InternalKlumObjectSupport.getValidationResult(instance);
         return KlumObjectSupport.of(instance).getValidation().getResult();
     }
 
     private static KlumValidationResult doGetOrCreateValidationResult(Object instance) {
-        if (instance instanceof KlumBuilder) {
-            KlumBuilder<?> builder = (KlumBuilder<?>) instance;
-            if (!builder.hasMetaData(KlumValidationResult.METADATA_KEY))
-                builder.setMetaData(KlumValidationResult.METADATA_KEY, new KlumValidationResult(DslHelper.getModelAndBreadcrumbPath(instance)));
-        } else {
-            KlumModelProxy proxy = KlumModelProxy.getProxyFor(instance);
-            if (!proxy.hasMetaData(KlumValidationResult.METADATA_KEY))
-                proxy.setMetaData(KlumValidationResult.METADATA_KEY, new KlumValidationResult(DslHelper.getModelAndBreadcrumbPath(instance)));
-        }
-        return doGetValidationResult(instance);
+        return InternalKlumObjectSupport.getOrCreateValidationResult(instance);
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -89,11 +89,10 @@ public class Validator {
     }
 
     /**
-     * Retrieves the validation result for the given instance, either from the proxy or by performing a lenient validation.
-     * This method is useful when you want to check the validation results without throwing an exception.
+     * Retrieves the validation result already stored for the given instance without executing validators.
      *
-     * @param instance the instance to validate
-     * @return a {@link KlumValidationResult} containing validation errors
+     * @param instance the instance whose stored validation result is requested
+     * @return the stored {@link KlumValidationResult}, or {@code null} when none was recorded
      * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().getResult()} for a completed DSL Object
      */
     @Deprecated(forRemoval = true)

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -26,11 +26,9 @@ package com.blackbuild.klum.ast.validation;
 import com.blackbuild.groovy.configdsl.transform.Validate;
 import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.util.*;
-import com.blackbuild.klum.ast.util.layer3.ModelVisitor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -52,11 +50,12 @@ public class Validator {
      *
      * @param instance the instance to validate the structure of. Must be a DSL object.
      * @return a list of {@link KlumValidationResult} containing validation errors.
+     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().getResults()}
      */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("java:S1133") // source-compatible OS-2 migration adapter
     public static List<KlumValidationResult> getValidationResultsFromStructure(Object instance) {
-        ValidationResultCollector visitor = new ValidationResultCollector();
-        KlumObjectSupport.of(instance).getStructure().visit(visitor);
-        return visitor.aggregatedErrors;
+        return KlumObjectSupport.of(instance).getValidation().getResults();
     }
 
     /**
@@ -66,9 +65,12 @@ public class Validator {
      * @param instance the instance to validate the structure of. Must be a DSL object.
      * @return a list of {@link KlumValidationResult} containing validation errors.
      * @throws KlumValidationException if validation errors are found with a level equal or worse than the given level.
+     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().verify()}
      */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("java:S1133") // source-compatible OS-2 migration adapter
     public static List<KlumValidationResult> verifyStructure(Object instance) throws KlumValidationException {
-        return verifyStructure(instance, getFailLevel());
+        return KlumObjectSupport.of(instance).getValidation().verify();
     }
 
     /**
@@ -78,24 +80,12 @@ public class Validator {
      * @param failLevel the minimum encountered level to result in an exception.
      * @return a list of {@link KlumValidationResult} containing validation errors.
      * @throws KlumValidationException if validation errors are found with a level equal or worse than the given level.
+     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().verify(failLevel)}
      */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("java:S1133") // source-compatible OS-2 migration adapter
     public static List<KlumValidationResult> verifyStructure(Object instance, Validate.Level failLevel) throws KlumValidationException {
-        ValidationResultCollector visitor = new ValidationResultCollector();
-        KlumObjectSupport.of(instance).getStructure().visit(visitor);
-        KlumValidationResult.throwOn(visitor.aggregatedErrors, failLevel);
-        return visitor.aggregatedErrors;
-    }
-
-    static class ValidationResultCollector implements ModelVisitor {
-
-        private final List<KlumValidationResult> aggregatedErrors = new ArrayList<>();
-
-        @Override
-        public void visit(@NotNull String path, @NotNull Object element, @Nullable Object container, @Nullable String nameOfFieldInContainer) {
-            KlumValidationResult result = getValidationResult(element);
-            if (result != null && result.has(Validate.Level.INFO))
-                aggregatedErrors.add(result);
-        }
+        return KlumObjectSupport.of(instance).getValidation().verify(failLevel);
     }
 
     /**
@@ -104,7 +94,10 @@ public class Validator {
      *
      * @param instance the instance to validate
      * @return a {@link KlumValidationResult} containing validation errors
+     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().getResult()} for a completed DSL Object
      */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("java:S1133") // source-compatible OS-2 migration adapter
     public static KlumValidationResult getValidationResult(Object instance) {
         return doGetValidationResult(instance);
     }
@@ -241,7 +234,7 @@ public class Validator {
     private static KlumValidationResult doGetValidationResult(Object instance) {
         if (instance instanceof KlumBuilder)
             return ((KlumBuilder<?>) instance).getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
-        return KlumModelProxy.getProxyFor(instance).getMetaData(KlumValidationResult.METADATA_KEY, KlumValidationResult.class);
+        return KlumObjectSupport.of(instance).getValidation().getResult();
     }
 
     private static KlumValidationResult doGetOrCreateValidationResult(Object instance) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -231,9 +231,7 @@ public class Validator {
     }
 
     private static KlumValidationResult doGetValidationResult(Object instance) {
-        if (instance instanceof KlumBuilder)
-            return InternalKlumObjectSupport.getValidationResult(instance);
-        return KlumObjectSupport.of(instance).getValidation().getResult();
+        return InternalKlumObjectSupport.getValidationResult(instance);
     }
 
     private static KlumValidationResult doGetOrCreateValidationResult(Object instance) {

--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/KlumInstanceProxyTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/KlumInstanceProxyTest.groovy
@@ -98,6 +98,6 @@ class KlumInstanceProxyTest extends AbstractRuntimeTest {
         then:
         KlumException failure = thrown()
         failure.message.contains("Builder-only")
-        failure.message.contains("KlumModelProxy")
+        failure.message.contains("KlumObjectSupport")
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -35,7 +35,6 @@ import com.blackbuild.klum.ast.doc.DocUtil;
 import com.blackbuild.klum.ast.process.DefaultKlumPhase;
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumFactory;
-import com.blackbuild.klum.ast.util.KlumModelProxy;
 import com.blackbuild.klum.ast.util.KlumObjectCompanion;
 import com.blackbuild.klum.ast.util.layer3.ClusterFactoryBuilder;
 import com.blackbuild.klum.ast.util.reflect.AstReflectionBridge;
@@ -305,7 +304,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         annotatedClass.getModule().addClass(rwClass);
         if (dslParent == null)
-            annotatedClass.addField(KlumModelProxy.NAME_IN_MODEL, ACC_PRIVATE | ACC_SYNTHETIC | ACC_FINAL, OBJECT_COMPANION, null);
+            annotatedClass.addField(KlumObjectCompanion.NAME_IN_MODEL, ACC_PRIVATE | ACC_SYNTHETIC | ACC_FINAL, OBJECT_COMPANION, null);
 
         ClassNode parentProxy = annotatedClass.getNodeMetaData(RWCLASS_METADATA_KEY);
         if (parentProxy == null)
@@ -571,7 +570,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         if (dslParent == null)
             body.addStatement(assignS(
-                    attrX(varX("this"), constX(KlumModelProxy.NAME_IN_MODEL)),
+                    attrX(varX("this"), constX(KlumObjectCompanion.NAME_IN_MODEL)),
                     callX(varX(BUILDER_PARAMETER), "$createCompanion", args(varX("this")))
             ));
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AsBuilderSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/AsBuilderSpec.groovy
@@ -27,7 +27,7 @@ import com.blackbuild.klum.ast.process.ConstructionSession
 import com.blackbuild.klum.ast.util.DslHelper
 import com.blackbuild.klum.ast.util.KlumBuilder
 import com.blackbuild.klum.ast.util.KlumModelException
-import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 
 import java.lang.reflect.Modifier
 import java.util.concurrent.CountDownLatch
@@ -132,7 +132,7 @@ class AsBuilderSpec extends AbstractDSLSpec {
         Child.postTreeCalls == 1
         Child.validationCalls == 1
         instance.child.owner.is(instance)
-        KlumModelProxy.getProxyFor(instance.child).modelPath == '<root>.child'
+        KlumObjectSupport.of(instance.child).modelPath == '<root>.child'
         DslHelper.getBreadcrumbPath(instance.child) == '$/p.Root.With/p.Child.AsBuilder.With'
     }
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BoundTemplatesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BoundTemplatesSpec.groovy
@@ -27,7 +27,7 @@ package com.blackbuild.groovy.configdsl.transform
 
 import com.blackbuild.klum.ast.util.KlumInstanceProxy
 import com.blackbuild.klum.ast.util.KlumException
-import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -1329,7 +1329,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         then:
         instance.name == "Instance"
         instance.activeTemplatesDuringAutoCreate == [:]
-        KlumModelProxy.getProxyFor(instance).model.is(instance)
+        KlumObjectSupport.of(instance).object.is(instance)
 
         when: "the legacy proxy is looked up for a completed model"
         KlumInstanceProxy.getProxyFor(instance)
@@ -1337,7 +1337,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         then:
         def migrationFailure = thrown(KlumException)
         migrationFailure.message.contains("Builder-only")
-        migrationFailure.message.contains("KlumModelProxy")
+        migrationFailure.message.contains("KlumObjectSupport")
 
         when:
         def templatesDuringCreation = null
@@ -1351,7 +1351,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         instance.name == "Overridden"
         templatesDuringCreation == [(clazz): template]
         instance.activeTemplatesDuringAutoCreate == [(clazz): template]
-        KlumModelProxy.getProxyFor(instance).model.is(instance)
+        KlumObjectSupport.of(instance).object.is(instance)
 
     }
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
@@ -27,7 +27,7 @@ import com.blackbuild.klum.ast.KlumRwObject
 import com.blackbuild.klum.ast.util.KlumBuilder
 import com.blackbuild.klum.ast.util.FactoryHelper
 import com.blackbuild.klum.ast.util.KlumModelException
-import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 import com.blackbuild.klum.ast.validation.Validator
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 
@@ -241,9 +241,9 @@ class BuilderFirstSpec extends AbstractDSLSpec {
 
         then:
         instance.result == "MODEL"
-        KlumModelProxy.getProxyFor(instance).object.is(instance)
-        !KlumModelProxy.declaredFields*.name.contains("applyLaterClosures")
-        !KlumModelProxy.declaredMethods*.name.contains("getApplyLaterClosures")
+        KlumObjectSupport.of(instance).object.is(instance)
+        !Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy').declaredFields*.name.contains("applyLaterClosures")
+        !Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy').declaredMethods*.name.contains("getApplyLaterClosures")
         !KlumBuilder.ModelState.declaredFields*.name.contains("applyLaterClosures")
         !KlumBuilder.ModelState.declaredMethods*.name.contains("getApplyLaterClosures")
     }
@@ -827,8 +827,6 @@ class BuilderFirstSpec extends AbstractDSLSpec {
             name "serialized"
             values "one", "two"
         }
-        KlumModelProxy.getProxyFor(instance).setMetaData("marker", "preserved")
-
         when:
         def bytes = new ByteArrayOutputStream()
         new ObjectOutputStream(bytes).withCloseable { it.writeObject(instance) }
@@ -847,9 +845,9 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         then:
         restored.name == "serialized"
         restored.values == ["one", "two"]
-        def companion = KlumModelProxy.getProxyFor(restored)
-        companion.model.is(restored)
-        companion.modelPath == "<root>"
-        companion.getMetaData("marker", String) == "preserved"
+        def support = KlumObjectSupport.of(restored)
+        support.object.is(restored)
+        support.modelPath == "<root>"
+        support.validation.result != null
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
@@ -244,8 +244,8 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         KlumObjectSupport.of(instance).object.is(instance)
         !Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy').declaredFields*.name.contains("applyLaterClosures")
         !Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy').declaredMethods*.name.contains("getApplyLaterClosures")
-        !KlumBuilder.ModelState.declaredFields*.name.contains("applyLaterClosures")
-        !KlumBuilder.ModelState.declaredMethods*.name.contains("getApplyLaterClosures")
+        !KlumBuilder.declaredClasses.find { it.simpleName == 'ModelState' }.declaredFields*.name.contains("applyLaterClosures")
+        !KlumBuilder.declaredClasses.find { it.simpleName == 'ModelState' }.declaredMethods*.name.contains("getApplyLaterClosures")
     }
 
     def "Template recipe actions replay into fresh Builders"() {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -93,6 +93,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
     def "completed companion lookup and raw metadata are not client API"() {
         given:
         Class<?> modelProxyClass = Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy')
+        Class<?> modelStateClass = KlumBuilder.declaredClasses.find { it.simpleName == 'ModelState' }
 
         expect:
         !Modifier.isPublic(modelProxyClass.modifiers)
@@ -102,6 +103,9 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         ['hasMetaData', 'getMetaData', 'setMetaData'].every { methodName ->
             KlumBuilder.declaredMethods.findAll { it.name == methodName }.every { !Modifier.isPublic(it.modifiers) }
         }
+        !Modifier.isPublic(KlumBuilder.getDeclaredMethod('exportModelState').modifiers)
+        !Modifier.isPublic(modelStateClass.modifiers)
+        !Modifier.isPublic(modelStateClass.getDeclaredMethod('getMetadata').modifiers)
 
         and: 'Java source receives an immediate migration diagnostic instead of companion access'
         compileJavaConsumerFails('''
@@ -124,6 +128,17 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                 }
             }
         ''', 'getMetaData(String,Class<T>) is not public')
+
+        and: 'the materialization state carrier cannot bypass that lockdown'
+        compileJavaConsumerFails('''
+            import com.blackbuild.klum.ast.util.KlumBuilder;
+
+            public final class JavaObjectSupportConsumer {
+                public static Object inspect(KlumBuilder<?> builder) {
+                    return builder.exportModelState();
+                }
+            }
+        ''', 'exportModelState() is not public')
     }
 
     def "validation support reads stored root and subtree results without rerunning validation"() {
@@ -135,6 +150,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                 @Required(level = Validate.Level.WARNING)
                 String name
                 Child child
+                CleanChild clean
 
                 @Validate
                 void countValidation() {
@@ -153,12 +169,26 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                     validationCalls++
                 }
             }
+
+            @DSL class CleanChild {
+                static int validationCalls
+                String value
+
+                @Validate
+                void countValidation() {
+                    validationCalls++
+                }
+            }
         '''
-        instance = Root.Create.With { child {} }
+        instance = Root.Create.With {
+            child {}
+            clean { value 'valid' }
+        }
         def support = KlumObjectSupport.of(instance)
         def childSupport = KlumObjectSupport.of(instance.child)
         def storedRootResult = support.validation.result
         def storedChildResult = childSupport.validation.result
+        def storedCleanResult = KlumObjectSupport.of(instance.clean).validation.result
         def rootIssues = storedRootResult.issues.toList()
         def childIssues = storedChildResult.issues.toList()
 
@@ -186,11 +216,13 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
 
         then:
         result.is(storedRootResult)
-        results == [storedRootResult, storedChildResult]
+        results == [storedRootResult, storedChildResult, storedCleanResult]
         subtreeResults == [storedChildResult]
         verified == results
         Root.validationCalls == 1
         Child.validationCalls == 1
+        CleanChild.validationCalls == 1
+        storedCleanResult.issues.empty
         storedRootResult.issues.toList() == rootIssues
         storedChildResult.issues.toList() == childIssues
 
@@ -202,6 +234,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         error.validationResults == results
         Root.validationCalls == 1
         Child.validationCalls == 1
+        CleanChild.validationCalls == 1
         support.validation.result.is(storedRootResult)
         storedRootResult.issues.toList() == rootIssues
         storedChildResult.issues.toList() == childIssues
@@ -418,22 +451,14 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
     }
 
     private void compileJavaConsumer(String source) {
-        File sourceFile = new File(tempFolder.root, 'JavaObjectSupportConsumer.java')
-        sourceFile.text = source.stripIndent()
-        String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
-                .join(File.pathSeparator)
-        int result = ToolProvider.systemJavaCompiler.run(
-                null,
-                null,
-                null,
-                '-classpath', classpath,
-                '-d', compilerConfiguration.targetDirectory.absolutePath,
-                sourceFile.absolutePath
-        )
-        assert result == 0
+        assertJavaCompilation(source, null)
     }
 
     private void compileJavaConsumerFails(String source, String expectedDiagnostic) {
+        assertJavaCompilation(source, expectedDiagnostic)
+    }
+
+    private void assertJavaCompilation(String source, String expectedDiagnostic) {
         File sourceFile = new File(tempFolder.root, 'JavaObjectSupportConsumer.java')
         sourceFile.text = source.stripIndent()
         String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
@@ -447,7 +472,11 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                 '-d', compilerConfiguration.targetDirectory.absolutePath,
                 sourceFile.absolutePath
         )
-        assert result != 0
-        assert errors.toString().contains(expectedDiagnostic)
+        if (expectedDiagnostic == null) {
+            assert result == 0: errors.toString()
+        } else {
+            assert result != 0
+            assert errors.toString().contains(expectedDiagnostic)
+        }
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -30,6 +30,7 @@ import com.blackbuild.klum.ast.util.KlumValidationException
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor
 import com.blackbuild.klum.ast.util.layer3.StructureUtil
 import com.blackbuild.klum.ast.validation.KlumValidationResult
+import com.blackbuild.klum.ast.validation.Validator
 import org.jetbrains.annotations.NotNull
 
 import javax.tools.ToolProvider
@@ -141,7 +142,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         ''', 'exportModelState() is not public')
     }
 
-    def "validation support reads stored root and subtree results without rerunning validation"() {
+    def "validation support includes clean stored results without rerunning validation"() {
         given:
         createClass '''
             @DSL class Root {
@@ -195,6 +196,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         when:
         def result = support.validation.result
         def results = support.validation.results
+        def deprecatedResults = Validator.getValidationResultsFromStructure(instance)
         def subtreeResults = childSupport.validation.results
         def verified = support.validation.verify()
         compileJavaConsumer('''
@@ -217,6 +219,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         then:
         result.is(storedRootResult)
         results == [storedRootResult, storedChildResult, storedCleanResult]
+        deprecatedResults == results
         subtreeResults == [storedChildResult]
         verified == results
         Root.validationCalls == 1

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -26,14 +26,97 @@ package com.blackbuild.groovy.configdsl.transform
 import com.blackbuild.klum.ast.util.KlumModelProxy
 import com.blackbuild.klum.ast.util.KlumObjectSupport
 import com.blackbuild.klum.ast.util.KlumException
+import com.blackbuild.klum.ast.util.KlumValidationException
 import com.blackbuild.klum.ast.util.layer3.ModelVisitor
 import com.blackbuild.klum.ast.util.layer3.StructureUtil
+import com.blackbuild.klum.ast.validation.KlumValidationResult
 import org.jetbrains.annotations.NotNull
 
 import javax.tools.ToolProvider
 import java.lang.reflect.Modifier
 
 class KlumObjectSupportSpec extends AbstractDSLSpec {
+
+    def "validation support reads stored root and subtree results without rerunning validation"() {
+        given:
+        createClass '''
+            @DSL class Root {
+                static int validationCalls
+
+                @Required(level = Validate.Level.WARNING)
+                String name
+                Child child
+
+                @Validate
+                void countValidation() {
+                    validationCalls++
+                }
+            }
+
+            @DSL class Child {
+                static int validationCalls
+
+                @Required(level = Validate.Level.WARNING)
+                String value
+
+                @Validate
+                void countValidation() {
+                    validationCalls++
+                }
+            }
+        '''
+        instance = Root.Create.With { child {} }
+        def support = KlumObjectSupport.of(instance)
+        def childSupport = KlumObjectSupport.of(instance.child)
+        def storedRootResult = support.validation.result
+        def storedChildResult = childSupport.validation.result
+        def rootIssues = storedRootResult.issues.toList()
+        def childIssues = storedChildResult.issues.toList()
+
+        when:
+        def result = support.validation.result
+        def results = support.validation.results
+        def subtreeResults = childSupport.validation.results
+        def verified = support.validation.verify()
+        compileJavaConsumer('''
+            import com.blackbuild.groovy.configdsl.transform.Validate;
+            import com.blackbuild.klum.ast.util.KlumObjectSupport;
+            import com.blackbuild.klum.ast.validation.KlumValidationResult;
+            import java.util.List;
+
+            public final class JavaObjectSupportConsumer {
+                public static void inspect(Root root) {
+                    KlumObjectSupport.Validation<Root> validation = KlumObjectSupport.of(root).getValidation();
+                    KlumValidationResult result = validation.getResult();
+                    List<KlumValidationResult> results = validation.getResults();
+                    List<KlumValidationResult> verified = validation.verify();
+                    validation.verify(Validate.Level.WARNING);
+                }
+            }
+        ''')
+
+        then:
+        result.is(storedRootResult)
+        results == [storedRootResult, storedChildResult]
+        subtreeResults == [storedChildResult]
+        verified == results
+        Root.validationCalls == 1
+        Child.validationCalls == 1
+        storedRootResult.issues.toList() == rootIssues
+        storedChildResult.issues.toList() == childIssues
+
+        when:
+        support.validation.verify(Validate.Level.WARNING)
+
+        then:
+        def error = thrown(KlumValidationException)
+        error.validationResults == results
+        Root.validationCalls == 1
+        Child.validationCalls == 1
+        support.validation.result.is(storedRootResult)
+        storedRootResult.issues.toList() == rootIssues
+        storedChildResult.issues.toList() == childIssues
+    }
 
     def "Java callers use explicit completed-object getters for a root and subtree without proxy access"() {
         given:

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -23,7 +23,7 @@
  */
 package com.blackbuild.groovy.configdsl.transform
 
-import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumBuilder
 import com.blackbuild.klum.ast.util.KlumObjectSupport
 import com.blackbuild.klum.ast.util.KlumException
 import com.blackbuild.klum.ast.util.KlumValidationException
@@ -36,6 +36,95 @@ import javax.tools.ToolProvider
 import java.lang.reflect.Modifier
 
 class KlumObjectSupportSpec extends AbstractDSLSpec {
+
+    def "support helpers neither cache a companion nor duplicate it during model serialization"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL class SerializableRoot {
+                @Required(level = Validate.Level.WARNING)
+                String name
+            }
+        '''
+        instance = clazz.Create.One()
+        def companionField = clazz.getDeclaredField('$proxy')
+        companionField.accessible = true
+        def companion = companionField.get(instance)
+        def support = KlumObjectSupport.of(instance)
+
+        when: 'all facade helpers are exercised before serialization'
+        support.breadcrumbPath
+        support.modelPath
+        support.structure.findAll(clazz)
+        def storedResult = support.validation.result
+        support.validation.results
+        def bytes = new ByteArrayOutputStream()
+        new ObjectOutputStream(bytes).withCloseable { it.writeObject(instance) }
+        def dynamicLoader = loader
+        def restored = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray())) {
+            @Override
+            protected Class<?> resolveClass(ObjectStreamClass descriptor) {
+                try {
+                    return dynamicLoader.loadClass(descriptor.name)
+                } catch (ClassNotFoundException ignored) {
+                    return super.resolveClass(descriptor)
+                }
+            }
+        }.withCloseable { it.readObject() }
+        def restoredCompanion = companionField.get(restored)
+        def getCompanionObject = restoredCompanion.class.getDeclaredMethod('getObject')
+        getCompanionObject.accessible = true
+        def restoredCompanionObject = getCompanionObject.invoke(restoredCompanion)
+        def restoredResult = KlumObjectSupport.of(restored).validation.result
+
+        then: 'the facade and grouped helpers retain only their target object'
+        KlumObjectSupport.declaredFields.findAll { !it.synthetic }*.name == ['object']
+        KlumObjectSupport.Structure.declaredFields.findAll { !it.synthetic }*.name == ['object']
+        KlumObjectSupport.Validation.declaredFields.findAll { !it.synthetic }*.name == ['object']
+        companionField.get(instance).is(companion)
+
+        and: 'serialization restores the model-companion back-reference and its stored validation once'
+        restoredCompanionObject.is(restored)
+        restoredResult.issues*.message == storedResult.issues*.message
+        restoredResult.breadcrumbPath == storedResult.breadcrumbPath
+    }
+
+    def "completed companion lookup and raw metadata are not client API"() {
+        given:
+        Class<?> modelProxyClass = Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy')
+
+        expect:
+        !Modifier.isPublic(modelProxyClass.modifiers)
+        ['getProxyFor', 'hasMetaData', 'getMetaData', 'setMetaData'].every { methodName ->
+            modelProxyClass.declaredMethods.findAll { it.name == methodName }.every { !Modifier.isPublic(it.modifiers) }
+        }
+        ['hasMetaData', 'getMetaData', 'setMetaData'].every { methodName ->
+            KlumBuilder.declaredMethods.findAll { it.name == methodName }.every { !Modifier.isPublic(it.modifiers) }
+        }
+
+        and: 'Java source receives an immediate migration diagnostic instead of companion access'
+        compileJavaConsumerFails('''
+            import com.blackbuild.klum.ast.util.KlumModelProxy;
+
+            public final class JavaObjectSupportConsumer {
+                public static Object inspect(Object model) {
+                    return KlumModelProxy.getProxyFor(model);
+                }
+            }
+        ''', 'KlumModelProxy is not public')
+
+        and: 'raw Builder metadata is likewise absent from Java source API'
+        compileJavaConsumerFails('''
+            import com.blackbuild.klum.ast.util.KlumBuilder;
+
+            public final class JavaObjectSupportConsumer {
+                public static Object inspect(KlumBuilder<?> builder) {
+                    return builder.getMetaData("client-extension", Object.class);
+                }
+            }
+        ''', 'getMetaData(String,Class<T>) is not public')
+    }
 
     def "validation support reads stored root and subtree results without rerunning validation"() {
         given:
@@ -138,6 +227,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         }
         def rootSupport = KlumObjectSupport.of(instance)
         def childSupport = KlumObjectSupport.of(instance.child)
+        Class<?> modelProxyClass = Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy')
         compileJavaConsumer('''
             import com.blackbuild.klum.ast.util.KlumObjectSupport;
 
@@ -165,9 +255,10 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         rootSupport.structure.singleOwner.empty
 
         and: "the public facade stores and exposes only its completed-object target"
-        KlumObjectSupport.declaredFields*.type.every { it != KlumModelProxy }
-        KlumObjectSupport.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != KlumModelProxy : true }
-        KlumObjectSupport.Structure.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != KlumModelProxy : true }
+        KlumObjectSupport.declaredFields*.type.every { it != modelProxyClass }
+        KlumObjectSupport.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != modelProxyClass : true }
+        KlumObjectSupport.Structure.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != modelProxyClass : true }
+        KlumObjectSupport.Validation.methods.every { Modifier.isPublic(it.modifiers) ? it.returnType != modelProxyClass : true }
         !Serializable.isAssignableFrom(KlumObjectSupport)
 
         when: 'the target is not a completed DSL Object'
@@ -178,7 +269,9 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         error.message.contains('not a completed DSL Object')
 
         when: 'the internal companion itself is supplied'
-        KlumObjectSupport.of(KlumModelProxy.getProxyFor(instance))
+        def companionField = instance.class.getDeclaredField('$proxy')
+        companionField.accessible = true
+        KlumObjectSupport.of(companionField.get(instance))
 
         then:
         def companionError = thrown(KlumException)
@@ -338,5 +431,23 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                 sourceFile.absolutePath
         )
         assert result == 0
+    }
+
+    private void compileJavaConsumerFails(String source, String expectedDiagnostic) {
+        File sourceFile = new File(tempFolder.root, 'JavaObjectSupportConsumer.java')
+        sourceFile.text = source.stripIndent()
+        String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
+                .join(File.pathSeparator)
+        def errors = new ByteArrayOutputStream()
+        int result = ToolProvider.systemJavaCompiler.run(
+                null,
+                null,
+                errors,
+                '-classpath', classpath,
+                '-d', compilerConfiguration.targetDirectory.absolutePath,
+                sourceFile.absolutePath
+        )
+        assert result != 0
+        assert errors.toString().contains(expectedDiagnostic)
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ModelPathTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ModelPathTest.groovy
@@ -24,8 +24,7 @@
 package com.blackbuild.groovy.configdsl.transform
 
 import com.blackbuild.klum.ast.util.KlumModelException
-
-import static com.blackbuild.klum.ast.util.KlumModelProxy.getProxyFor
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 
 class ModelPathTest extends AbstractDSLSpec {
 
@@ -65,15 +64,15 @@ class ModelPathTest extends AbstractDSLSpec {
         }
 
         then:
-        getProxyFor(instance).modelPath == '<root>'
-        getProxyFor(instance.level2).modelPath == '<root>.level2'
-        getProxyFor(instance.level2.level3).modelPath == '<root>.level2.level3'
-        getProxyFor(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
-        getProxyFor(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
-        getProxyFor(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
-        getProxyFor(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
-        getProxyFor(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
-        getProxyFor(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
+        KlumObjectSupport.of(instance).modelPath == '<root>'
+        KlumObjectSupport.of(instance.level2).modelPath == '<root>.level2'
+        KlumObjectSupport.of(instance.level2.level3).modelPath == '<root>.level2.level3'
+        KlumObjectSupport.of(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
+        KlumObjectSupport.of(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
+        KlumObjectSupport.of(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
+        KlumObjectSupport.of(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
     }
 
     def "model path is set correctly when using nested Create.With"() {
@@ -121,15 +120,15 @@ class ModelPathTest extends AbstractDSLSpec {
         }
 
         then:
-        getProxyFor(instance).modelPath == '<root>'
-        getProxyFor(instance.level2).modelPath == '<root>.level2'
-        getProxyFor(instance.level2.level3).modelPath == '<root>.level2.level3'
-        getProxyFor(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
-        getProxyFor(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
-        getProxyFor(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
-        getProxyFor(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
-        getProxyFor(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
-        getProxyFor(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
+        KlumObjectSupport.of(instance).modelPath == '<root>'
+        KlumObjectSupport.of(instance.level2).modelPath == '<root>.level2'
+        KlumObjectSupport.of(instance.level2.level3).modelPath == '<root>.level2.level3'
+        KlumObjectSupport.of(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
+        KlumObjectSupport.of(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
+        KlumObjectSupport.of(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
+        KlumObjectSupport.of(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
     }
 
     def "completed converter results cannot become nested composition"() {
@@ -242,15 +241,15 @@ class ModelPathTest extends AbstractDSLSpec {
         instance = Model.fromString("bla")
 
         then:
-        getProxyFor(instance).modelPath == '<root>'
-        getProxyFor(instance.level2).modelPath == '<root>.level2'
-        getProxyFor(instance.level2.level3).modelPath == '<root>.level2.level3'
-        getProxyFor(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
-        getProxyFor(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
-        getProxyFor(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
-        getProxyFor(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
-        getProxyFor(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
-        getProxyFor(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
+        KlumObjectSupport.of(instance).modelPath == '<root>'
+        KlumObjectSupport.of(instance.level2).modelPath == '<root>.level2'
+        KlumObjectSupport.of(instance.level2.level3).modelPath == '<root>.level2.level3'
+        KlumObjectSupport.of(instance.level2.level3Elements[0]).modelPath == '<root>.level2.level3Elements[0]'
+        KlumObjectSupport.of(instance.level2.level3Elements[1]).modelPath == '<root>.level2.level3Elements[1]'
+        KlumObjectSupport.of(instance.level2.keyedValues[0]).modelPath == '<root>.level2.keyedValues[0]'
+        KlumObjectSupport.of(instance.level2.keyedValues[1]).modelPath == '<root>.level2.keyedValues[1]'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['mapFirst']).modelPath == '<root>.level2.keyedMapValue.mapFirst'
+        KlumObjectSupport.of(instance.level2.keyedMapValue['map-second']).modelPath == "<root>.level2.keyedMapValue.'map-second'"
     }
 
     def "model path is set correctly when using nested AutoCreate"() {
@@ -275,9 +274,9 @@ import java.util.logging.Level
         instance = Model.Create.One()
 
         then:
-        getProxyFor(instance).modelPath == '<root>'
-        getProxyFor(instance.level2).modelPath == '<root>.level2'
-        getProxyFor(instance.level2.level3).modelPath == '<root>.level2.level3'
+        KlumObjectSupport.of(instance).modelPath == '<root>'
+        KlumObjectSupport.of(instance.level2).modelPath == '<root>.level2'
+        KlumObjectSupport.of(instance.level2.level3).modelPath == '<root>.level2.level3'
     }
 
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplateCompanionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplateCompanionSpec.groovy
@@ -27,8 +27,8 @@ import com.blackbuild.klum.ast.process.ConstructionSession
 import com.blackbuild.klum.ast.util.DslHelper
 import com.blackbuild.klum.ast.util.KlumBuilder
 import com.blackbuild.klum.ast.util.KlumModelException
-import com.blackbuild.klum.ast.util.KlumModelProxy
 import com.blackbuild.klum.ast.util.KlumObjectCompanion
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 import com.blackbuild.klum.ast.util.KlumTemplateProxy
 import com.blackbuild.klum.ast.util.TemplateManager
 
@@ -63,17 +63,17 @@ class TemplateCompanionSpec extends AbstractDSLSpec {
 
         and:
         KlumObjectCompanion.sealed
-        KlumObjectCompanion.permittedSubclasses as Set == [KlumModelProxy, KlumTemplateProxy] as Set
+        KlumObjectCompanion.permittedSubclasses*.simpleName as Set == ['KlumModelProxy', 'KlumTemplateProxy'] as Set
         KlumObjectCompanion.declaredMethods*.name as Set == [
                 'getObject',
                 'getBreadcrumbPath',
                 'getModelPath'
         ] as Set
-        Modifier.isFinal(KlumModelProxy.modifiers)
+        Modifier.isFinal(Class.forName('com.blackbuild.klum.ast.util.KlumModelProxy').modifiers)
         Modifier.isFinal(KlumTemplateProxy.modifiers)
 
         and:
-        modelCompanion.class == KlumModelProxy
+        modelCompanion.class.simpleName == 'KlumModelProxy'
         modelCompanion.object.is(model)
         modelCompanion.breadcrumbPath == DslHelper.getBreadcrumbPath(model)
         modelCompanion.modelPath == DslHelper.getModelPath(model)
@@ -185,7 +185,7 @@ class TemplateCompanionSpec extends AbstractDSLSpec {
         template.external.is(existingLink)
         rehydrated.external.is(existingLink)
         !TemplateManager.isTemplate(existingLink)
-        KlumModelProxy.getProxyFor(existingLink).object.is(existingLink)
+        KlumObjectSupport.of(existingLink).object.is(existingLink)
     }
 
     def "completed Templates are rejected from the #field relationship"() {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesSpec.groovy
@@ -27,7 +27,7 @@ package com.blackbuild.groovy.configdsl.transform
 
 import com.blackbuild.klum.ast.util.KlumInstanceProxy
 import com.blackbuild.klum.ast.util.KlumException
-import com.blackbuild.klum.ast.util.KlumModelProxy
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -1364,7 +1364,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         then:
         instance.name == "Instance"
         instance.activeTemplatesDuringAutoCreate == [:]
-        KlumModelProxy.getProxyFor(instance).model.is(instance)
+        KlumObjectSupport.of(instance).object.is(instance)
 
         when: "the legacy proxy is looked up for a completed model"
         KlumInstanceProxy.getProxyFor(instance)
@@ -1372,7 +1372,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         then:
         def migrationFailure = thrown(KlumException)
         migrationFailure.message.contains("Builder-only")
-        migrationFailure.message.contains("KlumModelProxy")
+        migrationFailure.message.contains("KlumObjectSupport")
 
         when:
         def templatesDuringCreation = null
@@ -1387,7 +1387,7 @@ import com.blackbuild.klum.ast.util.KlumInstanceProxy
         instance.name == "Overridden"
         templatesDuringCreation == [(clazz): template]
         instance.activeTemplatesDuringAutoCreate == [(clazz): template]
-        KlumModelProxy.getProxyFor(instance).model.is(instance)
+        KlumObjectSupport.of(instance).object.is(instance)
     }
 
     @Issue("376")

--- a/wiki/Builder-First-Migration.md
+++ b/wiki/Builder-First-Migration.md
@@ -133,9 +133,9 @@ Template companion and immutable recipe state, but never Builders, Construction 
 collections. Ordinary completed models retain no deferred actions.
 
 The internal generated `$proxy` field uses a sealed common Model/Template companion solely for cross-package generated
-linkage. It is not client API. Use `KlumObjectSupport.of(object)` for supported completed-object paths and structure; do
-not build integrations on `KlumModelProxy`, `KlumTemplateProxy`, or raw metadata. #390 retains the remaining facade and
-proxy-lockdown work from [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md).
+linkage. It is not client API. Use `KlumObjectSupport.of(object)` for supported completed-object paths, structure, and
+stored validation; do not build integrations on companion classes or raw metadata. Broader compatibility closure remains
+tracked by [#390](https://github.com/klum-dsl/klum-ast/issues/390) and [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md).
 
 Jackson now replays public Builder configuration through resolved property metadata. Missing input preserves source
 initializers and later defaults; present values, `null`, and containers replace current Builder state authoritatively between

--- a/wiki/Builder-First-Migration.md
+++ b/wiki/Builder-First-Migration.md
@@ -137,6 +137,10 @@ linkage. It is not client API. Use `KlumObjectSupport.of(object)` for supported 
 stored validation; do not build integrations on companion classes or raw metadata. Broader compatibility closure remains
 tracked by [#390](https://github.com/klum-dsl/klum-ast/issues/390) and [ADR 0006](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0006-completed-object-support.md).
 
+`getValidation().getResults()` returns every stored result in the owned subtree, including clean results without issues.
+This is broader than the old `Validator.getValidationResultsFromStructure` and `verifyStructure` list contract; their
+deprecated adapters now return the facade's complete stored-result list.
+
 Jackson now replays public Builder configuration through resolved property metadata. Missing input preserves source
 initializers and later defaults; present values, `null`, and containers replace current Builder state authoritatively between
 `PostCreate` and `PostApply`. Derived output must be `PROTECTED`, ignored, or explicitly Jackson read-only so the single

--- a/wiki/Completed-Object-Support.md
+++ b/wiki/Completed-Object-Support.md
@@ -48,7 +48,7 @@ ensures that object graphs remain safe even when DSL types override `equals`.
 
 ## Stored validation
 
-`getValidation().getResult()` returns the result already stored for the target object. `getResults()` reads issue-bearing
+`getValidation().getResult()` returns the result already stored for the target object. `getResults()` reads all stored
 results from the target's owned composition subtree. `verify()` uses the configured failure level, while `verify(level)`
 uses the supplied level. These operations only inspect lifecycle results: they do not execute `InstanceValidator`s, create
 results, or mutate recorded issues.

--- a/wiki/Completed-Object-Support.md
+++ b/wiki/Completed-Object-Support.md
@@ -8,6 +8,8 @@ The facade accepts either a completed root object or any completed DSL Object in
 
 ```java
 import com.blackbuild.klum.ast.util.KlumObjectSupport;
+import com.blackbuild.klum.ast.validation.KlumValidationResult;
+import java.util.List;
 import java.util.Map;
 
 KlumObjectSupport<Deployment> support = KlumObjectSupport.of(deployment);
@@ -18,10 +20,14 @@ String modelPath = support.getModelPath();
 
 KlumObjectSupport.Structure<Deployment> structure = support.getStructure();
 Map<String, Service> services = structure.findAll(Service.class);
+
+KlumObjectSupport.Validation<Deployment> validation = support.getValidation();
+KlumValidationResult result = validation.getResult();
+List<KlumValidationResult> subtreeResults = validation.getResults();
 ```
 
-The Javadoc for `KlumObjectSupport` and its nested `Structure` helper is the source of truth for complete signatures,
-overloads, return types, and exceptional cases.
+The Javadoc for `KlumObjectSupport` and its nested `Structure` and `Validation` helpers is the source of truth for complete
+signatures, overloads, return types, and exceptional cases.
 
 ## Provenance and model paths
 
@@ -40,6 +46,13 @@ questions and are not interchangeable.
 Traversal follows composed DSL values only. Owner and `LINK` edges are not followed, and identity-based cycle protection
 ensures that object graphs remain safe even when DSL types override `equals`.
 
+## Stored validation
+
+`getValidation().getResult()` returns the result already stored for the target object. `getResults()` reads issue-bearing
+results from the target's owned composition subtree. `verify()` uses the configured failure level, while `verify(level)`
+uses the supplied level. These operations only inspect lifecycle results: they do not execute `InstanceValidator`s, create
+results, or mutate recorded issues.
+
 The facade may also start at a subtree:
 
 ```java
@@ -57,5 +70,5 @@ String pathFromDeployment = support.getStructure().getRelativePath(service);
 `KlumObjectSupport` directly. `KlumModelProxy` and its raw metadata are internal implementation details and are not a
 supported client extension API.
 
-Stored validation results are currently accessed through the supported `Validator` utilities described in
-[[Validation]]. A grouped validation helper on `KlumObjectSupport` belongs to the later completed-object validation slice.
+The former `Validator.getValidationResult`, `getValidationResultsFromStructure`, and `verifyStructure` readers remain as
+deprecated adapters. New completed-object code uses `KlumObjectSupport.getValidation()` as described in [[Validation]].

--- a/wiki/Validation.md
+++ b/wiki/Validation.md
@@ -61,8 +61,7 @@ class MyModel {
 
 Any failed validation is represented by a `KlumValidationIssue`, all
 issues of a single object are collected in a `KlumValidationResult`. The result is stored in the completed object's Model
-companion and is accessed through the supported `Validator.getValidationResult(Object)` utility rather than through
-`KlumInstanceProxy`.
+companion and is accessed through `KlumObjectSupport.of(object).getValidation().getResult()` rather than through a proxy.
 
 # `@Required` and `@Optional`
 
@@ -292,7 +291,9 @@ There are different levels for validation problems: INFO, WARNING, DEPRECATION, 
 
 Usually, validation problems are considered errors, but you can use the `level` parameter of the `@Validate` (or `@Required`) annotation to change this. 
 
-In the normal case, only errors lead to a `KlumValidationException` being thrown, but all validation problems are collected in the `KlumValidationResult` and can be accessed via the `Validator.getValidationResult(Object)`.
+In the normal case, only errors lead to a `KlumValidationException` being thrown, but all validation problems are collected
+in `KlumValidationResult` objects. Use `KlumObjectSupport.of(object).getValidation().getResult()` for one object or
+`getResults()` for its owned subtree.
 
 The level on which the validation causes an exception can be overridden by the `klum.validation.failOnLevel` system property.
 
@@ -344,7 +345,9 @@ The actual check against the fail level is done in the Verify phase. This allows
 
 # Skipping verification
 
-By setting the system property `klum.validation.skipVerify` to `true`, the verify phase is skipped. Validation is still executed, and the results can be extracted from the instances using the `Validator.getValidationResultsFromStructure(Object)` method (or `verifyStructure(Object)` can be used to run the verification later and throw an exception as needed). 
+By setting the system property `klum.validation.skipVerify` to `true`, the verify phase is skipped. Validation is still
+executed. Read the stored results through `KlumObjectSupport.of(object).getValidation().getResults()`, or call `verify()`
+later to apply the configured failure level without rerunning validators.
 
 # JSR380 validation
 


### PR DESCRIPTION
## Summary

- add `KlumObjectSupport.getValidation()` with Java-first target/subtree stored-result access and `verify` overloads
- keep validation reads side-effect-free: facade calls neither execute `InstanceValidator`s nor create or mutate lifecycle results
- make the Model companion, companion lookup, Builder/Model raw metadata, and materialization state carrier internal
- migrate completed-model callers to `KlumObjectSupport` and retain the former `Validator` readers as deprecated adapters
- cover root/subtree behavior, clean stored results, Java source API visibility, validator memoization, and serialized model/companion identity
- synchronize OS-2-facing ADR, architecture, wiki, migration, and changelog statements while leaving OS-3 open

## Compatibility

Direct `KlumModelProxy` and raw metadata access are intentionally unavailable to clients in 4.0, as accepted by ADR 0006. Existing `Validator.getValidationResult`, `getValidationResultsFromStructure`, and `verifyStructure` calls remain source-compatible deprecated adapters.

This implements tracer bullet OS-2 only. It does not add extension APIs, generation logs, model-specific support generation, or the broader OS-3 documentation/compatibility closure.

## Validation

- `./gradlew --no-daemon :klum-ast-runtime:test :klum-ast:test`
- `./gradlew --no-daemon :klum-ast-runtime:groovy4Tests :klum-ast-runtime:groovy5Tests :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- `./gradlew --no-daemon check`
- two-axis branch review against `c2d56fb7`: no remaining Standards or OS-2 Spec findings

An additional Javadoc probe remains blocked by two pre-existing invalid `@param proxy` tags in unchanged `LifecycleHelper` methods; the required root `check` is green.

References #390. This PR intentionally does not close it because OS-3 remains.
