### PR TITLE
Document documentary test policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ name conflicts or another documented technical necessity. See `docs/agents/codin
 ### Testing
 
 Groovy 3 is the baseline test lane (`test`). Groovy 4 and Groovy 5 compatibility use `groovy4Tests` and `groovy5Tests`; run them when a version difference is expected and at the end of a change, rather than on every focused iteration. Every ignored, conditionally ignored, or pending test must state an actionable reason. See `docs/agents/testing.md`.
+Documentation-only pull requests that cannot affect compilation, test execution, or runtime behavior do not require the
+Groovy test lanes; run the applicable documentation and diff checks instead. See `docs/agents/testing.md`.
 Every newly added test must carry its driving issue number in `@Issue`; a class-level annotation is sufficient while all
 tests in that class originate from the same issue. Add or amend `@Issue` on an existing test only when a change to it is
 significant. Every new user-visible DSL feature also needs a documentary test marked with `@Tag("documentary")` and linked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ Groovy 3 is the baseline test lane (`test`). Groovy 4 and Groovy 5 compatibility
 Every newly added test must carry its driving issue number in `@Issue`; a class-level annotation is sufficient while all
 tests in that class originate from the same issue. Add or amend `@Issue` on an existing test only when a change to it is
 significant. Every new user-visible DSL feature also needs a documentary test marked with `@Tag("documentary")` and linked
-to its documentation through `@See`. See `docs/agents/testing.md`.
+to its documentation through `@See`. Name new executable test classes with the `Test` suffix; use
+`<Theme>DocumentaryTest` for dedicated documentary classes. Existing `*Spec` classes need not be renamed. See
+`docs/agents/testing.md`.
 
 ### Feature discussion examples
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,10 @@ name conflicts or another documented technical necessity. See `docs/agents/codin
 ### Testing
 
 Groovy 3 is the baseline test lane (`test`). Groovy 4 and Groovy 5 compatibility use `groovy4Tests` and `groovy5Tests`; run them when a version difference is expected and at the end of a change, rather than on every focused iteration. Every ignored, conditionally ignored, or pending test must state an actionable reason. See `docs/agents/testing.md`.
-Tests added for user-visible feature work must carry the driving issue number in `@Issue`. Every new user-visible DSL
-feature also needs a documentary test marked with `@Tag("documentary")` and linked to its documentation through `@See`.
-See `docs/agents/testing.md`.
+Every newly added test must carry its driving issue number in `@Issue`; a class-level annotation is sufficient while all
+tests in that class originate from the same issue. Add or amend `@Issue` on an existing test only when a change to it is
+significant. Every new user-visible DSL feature also needs a documentary test marked with `@Tag("documentary")` and linked
+to its documentation through `@See`. See `docs/agents/testing.md`.
 
 ### Feature discussion examples
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,16 @@ name conflicts or another documented technical necessity. See `docs/agents/codin
 ### Testing
 
 Groovy 3 is the baseline test lane (`test`). Groovy 4 and Groovy 5 compatibility use `groovy4Tests` and `groovy5Tests`; run them when a version difference is expected and at the end of a change, rather than on every focused iteration. Every ignored, conditionally ignored, or pending test must state an actionable reason. See `docs/agents/testing.md`.
+Tests added for user-visible feature work must carry the driving issue number in `@Issue`. Every new user-visible DSL
+feature also needs a documentary test marked with `@Tag("documentary")` and linked to its documentation through `@See`.
+See `docs/agents/testing.md`.
+
+### Feature discussion examples
+
+During grilling and implementation, usually present a compact usage example in the conversation so the feature's syntax
+and feel can be evaluated early. For DSL changes, use only Groovy and show the relevant Schema or Model syntax. For client
+APIs, show Java first and Groovy second. Evolve the example into the documentary test and user documentation once the
+feature direction is settled. See `docs/agents/testing.md`.
 
 ### Issue implementation commits
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -38,9 +38,11 @@ marking the pull request ready for review, merging it, or expanding the assigned
 - Fix reliability and security findings before handoff. Address maintainability findings or retain them only with a localized suppression and a concrete reason.
 - Do not use broad suppressions to hide unrelated findings. A suppression is documentation of an intentional exception and must explain the invariant or compatibility constraint.
 - Follow `docs/agents/testing.md`: use Groovy 3 for focused iterations and run the Groovy 4 and 5 compatibility lanes before final handoff.
-- For user-visible feature work, verify that new tests carry the driving `@Issue` number. A new user-visible DSL feature
-  must also have a documentary test marked with `@Tag("documentary")` and linked to its documentation through `@See`.
-  The feature issue, test, and documentation must reference one another as defined in `docs/agents/testing.md`.
+- Verify that every new test carries its driving `@Issue` number, using a class-level annotation while one issue owns the
+  complete specification. Add or amend `@Issue` on changed existing tests only for significant behavioral changes. A new
+  user-visible DSL feature must also have a documentary test marked with `@Tag("documentary")` and linked to its
+  documentation through `@See`. The feature issue, test, and documentation must reference one another as defined in
+  `docs/agents/testing.md`.
 
 ## Review feedback follow-up
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -43,6 +43,8 @@ marking the pull request ready for review, merging it, or expanding the assigned
   user-visible DSL feature must also have a documentary test marked with `@Tag("documentary")` and linked to its
   documentation through `@See`. The feature issue, test, and documentation must reference one another as defined in
   `docs/agents/testing.md`.
+- Verify that new executable test classes use the `Test` suffix and that dedicated documentary classes use
+  `<Theme>DocumentaryTest`. Existing `*Spec` classes need not be renamed unless a scoped rename improves the change.
 
 ## Review feedback follow-up
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -38,6 +38,9 @@ marking the pull request ready for review, merging it, or expanding the assigned
 - Fix reliability and security findings before handoff. Address maintainability findings or retain them only with a localized suppression and a concrete reason.
 - Do not use broad suppressions to hide unrelated findings. A suppression is documentation of an intentional exception and must explain the invariant or compatibility constraint.
 - Follow `docs/agents/testing.md`: use Groovy 3 for focused iterations and run the Groovy 4 and 5 compatibility lanes before final handoff.
+- For user-visible feature work, verify that new tests carry the driving `@Issue` number. A new user-visible DSL feature
+  must also have a documentary test marked with `@Tag("documentary")` and linked to its documentation through `@See`.
+  The feature issue, test, and documentation must reference one another as defined in `docs/agents/testing.md`.
 
 ## Review feedback follow-up
 
@@ -57,6 +60,8 @@ marking the pull request ready for review, merging it, or expanding the assigned
 
 - Add user-visible features, fixes, deprecations, and compatibility breaks to the next release section in `CHANGES.md`.
 - The canonical user documentation lives in `wiki/`, not under `docs/`. Update every affected feature page as part of the behavioral change.
+- Demonstrate new user-visible DSL features with concise examples aligned with their documentary tests, and identify the
+  corresponding documentary test file and feature method on the affected wiki page.
 - Put migration guides in `wiki/`. A substantial migration may use a dedicated page, but it must be linked from `wiki/Migration.md`.
 - Whenever a wiki page is added, renamed, or removed, update `wiki/_Sidebar.md` so the page remains discoverable.
 - Keep provisional policies explicitly labelled and linked to the issue that will finalize them.

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -37,7 +37,9 @@ marking the pull request ready for review, merging it, or expanding the assigned
 - Inspect all required CI checks, including SonarCloud, against the current pull request revision.
 - Fix reliability and security findings before handoff. Address maintainability findings or retain them only with a localized suppression and a concrete reason.
 - Do not use broad suppressions to hide unrelated findings. A suppression is documentation of an intentional exception and must explain the invariant or compatibility constraint.
-- Follow `docs/agents/testing.md`: use Groovy 3 for focused iterations and run the Groovy 4 and 5 compatibility lanes before final handoff.
+- Follow `docs/agents/testing.md`: use Groovy 3 for focused iterations and run the Groovy 4 and 5 compatibility lanes
+  before final handoff. Documentation-only pull requests that cannot affect compilation, tests, generated output, or
+  runtime behavior may omit the Groovy lanes when the applicable documentation and diff checks are reported instead.
 - Verify that every new test carries its driving `@Issue` number, using a class-level annotation while one issue owns the
   complete specification. Add or amend `@Issue` on changed existing tests only for significant behavioral changes. A new
   user-visible DSL feature must also have a documentary test marked with `@Tag("documentary")` and linked to its

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -15,13 +15,13 @@ Start with the narrowest relevant Groovy 3 test, then run the affected module's 
 Typical commands are:
 
 ```shell
-./gradlew :klum-ast:test --tests com.blackbuild.groovy.configdsl.transform.SomeSpec
+./gradlew :klum-ast:test --tests com.blackbuild.groovy.configdsl.transform.SomeTest
 ./gradlew test
 ./gradlew groovy4Tests groovy5Tests
 ./gradlew check
 ```
 
-## Issue traceability and documentary tests
+## Issue traceability
 
 Every newly added test must carry Spock's `@Issue` annotation with the number of its driving GitHub issue. When a complete
 specification or test class relates to one issue, put `@Issue` on the class; that remains sufficient for every test that
@@ -33,6 +33,25 @@ When implementation changes an existing test, add or amend its `@Issue` annotati
 A change is significant when it materially changes the tested behavior, scenario, or expected contract. Mechanical edits,
 renames, formatting, or adjustments to shared setup do not require issue-annotation churn.
 
+The driving issue is the normal historical link from a test. When an ADR governs the behavior, the governing issue must
+reference it. Do not routinely repeat that ADR link on every test. Add another `@See` for the ADR only when the test
+directly enforces an architectural decision or non-obvious invariant and the link materially helps a reader understand why
+the asserted boundary is intentional. A documentary happy path should normally link to user documentation rather than an
+ADR.
+
+## Test class naming and organization
+
+Name every new executable test class with the `Test` suffix. Use `<Subject><Concern>Test` when a concern distinguishes the
+class from other tests for the same subject, or `<Subject>Test` when the subject is already narrow. Do not introduce new
+`*Spec` names. Existing `*Spec` classes need not be renamed; they may be renamed when the change stays within the task's
+scope and all test filters and references remain correct.
+
+A production class or concept does not need a one-to-one test class. Split its tests into multiple classes when each
+resulting class has a cohesive purpose and the split improves readability, navigation, or fixture clarity. Avoid splitting
+so finely that related behavior or setup becomes harder to understand.
+
+## Documentary tests
+
 Every new user-visible DSL feature must also have one or more documentary tests. At least one should normally be a happy
 path that demonstrates the feature's basic use as readable, executable DSL code. Prefer meaningful hypothetical domain
 vocabulary over placeholders such as `Foo` and `Bar` when that makes the example easier to understand.
@@ -42,6 +61,17 @@ entire specification is documentary, in which case a specification-level tag is 
 feature or specification to link to the relevant documentation element. `@See` is represented as an attachment in Spock
 reports, so give it an absolute URL to the current documentation source and include a heading anchor when it is stable.
 Until issue #456 settles the final documentation placement, a URL to the relevant file under `wiki/` is sufficient.
+
+Documentary tests may live beside the focused behavioral tests or in a separate thematic class. Prefer a dedicated
+`<Theme>DocumentaryTest` when several examples form a coherent reading path or review entry point, share comprehensible
+domain setup, or span multiple driving issues within one theme. Keep an isolated documentary happy path with its focused
+behavioral tests when extraction would duplicate fixtures or fragment ownership. Use `DocumentaryTest`, not
+`DocumentationTest`, so the name identifies an executable example rather than suggesting a test of documentation tooling.
+
+In a dedicated documentary class, put `@Tag("documentary")` on the class in addition to using the documentary class name.
+If its features originate from different issues, put `@Issue` on each feature method. Put `@See` on each feature when the
+documentation targets differ; a class-level `@See` is sufficient only when one documentation target genuinely covers the
+whole class.
 
 The normal annotation shape is:
 
@@ -54,9 +84,29 @@ def "demonstrates the basic feature syntax"() {
 }
 ```
 
-Do not require a feature-name prefix as a second documentary marker; the tag is the single machine-readable convention.
-`@Narrative` and `@Title` apply only to specifications, so they may improve a wholly documentary specification but do not
-replace its `@Tag("documentary")` marker.
+A thematic class spanning issues normally looks like:
+
+```groovy
+@Tag("documentary")
+class TemplatesDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("123")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Templates.md#applying-templates")
+    def "applies a named template"() {
+        // first readable example
+    }
+
+    @Issue("124")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Templates.md#combining-templates")
+    def "combines templates in declaration order"() {
+        // related example from another issue
+    }
+}
+```
+
+Do not require documentary prefixes in feature-method names. `@Tag("documentary")` is the machine-readable marker, while
+the `DocumentaryTest` suffix identifies a dedicated documentary class. `@Narrative` and `@Title` apply only to
+specifications, so they may improve a wholly documentary specification but do not replace its `documentary` tag.
 
 Keep the feature issue, documentary test, and user documentation mutually traceable:
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -12,6 +12,12 @@ KlumAST supports three Groovy generations. Passing one generation is not evidenc
 
 Start with the narrowest relevant Groovy 3 test, then run the affected module's Groovy 3 suite. Run Groovy 4 and 5 sparingly during development unless the change touches compiler APIs, AST behavior, Groovy syntax, dependency compatibility, or another known version seam. Before handing off a completed change, run both compatibility lanes; the root `check` task includes them for projects using the multi-Groovy convention.
 
+A documentation-only pull request does not require the Groovy 3, 4, or 5 test lanes when its changes cannot affect
+compilation, test execution, generated output, or runtime behavior. Run `git diff --check` plus any applicable Markdown,
+link, rendering, or documentation-generation checks instead, and state the omission in the pull request. Treat changes to
+build configuration, executable or compiled examples, generated-source inputs, and test fixtures as code changes rather
+than documentation-only changes.
+
 Typical commands are:
 
 ```shell

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -21,12 +21,17 @@ Typical commands are:
 ./gradlew check
 ```
 
-## Feature traceability and documentary tests
+## Issue traceability and documentary tests
 
-Every test added as part of user-visible feature work must carry Spock's `@Issue` annotation with the number of the
-driving GitHub issue. Put the annotation on the specification when one issue owns all of its tests, or on individual
-features when a specification covers several issues. Choose the specific implementation issue or its governing parent
-case by case, according to which one best explains the behavior under test.
+Every newly added test must carry Spock's `@Issue` annotation with the number of its driving GitHub issue. When a complete
+specification or test class relates to one issue, put `@Issue` on the class; that remains sufficient for every test that
+originates from the same issue. Annotate an individual test when it originates from a different issue, such as a later bug
+fix or feature addition. Choose the specific implementation issue or its governing parent case by case, according to
+which one best explains the behavior under test.
+
+When implementation changes an existing test, add or amend its `@Issue` annotation only if the test change is significant.
+A change is significant when it materially changes the tested behavior, scenario, or expected contract. Mechanical edits,
+renames, formatting, or adjustments to shared setup do not require issue-annotation churn.
 
 Every new user-visible DSL feature must also have one or more documentary tests. At least one should normally be a happy
 path that demonstrates the feature's basic use as readable, executable DSL code. Prefer meaningful hypothetical domain

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -21,6 +21,67 @@ Typical commands are:
 ./gradlew check
 ```
 
+## Feature traceability and documentary tests
+
+Every test added as part of user-visible feature work must carry Spock's `@Issue` annotation with the number of the
+driving GitHub issue. Put the annotation on the specification when one issue owns all of its tests, or on individual
+features when a specification covers several issues. Choose the specific implementation issue or its governing parent
+case by case, according to which one best explains the behavior under test.
+
+Every new user-visible DSL feature must also have one or more documentary tests. At least one should normally be a happy
+path that demonstrates the feature's basic use as readable, executable DSL code. Prefer meaningful hypothetical domain
+vocabulary over placeholders such as `Foo` and `Bar` when that makes the example easier to understand.
+
+Mark each documentary test with Spock's `@Tag("documentary")`. Put the tag on an individual feature method unless the
+entire specification is documentary, in which case a specification-level tag is sufficient. Use `@See` on the same
+feature or specification to link to the relevant documentation element. `@See` is represented as an attachment in Spock
+reports, so give it an absolute URL to the current documentation source and include a heading anchor when it is stable.
+Until issue #456 settles the final documentation placement, a URL to the relevant file under `wiki/` is sufficient.
+
+The normal annotation shape is:
+
+```groovy
+@Issue("123")
+@Tag("documentary")
+@See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Feature.md#basic-use")
+def "demonstrates the basic feature syntax"() {
+    // readable happy path
+}
+```
+
+Do not require a feature-name prefix as a second documentary marker; the tag is the single machine-readable convention.
+`@Narrative` and `@Title` apply only to specifications, so they may improve a wholly documentary specification but do not
+replace its `@Tag("documentary")` marker.
+
+Keep the feature issue, documentary test, and user documentation mutually traceable:
+
+- The feature issue names the documentary test file and feature method, and the relevant documentation element. A wiki
+  filename is sufficient while the final documentation placement remains open.
+- The documentary test carries the driving `@Issue` number, the `documentary` tag, and an `@See` link to the relevant
+  documentation file or section.
+- The documentation demonstrates the feature with an abbreviated example that may omit imports and other setup, and
+  refers to the documentary test file and feature method. Align the example with the test where practical so executable
+  coverage guards the documented usage.
+
+This policy applies prospectively. Do not expand unrelated feature work by retrofitting the existing suite; the existing
+documentation and test audit is tracked in [issue #491](https://github.com/klum-dsl/klum-ast/issues/491). This policy is
+KlumAST-specific because it connects the project's DSL behavior, Spock suite, GitHub issues, and user documentation.
+
+## Feature discussion examples
+
+During grilling and implementation of a user-visible feature, normally present a compact usage example in the dialogue
+before the design is considered settled. Use it as a syntax probe: it should be small enough that a reviewer can quickly
+get a feel for the feature, question awkward calls or names, and compare alternatives. Once accepted, use it as the seed
+for the documentary test and its abbreviated documentation example.
+
+- When the feature changes the DSL, show only Groovy. Show Schema code, Model code, or both according to the surface being
+  designed; omit unrelated setup.
+- When the feature changes a client API, show Java first as the primary contract and Groovy second as the convenience
+  view.
+- For a feature spanning both DSL and client surfaces, apply the corresponding language rule to each example.
+- An internal-only change or a discussion without a meaningful usage surface may omit the example, but state that briefly
+  instead of silently skipping it.
+
 ## Suppressed tests
 
 Every test-suppressing annotation must explain why the test does not currently run. This includes `@Ignore`, `@IgnoreIf`, and `@PendingFeature`.


### PR DESCRIPTION
## Summary

- require every newly added test to carry its driving Spock `@Issue`, with a class-level annotation sufficient while one issue owns the complete test class
- require annotations on changed existing tests only when their behavior, scenario, or expected contract changes significantly
- standardize new executable test classes on `<Subject><Concern>Test`; existing `*Spec` classes need no blanket rename
- allow one class or concept to use several cohesive test classes when that improves readability
- require user-visible DSL features to provide documentary happy paths marked with `@Tag("documentary")` and linked to user documentation through `@See`
- define `<Theme>DocumentaryTest` for coherent thematic documentary collections, including collections spanning several driving issues
- define reciprocal traceability among feature issues, documentary tests, and documentation examples, with selective ADR links only for tests that directly enforce architectural decisions
- require compact feature examples during grilling and implementation, using Groovy for DSL changes and Java-first plus Groovy for client APIs
- allow documentation-only PRs to omit Groovy test lanes when they cannot affect compilation, tests, generated output, or runtime behavior and report the applicable documentation checks instead
- add the issue-traceability, naming, documentary-test, and validation checks to the pull-request and release-documentation guidance

## Motivation

Tests should retain lightweight ownership history without repeating method-level annotations throughout a single-issue test class or creating annotation churn for mechanical edits. A consistent `Test` suffix improves navigation without forcing unrelated legacy renames, while cohesive splitting avoids oversized test classes.

KlumAST also places unusual weight on clear, approachable syntax. Documentary tests give reviewers an executable first view of a feature. Dedicated `<Theme>DocumentaryTest` classes are preferred when several examples form a coherent reading path or review entry point; isolated examples may remain with focused behavioral tests.

The policy applies prospectively. Existing documentation and test alignment remains separate audit work. Documentation-only policy or Markdown PRs need documentation validation, but running the Groovy compatibility matrix adds no evidence when the change cannot affect executable behavior.

## Review

- Standards review: no violations or reportable smells
- Specification review: all conversation requirements represented after the follow-up amendments

## Validation

- `git diff --check`
- `./gradlew groovy4Tests groovy5Tests` (passed earlier in this PR; the finalized policy no longer requires these lanes for qualifying documentation-only PRs)

## Related work

Related: #491

Issue #456 remains responsible for the final versioned documentation placement.
