### PR TITLE
Document generated model and Builder getters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ This is a breaking release. See the [Builder-first construction migration](https
 - Added `createKlumDslSourceMirrors` to the schema Gradle plugin. Run it after schema changes to compile the real
   `Foo_DSL` interfaces and refresh their AnnoDocimal IDE source mirrors without compiling, packaging, publishing, or
   propagating the mirrors themselves ([#434](https://github.com/klum-dsl/klum-ast/issues/434)).
+- Generated completed-model and Builder getters now carry field-derived AnnoDoc documentation, including deprecation
+  reasons ([#383](https://github.com/klum-dsl/klum-ast/issues/383)).
 - Provisional Builder validation issues transfer to the completed-model companion, and each `InstanceValidator` is memoized once per completed model.
 - Added active-session `Create.AsBuilder.With`, `One`, `FromMap`, and `From(DelegatingScript)` operations. They create an
   unsealed owned Builder in the current root Construction session, apply active Templates, and run `PostCreate`, explicit

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
@@ -23,10 +23,17 @@
  */
 package com.blackbuild.groovy.configdsl.transform.ast;
 
+import com.blackbuild.annodocimal.ast.extractor.ASTExtractor;
+import com.blackbuild.annodocimal.ast.formatting.AnnoDocUtil;
+import com.blackbuild.annodocimal.ast.formatting.DocBuilder;
+import com.blackbuild.annodocimal.ast.formatting.JavadocDocBuilder;
 import com.blackbuild.groovy.configdsl.transform.FieldType;
+import com.blackbuild.klum.ast.doc.DocUtil;
 import groovyjarjarasm.asm.Opcodes;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.PropertyNode;
 
 import java.util.ArrayList;
@@ -55,6 +62,7 @@ class PropertyAccessors {
                 .filter(property -> transformation.builderFields.containsKey(property.getField()))
                 .forEach(this::makeModelPropertyReadOnly);
         replaceProperties(transformation.annotatedClass, modelPropertiesToReplace);
+        modelPropertiesToReplace.forEach(this::documentModelGetters);
     }
 
     private void createBuilderAccessors(FieldNode modelField, FieldNode builderField) {
@@ -64,6 +72,8 @@ class PropertyAccessors {
         createMethod(getGetterName(fieldName))
                 .mod(visibility)
                 .returning(builderField.getType())
+                .linkToField(modelField)
+                .withDocumentation(documentation -> documentGetter(documentation, modelField))
                 .doReturn(attrX(varX("this"), constX(fieldName)))
                 .addTo(transformation.rwClass);
 
@@ -71,6 +81,8 @@ class PropertyAccessors {
             createMethod(getBooleanGetterName(fieldName))
                     .mod(visibility)
                     .returning(builderField.getType())
+                    .linkToField(modelField)
+                    .withDocumentation(documentation -> documentGetter(documentation, modelField))
                     .doReturn(attrX(varX("this"), constX(fieldName)))
                     .addTo(transformation.rwClass);
 
@@ -104,5 +116,25 @@ class PropertyAccessors {
             property.setGetterBlock(returnS(attrX(varX("this"), constX(field.getName()))));
         property.setSetterBlock(null);
         modelPropertiesToReplace.add(property);
+    }
+
+    private void documentModelGetters(PropertyNode property) {
+        FieldNode field = property.getField();
+        documentModelGetter(field, getGetterName(field.getName()));
+        if (ClassHelper.boolean_TYPE.equals(field.getType()) || ClassHelper.Boolean_TYPE.equals(field.getType()))
+            documentModelGetter(field, getBooleanGetterName(field.getName()));
+    }
+
+    private void documentModelGetter(FieldNode field, String getterName) {
+        MethodNode getter = transformation.annotatedClass.getDeclaredMethod(getterName, Parameter.EMPTY_ARRAY);
+        JavadocDocBuilder documentation = new JavadocDocBuilder();
+        documentGetter(documentation, field);
+        AnnoDocUtil.addDocumentation(getter, documentation);
+    }
+
+    private static void documentGetter(DocBuilder documentation, FieldNode field) {
+        documentation.title(DocUtil.getGetterText(field));
+        if (!field.getAnnotations(ClassHelper.make(Deprecated.class)).isEmpty())
+            documentation.deprecated(ASTExtractor.extractDocText(field).getTag("deprecated").orElse(null));
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/PropertyAccessors.java
@@ -127,6 +127,8 @@ class PropertyAccessors {
 
     private void documentModelGetter(FieldNode field, String getterName) {
         MethodNode getter = transformation.annotatedClass.getDeclaredMethod(getterName, Parameter.EMPTY_ARRAY);
+        if (getter == null)
+            throw new IllegalStateException("Generated model getter not found: " + transformation.annotatedClass.getName() + "#" + getterName);
         JavadocDocBuilder documentation = new JavadocDocBuilder();
         documentGetter(documentation, field);
         AnnoDocUtil.addDocumentation(getter, documentation);
@@ -134,7 +136,7 @@ class PropertyAccessors {
 
     private static void documentGetter(DocBuilder documentation, FieldNode field) {
         documentation.title(DocUtil.getGetterText(field));
-        if (!field.getAnnotations(ClassHelper.make(Deprecated.class)).isEmpty())
+        if (!field.getAnnotations(AbstractMethodBuilder.DEPRECATED_NODE).isEmpty())
             documentation.deprecated(ASTExtractor.extractDocText(field).getTag("deprecated").orElse(null));
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/AnnoDocTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ast/AnnoDocTest.groovy
@@ -75,6 +75,10 @@ class AnnoDocTest extends AbstractDSLSpec {
         return rwClazz.getMethod(methodName, params).getAnnotation(AnnoDoc)?.value()
     }
 
+    String builderMethodDoc(String methodName, Class... params) {
+        return getClass(clazz.name + '_DSL$Builder').getMethod(methodName, params).getAnnotation(AnnoDoc)?.value()
+    }
+
     String creatorDoc(String methodName, Class... params) {
         def methodNode = getMethod(factoryClassNode, methodName, params)
         return ASTExtractor.extractDocumentation(methodNode)
@@ -123,6 +127,47 @@ import com.blackbuild.groovy.configdsl.transform.DSL
         rwMethodDoc("copyFrom", clazz) == """Copies all non-null/non-empty recipe values from the template to this Builder.
 @param template the recipe to apply"""
 
+    }
+
+    def "generated getters document model and Builder values"() {
+        when:
+        createClass("dummy/Foo.groovy", '''
+package dummy
+
+import com.blackbuild.groovy.configdsl.transform.DSL
+
+@DSL class Foo {
+    /** display name. */
+    String name
+
+    /** active flag. */
+    boolean active
+
+    /** legacy name.
+     * @deprecated Use name instead.
+     */
+    @Deprecated
+    String legacyName
+}
+''')
+
+        then: "completed-model getters are documented"
+        methodDoc("getName") == "Returns the display name."
+        methodDoc("getActive") == "Returns the active flag."
+        methodDoc("isActive") == "Returns the active flag."
+        methodDoc("getLegacyName") == "Returns the legacy name.\n@deprecated Use name instead."
+
+        and: "Builder implementation getters are documented"
+        rwMethodDoc("getName") == "Returns the display name."
+        rwMethodDoc("getActive") == "Returns the active flag."
+        rwMethodDoc("isActive") == "Returns the active flag."
+        rwMethodDoc("getLegacyName") == "Returns the legacy name.\n@deprecated Use name instead."
+
+        and: "public Builder contract getters carry the same documentation"
+        builderMethodDoc("getName") == "Returns the display name."
+        builderMethodDoc("getActive") == "Returns the active flag."
+        builderMethodDoc("isActive") == "Returns the active flag."
+        builderMethodDoc("getLegacyName") == "Returns the legacy name.\n@deprecated Use name instead."
     }
 
     def "javadoc for auto overridden creator"() {


### PR DESCRIPTION
## Summary

- attach field-derived AnnoDoc documentation to completed-model getters
- carry the same documentation onto generated Builder implementations and their public Builder interfaces
- preserve field deprecation reasons on generated getter documentation
- record the change in the 4.0 release notes

## Why

Generated getters omitted documentation even though their source fields and the other generated DSL methods carried AnnoDoc metadata. This left IDE and generated-API documentation incomplete, especially for deprecated fields.

## Impact

This changes generated documentation metadata only. Runtime lifecycle, serialization, and model behavior are unchanged.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.groovy.configdsl.transform.ast.AnnoDocTest`
- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `./gradlew :klum-ast:check`

Closes #383
