### PR TITLE
Guard issue references from GitHub closing syntax

### DIFF
--- a/.agents/skills/setup-matt-pocock-skills/commits.md
+++ b/.agents/skills/setup-matt-pocock-skills/commits.md
@@ -14,6 +14,11 @@ Use these rules when implementing an issue.
 - Make each commit one self-contained reasoning step: a reviewer should be able to understand why the step exists and how it advances the issue without depending on unrelated later work.
 - Prefer small vertical or preparatory steps over commits split mechanically by file or layer.
 - Write a concise imperative subject that states the change and its reason. Use the body only when the reasoning does not fit clearly in the subject.
+- Treat commit subjects and bodies as issue-tracker linking input. For GitHub repositories, do not place `close`,
+  `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` before an issue reference unless merging
+  that commit is intended to close the issue automatically. Negation, quotation, code formatting, and explanatory context
+  do not make the pattern safe; use neutral wording such as `Related: #123`, `Issue #123 remains open`, or `This commit
+  leaves the issue state unchanged`.
 - Keep tests and the production change that makes them pass together. During TDD, do not commit the initial failing test separately; finish the red-to-green cycle and commit only when that test is green again.
 - Before each commit, run the relevant build and tests and normally require them to pass. Outside a TDD cycle, a temporarily non-working intermediate commit is acceptable when it makes the reasoning materially easier to follow; repair it in the immediately following commit and explain the boundary in both messages.
 - Documentation need not describe every intermediate commit. It must match the final branch state unless the issue explicitly excludes documentation. A separate, usually final documentation commit is valid.

--- a/docs/agents/commits.md
+++ b/docs/agents/commits.md
@@ -14,6 +14,9 @@ Use these rules when implementing an issue.
 - Make each commit one self-contained reasoning step: a reviewer should be able to understand why the step exists and how it advances the issue without depending on unrelated later work.
 - Prefer small vertical or preparatory steps over commits split mechanically by file or layer.
 - Write a concise imperative subject that states the change and its reason. Use the body only when the reasoning does not fit clearly in the subject.
+- Treat commit subjects and bodies as GitHub issue-linking input. Do not place a GitHub closing keyword before an issue
+  reference unless merging that commit is intended to close the issue automatically; negated wording can still trigger
+  GitHub's pattern matching. Use neutral issue references as described in `docs/agents/pull-requests.md`.
 - Keep tests and the production change that makes them pass together. During TDD, do not commit the initial failing test separately; finish the red-to-green cycle and commit only when that test is green again.
 - Before each commit, run the relevant build and tests and normally require them to pass. Outside a TDD cycle, a temporarily non-working intermediate commit is acceptable when it makes the reasoning materially easier to follow; repair it in the immediately following commit and explain the boundary in both messages.
 - Documentation need not describe every intermediate commit. It must match the final branch state unless the issue explicitly excludes documentation. A separate, usually final documentation commit is valid.

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -5,6 +5,11 @@ Use this checklist for any pull request that changes public behavior, compatibil
 ## Pull request scope and issue links
 
 - Use closing keywords only for issues whose accepted behavior is fully delivered by the pull request.
+- Treat GitHub closing keywords as mechanical syntax, not prose. In pull-request titles and bodies, never place `close`,
+  `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` before an issue reference unless the
+  pull request is intended to close that issue automatically. Negation, quotation, code formatting, and explanatory
+  context do not make the pattern safe. For non-closing relationships, use neutral wording such as `Related: #123`,
+  `Issue #123 remains open`, or `This pull request leaves the issue state unchanged`.
 - Reference related issues that remain intentionally deferred, and say what the pull request does not implement.
 - Keep the pull request summary, compatibility breaks, and test evidence current as commits are added.
 


### PR DESCRIPTION
## Summary

- treat GitHub closing keywords as mechanical syntax in pull-request and commit text
- require neutral wording for relationships that must not change issue state
- update the reusable repository setup template with the same commit-message safeguard

## Validation

- git diff --check