### PR TITLE
Authorize workers to open draft PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ Implement issues on a new, dedicated issue branch using small, reasoned commits.
 
 ### Pull requests and releases
 
+Workers may push a dedicated issue branch and open a draft pull request without additional permission when the change is
+small, its intent is settled, and the required review, tests, and documentation are complete. Complex or unresolved work
+still stops at `(ready:PR)`. See `docs/agents/pull-requests.md` for the publication boundary.
+
 User-facing documentation is maintained in `wiki/`. Pull requests with user-visible changes must keep the relevant wiki pages, migration navigation, `CHANGES.md`, linked issues, and SonarCloud findings in sync. See `docs/agents/pull-requests.md`.
 When reacting to pull-request review feedback, post one consolidated follow-up comment that states what was addressed, what
 was intentionally left unchanged and why, and which validation supports the result.

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -2,6 +2,23 @@
 
 Use this checklist for any pull request that changes public behavior, compatibility, or generated APIs.
 
+## Worker draft-pull-request authorization
+
+A worker implementing an assigned change on a dedicated issue branch may push that branch and open a draft pull request
+without asking for additional permission when all of the following are true:
+
+- The change is small and localized, and the implementation follows an established repository pattern.
+- The issue or other accepted specification settles the intended behavior; no product or maintainer decision remains.
+- The work does not require an unresolved cross-cutting architecture, compatibility, public or generated API, migration,
+  or release-policy decision. A localized user-visible fix may still qualify when its expected behavior is already settled.
+- Local review, commit-history review, applicable tests, and required documentation are complete, and any validation gap
+  is stated accurately in the draft pull request.
+- The branch and pull request contain only the assigned work and preserved pre-existing changes are excluded.
+
+If any condition is uncertain or unmet, stop at `(ready:PR)` and ask the maintainer to decide the publication boundary.
+This authorization covers pushing the dedicated branch and creating a draft pull request only. It does not authorize
+marking the pull request ready for review, merging it, or expanding the assigned scope.
+
 ## Pull request scope and issue links
 
 - Use closing keywords only for issues whose accepted behavior is fully delivered by the pull request.

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -48,6 +48,7 @@ local and avoid duplicating the canonical rule across files or skills. Record ex
 work is needed, link its baseline issue or pull request; otherwise, record a brief rationale for keeping the change local.
 Do not invent a baseline location or modify a separate checkout or remote repository without the required authorization.
 
-The reusable portion of this policy is tracked upstream in
+The reusable worker draft-pull-request authorization and the broader reusable portion of this policy are tracked
+upstream in
 [`blackbuild/engineering-baseline#2`](https://github.com/blackbuild/engineering-baseline/issues/2). The KlumAST-specific
 issue-tracker and authorization wording above remains local.


### PR DESCRIPTION
## Summary

- allow workers to push a dedicated issue branch and open a draft pull request without additional permission for small, settled changes
- define the qualifying scope, validation, and documentation criteria, with `(ready:PR)` as the fallback for uncertain or complex work
- record the reusable policy as tracked by `blackbuild/engineering-baseline#2`

## Why

Workers could already create commits autonomously, but the first-publication boundary was implicit. This makes the permitted draft-PR workflow explicit while retaining maintainer control over complex decisions, ready-for-review status, merging, and scope expansion.

## Impact

Straightforward worker changes can reach draft review and CI without an extra handoff. Changes involving unresolved architecture, compatibility, API, migration, or release-policy decisions still require maintainer direction.

## Validation

- `git diff --check`
- No Gradle tests run; this changes agent-policy Markdown only.
