### PR TITLE
Fix Codex skill invocation metadata

### DIFF
--- a/.agents/skills/ask-matt/SKILL.md
+++ b/.agents/skills/ask-matt/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ask-matt
 description: Ask which skill or flow fits your situation. A router over the skills in this repo.
-disable-model-invocation: true
 ---
 
 # Ask Matt

--- a/.agents/skills/ask-matt/agents/openai.yaml
+++ b/.agents/skills/ask-matt/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/claude-handoff/SKILL.md
+++ b/.agents/skills/claude-handoff/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: claude-handoff
 description: Hand the current conversation off to a fresh background agent that picks up the work immediately.
-argument-hint: "What will the next session be used for?"
-disable-model-invocation: true
 ---
 
 Write a handoff summary of the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the summary as its prompt: `claude --bg --name "<descriptive name>" "<handoff summary>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.

--- a/.agents/skills/claude-handoff/agents/openai.yaml
+++ b/.agents/skills/claude-handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  default_prompt: "Use $claude-handoff to hand this conversation off for the next session's stated purpose."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: grill-me
 description: A relentless interview to sharpen a plan or design.
-disable-model-invocation: true
 ---
 
 Run a `/grilling` session.

--- a/.agents/skills/grill-me/agents/openai.yaml
+++ b/.agents/skills/grill-me/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: grill-with-docs
 description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
-disable-model-invocation: true
 ---
 
 Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grill-with-docs/agents/openai.yaml
+++ b/.agents/skills/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: handoff
 description: Compact the current conversation into a handoff document for another agent to pick up.
-argument-hint: "What will the next session be used for?"
-disable-model-invocation: true
 ---
 
 Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.

--- a/.agents/skills/handoff/agents/openai.yaml
+++ b/.agents/skills/handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  default_prompt: "Use $handoff to prepare this conversation for the next session's stated purpose."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: implement
 description: "Implement a piece of work based on a PRD or set of issues."
-disable-model-invocation: true
 ---
 
 Implement the work described by the user in the PRD or issues.

--- a/.agents/skills/implement/agents/openai.yaml
+++ b/.agents/skills/implement/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: improve-codebase-architecture
 description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
-disable-model-invocation: true
 ---
 
 # Improve Codebase Architecture

--- a/.agents/skills/improve-codebase-architecture/agents/openai.yaml
+++ b/.agents/skills/improve-codebase-architecture/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/loop-me/SKILL.md
+++ b/.agents/skills/loop-me/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: loop-me
 description: Grill me about specs for the workflows I want to build, within this workspace.
-disable-model-invocation: true
-argument-hint: "A workflow to design, or nothing to go find one"
 ---
 
 Run a stateful `/grilling` session whose only output is **workflow** specs. Use the grilling discipline — relentless, one question at a time, a recommended answer attached to each — aimed at the vocabulary and goal below. Create, edit, and delete specs as the grilling resolves things.

--- a/.agents/skills/loop-me/agents/openai.yaml
+++ b/.agents/skills/loop-me/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  default_prompt: "Use $loop-me to design a stated workflow or help me identify one worth designing."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.agents/skills/setup-matt-pocock-skills/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: setup-matt-pocock-skills
 description: Configure this repo for the engineering skills — set up its issue tracker, triage label vocabulary, domain doc layout, and issue-commit policy. Run once before first use of the other engineering skills.
-disable-model-invocation: true
 ---
 
 # Setup Matt Pocock's Skills

--- a/.agents/skills/setup-matt-pocock-skills/agents/openai.yaml
+++ b/.agents/skills/setup-matt-pocock-skills/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/teach/SKILL.md
+++ b/.agents/skills/teach/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: teach
 description: Teach the user a new skill or concept, within this workspace.
-disable-model-invocation: true
-argument-hint: "What would you like to learn about?"
 ---
 
 The user has asked you to teach them something. This is a stateful request - they intend to learn the topic over multiple sessions.

--- a/.agents/skills/teach/agents/openai.yaml
+++ b/.agents/skills/teach/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  default_prompt: "Use $teach to teach me the stated skill or concept in this workspace."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: to-issues
 description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices.
-disable-model-invocation: true
 ---
 
 # To Issues

--- a/.agents/skills/to-issues/agents/openai.yaml
+++ b/.agents/skills/to-issues/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/to-prd/SKILL.md
+++ b/.agents/skills/to-prd/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: to-prd
 description: Turn the current conversation into a PRD and publish it to the project issue tracker — no interview, just synthesis of what you've already discussed.
-disable-model-invocation: true
 ---
 
 This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.

--- a/.agents/skills/to-prd/agents/openai.yaml
+++ b/.agents/skills/to-prd/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: triage
 description: Move issues and external PRs through a state machine of triage roles — categorise, verify, grill if needed, and write agent-ready briefs.
-disable-model-invocation: true
 ---
 
 # Triage

--- a/.agents/skills/triage/agents/openai.yaml
+++ b/.agents/skills/triage/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/writing-great-skills/SKILL.md
+++ b/.agents/skills/writing-great-skills/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: writing-great-skills
 description: Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable.
-disable-model-invocation: true
 ---
 
 A skill exists to wrangle determinism out of a stochastic system. **Predictability** — the agent taking the same _process_ every run, not producing the same output — is the root virtue; every lever below serves it.
@@ -12,8 +11,10 @@ A skill exists to wrangle determinism out of a stochastic system. **Predictabili
 
 Two choices, trading different costs:
 
-- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
-- A **user-invoked** skill strips the description from the agent's reach: only you, typing its name, can invoke it — and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+- A **model-invoked** skill keeps a **description** in the model context, so the agent can fire it autonomously (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: leave `policy.allow_implicit_invocation` at its default `true`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
+- A **user-invoked** skill keeps its description out of the model context and remains available through explicit `$skill-name` invocation. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `policy.allow_implicit_invocation: false` in `agents/openai.yaml`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Keep `SKILL.md` frontmatter portable. Put Codex-specific invocation and interface settings in `agents/openai.yaml`.
 
 Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
 

--- a/.agents/skills/writing-great-skills/agents/openai.yaml
+++ b/.agents/skills/writing-great-skills/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- move user-invoked skill policy from unsupported `SKILL.md` frontmatter into `agents/openai.yaml`
- preserve four imported argument hints as Codex `interface.default_prompt` values
- correct `writing-great-skills` to document `policy.allow_implicit_invocation`
- apply the migration consistently to all 14 affected repository skills

## Root cause

The imported skills used `disable-model-invocation` (and, in four cases, `argument-hint`) in `SKILL.md`. Codex skill
frontmatter validation does not accept those fields. Codex documents invocation policy under `agents/openai.yaml`; setting
`policy.allow_implicit_invocation: false` keeps a skill out of implicit model context while preserving explicit invocation.

Official reference: https://learn.chatgpt.com/docs/build-skills#optional-metadata

## Impact

Before this change, all 14 affected skills failed `quick_validate.py`, and their intended user-only invocation policy was not
expressed through Codex's supported metadata. The skills still loaded, so their instruction bodies were not corrupted; the
consequences were validation noise and unreliable implicit-trigger suppression.

## Validation

- all 32 repository skills pass `quick_validate.py`
- all 21 `agents/openai.yaml` files parse as YAML; exactly 14 set `allow_implicit_invocation: false`
- fresh-context forward test hides `triage`, `teach`, and `ask-matt` while retaining model-invoked skills
- `git diff --cached --check`
