### PR TITLE
Document release season naming

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,6 +33,8 @@ These terms are sourced from the project wiki and consolidated here. Use these c
 
   Keep this theme in project, artifact, and package names rather than API vocabulary, unless a name has a useful software double meaning, as with Klum-Wrap. Klum-Cast is a poor precedent: its name refers to entertainment casting but is easily mistaken for an object-oriented cast, making the project's purpose misleading.
 
+  Major releases may pair their canonical semantic version with a release-facing name in the form `Season <major>: <subtitle>`. The subtitle should use modeling or show vocabulary while describing the release's character, so the theme remains recognizable without obscuring the version or its purpose.
+
 - Domain API Developer
 
   A Domain API Developer defines the stable, consumer-facing model contract that Client Developers compile against. In a Layer 3 model, this contract precedes and constrains the Schema without exposing Schema-specific types to clients.

--- a/docs/implementation/issue-curation/release-4.0.md
+++ b/docs/implementation/issue-curation/release-4.0.md
@@ -5,6 +5,8 @@ This release view is derived from the complete [open issue index](issue-index.md
 current source/tests. ADR 0007 is superseded by ADR 0009, while ADR 0008 remains a later-4.x target. ADRs 0004–0006 and
 0009 define the remaining accepted 4.0 boundaries.
 
+Proposed release name: **Season 4: The Makeover**.
+
 ## Release thesis
 
 4.0 is the breaking Builder-first release. Its minimum coherent scope is to finish and freeze the public boundaries introduced by PR #429:


### PR DESCRIPTION
## Summary

- propose **Season 4: The Makeover** in the 4.0 release plan
- define season-style descriptive names in the Klum project naming glossary
- retain semantic versions as the canonical release identifiers

## Why

Descriptive season names reinforce the Klum/supermodel theme while giving each major release a memorable identity without obscuring its version.

## Validation

- `git diff --check origin/master..HEAD`

Documentation-only change; no build or test suite was run.
