### PR TITLE
Add short-term backlog policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 Issues and PRDs for this repo live in GitHub Issues (uses the `gh` CLI). External PRs are not treated as a request surface. See `docs/agents/issue-tracker.md`.
 
+### Short-term backlog
+
+Keep worthwhile side work visible without losing the current objective. Side work and agent-configuration changes normally
+belong in separate user-visible tasks. See `docs/agents/short-term-backlog.md` for task, sidetrack, and baseline-reflection
+rules.
+
 ### Triage labels
 
 This repo uses the canonical triage label vocabulary. See `docs/agents/triage-labels.md` for the mapping.

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -1,0 +1,48 @@
+# Short-term backlog and task boundaries
+
+Conversations often surface worthwhile work outside the current objective. Keep that work visible without silently
+expanding the active task.
+
+## Prefer a separate user-visible task
+
+When a side note or separate idea warrants follow-up and task creation is supported, create a separate user-visible task.
+That task is the short-term backlog entry: it owns the follow-up questions and the formulation of the corresponding issue.
+Remote issue creation still follows the repository's normal issue-tracker workflow and authorization.
+
+Before creating a task, recommend an appropriate model and reasoning level and briefly state why they fit. When that
+recommendation is lower than or equivalent to the current model and reasoning level, configure the new task with the
+recommendation directly. Ask for confirmation only when the choice is unclear or the recommendation has unusually high
+expected cost, such as Sol at very-high (`xhigh`) reasoning or `ultra`.
+
+If a task starts with a model or reasoning level different from the recommendation, its initial instructions must require
+it to ask for confirmation before substantive work begins. If the task-creation surface cannot set the recommendation,
+include it and the confirmation requirement in the task context. Do not substitute a hidden sub-agent for the user-visible
+backlog task.
+
+Agent-configuration work normally warrants its own task because it changes how later work is performed.
+
+## Small sidetracks may stay in the current task
+
+Keep a sidetrack in the current task when that is prudent for its size or cost. Clearly announce the sidetrack before
+starting it, then explicitly announce the return to the main topic when it is complete. Do not let the sidetrack silently
+replace or broaden the main objective.
+
+When a separate task would be disproportionate or unavailable, a temporary ignored or otherwise uncommitted file may hold
+the short-term backlog. Identify the file and its temporary status so it is not mistaken for durable project policy or a
+committed deliverable.
+
+## Reflect reusable agent policy upstream
+
+When changing agent configuration, inspect the repository's `AGENTS.md`, `CONTEXT.md`, repository-local skills, and related
+configuration to locate the authoritative project file. Keep operational instructions out of `CONTEXT.md` unless they
+define project domain language or architecture.
+
+Also check whether the change is reusable across Blackbuild/Klum repositories and should be reflected in
+[`blackbuild/engineering-baseline`](https://github.com/blackbuild/engineering-baseline). Keep project-specific overlays
+local and avoid duplicating the canonical rule across files or skills. Record exactly one auditable outcome: when upstream
+work is needed, link its baseline issue or pull request; otherwise, record a brief rationale for keeping the change local.
+Do not invent a baseline location or modify a separate checkout or remote repository without the required authorization.
+
+The reusable portion of this policy is tracked upstream in
+[`blackbuild/engineering-baseline#2`](https://github.com/blackbuild/engineering-baseline/issues/2). The KlumAST-specific
+issue-tracker and authorization wording above remains local.

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -19,6 +19,11 @@ it to ask for confirmation before substantive work begins. If the task-creation 
 include it and the confirmation requirement in the task context. Do not substitute a hidden sub-agent for the user-visible
 backlog task.
 
+Every spawned task must state its completion status clearly in its final response. When its work is complete, say that the
+task is finished. When the task's work is complete but an external condition remains, use a conditional completion
+statement that names and, when possible, links the condition, for example: "This task is finished, with final merge of PR
+#123 pending." Do not declare completion while substantive work assigned to the task remains.
+
 Agent-configuration work normally warrants its own task because it changes how later work is performed.
 
 ## Small sidetracks may stay in the current task


### PR DESCRIPTION
## Summary

- add a user-visible short-term backlog policy for conversational follow-up work
- define announced sidetracks and temporary uncommitted trackers
- define model and reasoning-level recommendations for newly created tasks
- require spawned tasks to state clearly when they are finished or conditionally finished
- require an auditable engineering-baseline reflection outcome for agent-configuration changes

## Why

Worthwhile side work needs a visible place without silently broadening the active task. Agent-configuration changes also need
a consistent check for reusable Blackbuild/Klum policy.

The reusable policy is tracked in blackbuild/engineering-baseline#2. KlumAST's GitHub issue-tracker authorization wording
remains a local overlay.

## Impact

This changes agent workflow only. It does not change KlumAST production code, public APIs, builds, or releases.

## Validation

- `git diff --cached --check`
- targeted content checks for every required policy clause
- verified the upstream tracker at blackbuild/engineering-baseline#2
