### PR TITLE
Document generated Builder capability

### DIFF
--- a/docs/implementation/adr-0005-generated-dsl-support-api.md
+++ b/docs/implementation/adr-0005-generated-dsl-support-api.md
@@ -44,6 +44,24 @@ Convert `KlumBuilder<T>` to the supported narrow interface, move implementation 
 `@DelegatesToRW`. Compile-fail when both annotations occur. Migrate generated code and tests to Builder vocabulary while
 retaining only the promised source alias.
 
+**Confirmed Builder capability refinement (2026-07-18):** `KlumBuilder<T>` is a zero-operation public construction
+capability, not a general-purpose mutable Builder API. Every generated `Foo_DSL.Builder` extends
+`KlumBuilder<Foo>` (with its declared model generics preserved), and `KlumFactory.BuilderFactory<T, B>` consistently
+uses `B extends KlumBuilder<T>`. The generated `Foo_DSL` interfaces remain the only public surface for
+schema-specific configuration. Runtime state, lifecycle, reflection, materialization, path, copy, and collection
+internals move behind an internal support base. The later dynamic `KlumBuilder.link(fieldName, target)` capability is
+owned by #474 and must not broaden DSL-2.
+
+This shares the intentional 4.0 recompilation boundary already required by package migration. `$_RW` and
+`KlumRwObject` have no retained source or binary compatibility; `@DelegatesToRW` is the sole deprecated source alias.
+After the 4.0 API is delivered, the `KlumBuilder<T>` bound, generated `Foo_DSL` interfaces, and Java
+`Create.getAsBuilder()` / static-Groovy `Create.AsBuilder` shapes are 4.x source and binary contracts. Hidden generated
+implementations remain non-contractual.
+
+The exact JSON-3 descriptors in #463 depend on this slice: an interface `Foo_DSL.Builder` cannot satisfy
+`B extends KlumBuilder<T>` while `KlumBuilder<T>` is a class. #463 remains blocked until DSL-2 is delivered, then proves
+the exact Java 17 and static-Groovy consumer shapes at the Jackson 2.14.2 and 2.21.x endpoints.
+
 ### DSL-3 — Generated-source distribution and documentation
 
 Exercise the DSL-G Gradle/IDE integration against the actual DSL-1 namespace, verify a same-project schema and Java

--- a/docs/implementation/adr-0009-jackson-interoperability.md
+++ b/docs/implementation/adr-0009-jackson-interoperability.md
@@ -75,6 +75,18 @@ The public call shapes are Java-first. Root and Template calls infer completed `
 `Child.Create.AsBuilder`. `applyToBuilder` returns the same Builder identity with its precise type. Issue #467 owns final
 framework factory/accessor naming without changing these importer descriptors.
 
+### Generated Builder capability prerequisite
+
+The descriptors above remain fixed. Their `B extends KlumBuilder<T>` bound requires #394 DSL-2 to make
+`KlumBuilder<T>` a zero-operation public interface and to make each generated `Foo_DSL.Builder` extend that interface;
+runtime implementation moves behind an internal base. This preserves precise Java and static-Groovy Builder inference
+without exposing hidden implementations or widening the importer to erased, reflective, or `Object`-typed alternatives.
+
+#463 is natively blocked by #394 until DSL-2 is delivered. JSON-3 must then compile the exact Java 17 and static-Groovy
+consumer shapes against Jackson 2.14.2 and 2.21.x. The 4.0 package migration already requires schema recompilation, so
+no pre-4.0 concrete `KlumBuilder` or RW-marker binary contract is retained; the delivered importer and generated Builder
+descriptors are 4.x source and binary commitments.
+
 ## Confirmed behavior and compatibility
 
 ### Importer and input ownership
@@ -152,6 +164,9 @@ Implement the confirmed public interface around the existing resolved-property e
 hide Jackson/source/lifecycle coordination behind the importer. No API decision remains open; internal adapter layout,
 reader attributes/context handoff, and parser/tree/Map normalization are implementation choices as long as they cannot
 leak ambient import state into ordinary nested Jackson reads.
+
+Implementation is blocked by #394 DSL-2, not by an unresolved JSON-3 product decision. Do not start with a weakened
+generic bound or an implementation-specific Builder type; first deliver the generated Builder capability prerequisite.
 
 #### Acceptance coverage
 


### PR DESCRIPTION
## Summary

- refine ADR 0005 DSL-2 with the confirmed public KlumBuilder<T> capability and generated Foo_DSL.Builder inheritance
- record the intentional 4.0 recompilation boundary and 4.x compatibility commitment
- document #394 as the prerequisite for JSON-3’s exact Builder descriptors in ADR 0009

## Why

Foo_DSL.Builder is an interface while the current KlumBuilder<T> is a class, so it cannot satisfy JSON-3’s accepted B extends KlumBuilder<T> bound. The maintained decision keeps that descriptor intact and does not expose generated implementations or runtime internals.

## Validation

- git diff --check

Related: #394, #463