### PR TITLE
Isolate multi-Groovy test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,19 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: success() || failure()
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/*/TEST-*.xml'
           check_name: 'JUnit Test Report'
+      - name: Archive compatibility-lane evidence
+        uses: actions/upload-artifact@v7
+        if: success() || failure()
+        with:
+          name: compatibility-lane-evidence
+          path: |
+            **/build/test-results/groovy4Tests/TEST-*.xml
+            **/build/test-results/groovy5Tests/TEST-*.xml
+            code-coverage-report/build/reports/jacoco/groovy4CodeCoverageReport/**
+            code-coverage-report/build/reports/jacoco/groovy5CodeCoverageReport/**
+          if-no-files-found: error
       - name: Archive test classes
         uses: actions/upload-artifact@v7
         if: failure()

--- a/buildSrc/src/main/groovy/klum-ast.jacoco-conventions.gradle
+++ b/buildSrc/src/main/groovy/klum-ast.jacoco-conventions.gradle
@@ -9,6 +9,7 @@ jacoco {
 sonar {
     properties {
         property "sonar.coverage.jacoco.xmlReportPaths",
-                project(":code-coverage-report").tasks.withType(JacocoReport).collect { it.reports.xml.outputLocation.getAsFile().get().absolutePath }.join(",")
+                project(":code-coverage-report").tasks.named("testCodeCoverageReport", JacocoReport)
+                        .get().reports.xml.outputLocation.getAsFile().get().absolutePath
     }
 }

--- a/buildSrc/src/main/groovy/klum-ast.multigroovy-conventions.gradle
+++ b/buildSrc/src/main/groovy/klum-ast.multigroovy-conventions.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+
 plugins {
     id "klum-ast.java-conventions"
     id 'jvm-test-suite'
@@ -30,6 +32,12 @@ testing {
                     srcDirs = ['src/test/groovy']
                     destinationDirectory = file("build/classes/groovy/test-g$groovyVersion")
                 }
+                java {
+                    srcDirs = ['src/test/java']
+                }
+                resources {
+                    srcDirs = ['src/test/resources']
+                }
             }
 
             dependencies {
@@ -38,7 +46,6 @@ testing {
                 implementation libs.spock.junit4."g$groovyVersion"
                 implementation libs.groovy."v$groovyVersion"
                 implementation platform(libs.groovy."v$groovyVersion".bom)
-                implementation sourceSets.test.output
                 implementation 'uk.org.webcompere:system-stubs-core:2.1.8'
                 runtimeOnly libs.bytebuddy
                 runtimeOnly libs.objenesis
@@ -51,6 +58,83 @@ testing {
     }
 }
 
+def testLanes = [
+        3: [
+                sourceSet : sourceSets.test,
+                classpath : configurations.testRuntimeClasspath,
+                compileTask: tasks.named('compileTestGroovy'),
+                testTask   : tasks.named('test')
+        ],
+        4: [
+                sourceSet : sourceSets.groovy4Tests,
+                classpath : configurations.groovy4TestsRuntimeClasspath,
+                compileTask: tasks.named('compileGroovy4TestsGroovy'),
+                testTask   : tasks.named('groovy4Tests')
+        ],
+        5: [
+                sourceSet : sourceSets.groovy5Tests,
+                classpath : configurations.groovy5TestsRuntimeClasspath,
+                compileTask: tasks.named('compileGroovy5TestsGroovy'),
+                testTask   : tasks.named('groovy5Tests')
+        ]
+]
+
+tasks.register('verifyTestLaneIsolation') {
+    group = 'verification'
+    description = 'Verifies matching Groovy/Spock dependencies, isolated test output, and lane-specific JUnit results.'
+    dependsOn testLanes.values()*.testTask
+    mustRunAfter testLanes.values()*.testTask
+
+    doLast {
+        testLanes.each { generation, lane ->
+            def components = lane.classpath.incoming.resolutionResult.allComponents*.id.findAll {
+                it instanceof ModuleComponentIdentifier
+            }
+            def groovyComponents = components.findAll { it.group in ['org.codehaus.groovy', 'org.apache.groovy'] }
+            def expectedGroovyGroup = generation == 3 ? 'org.codehaus.groovy' : 'org.apache.groovy'
+            if (groovyComponents.isEmpty() || groovyComponents.any {
+                it.group != expectedGroovyGroup || it.version != libs.versions.groovy."v$generation".get()
+            })
+                throw new GradleException("Groovy $generation lane contains mismatched Groovy modules: $groovyComponents")
+
+            def spockComponents = components.findAll { it.group == 'org.spockframework' }
+            if (spockComponents.isEmpty() || spockComponents.any {
+                it.version != libs.versions.spock."g$generation".get()
+            })
+                throw new GradleException("Groovy $generation lane contains mismatched Spock modules: $spockComponents")
+
+            def forbiddenOutput = testLanes.findAll { otherGeneration, ignored -> otherGeneration != generation }
+                    .values()
+                    .collectMany { otherLane ->
+                        otherLane.sourceSet.output.classesDirs.files + [otherLane.sourceSet.output.resourcesDir]
+                    }
+                    .findAll { it != null }
+            def sourceSetCompileLeak = lane.sourceSet.compileClasspath.files.intersect(forbiddenOutput)
+            if (!sourceSetCompileLeak.isEmpty())
+                throw new GradleException("Groovy $generation source-set compile classpath contains another lane's output: $sourceSetCompileLeak")
+
+            def groovyCompileLeak = lane.compileTask.get().classpath.files.intersect(forbiddenOutput)
+            if (!groovyCompileLeak.isEmpty())
+                throw new GradleException("Groovy $generation Groovy compile classpath contains another lane's output: $groovyCompileLeak")
+
+            def testTask = lane.testTask.get()
+            def runtimeLeak = testTask.classpath.files.intersect(forbiddenOutput)
+            if (!runtimeLeak.isEmpty())
+                throw new GradleException("Groovy $generation test runtime classpath contains another lane's output: $runtimeLeak")
+
+            def expectedClasses = lane.sourceSet.output.classesDirs.files
+            if (testTask.testClassesDirs.files != expectedClasses)
+                throw new GradleException("Groovy $generation executes unexpected test classes: ${testTask.testClassesDirs.files}")
+
+            def expectedResults = layout.buildDirectory.dir("test-results/${testTask.name}").get().asFile
+            if (testTask.reports.junitXml.outputLocation.get().asFile != expectedResults)
+                throw new GradleException("Groovy $generation writes JUnit results outside $expectedResults")
+            if (!expectedResults.directory)
+                throw new GradleException("Groovy $generation did not produce JUnit results in $expectedResults")
+        }
+    }
+}
+
 // Need to add test fixtures as source, since we compile with different spock versions
 tasks.withType(GroovyCompile).configureEach {
     if (!name.contains("Test") || name.contains("Fixtures")) return
@@ -60,4 +144,5 @@ tasks.withType(GroovyCompile).configureEach {
 tasks.named('check') {
     dependsOn(testing.suites.groovy4Tests)
     dependsOn(testing.suites.groovy5Tests)
+    dependsOn(tasks.named('verifyTestLaneIsolation'))
 }

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -21,11 +21,11 @@ reporting {
         testCodeCoverageReport(JacocoCoverageReport) {
             testSuiteName = "test"
         }
-        groovy3CodeCoverageReport(JacocoCoverageReport) {
-            testSuiteName = "groovy3Tests"
-        }
         groovy4CodeCoverageReport(JacocoCoverageReport) {
             testSuiteName = "groovy4Tests"
+        }
+        groovy5CodeCoverageReport(JacocoCoverageReport) {
+            testSuiteName = "groovy5Tests"
         }
     }
 }

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -2,6 +2,13 @@
 
 KlumAST supports three Groovy generations. Passing one generation is not evidence that the other two pass, even when their compiler behavior is currently similar.
 
+The baseline and compatibility lanes share only their production artifact plus explicit `src/test/java` and
+`src/test/resources` inputs. Groovy test sources and Groovy test fixtures are compiled separately in each lane.
+`verifyTestLaneIsolation`, which is part of `check`, rejects mismatched Groovy/Spock dependencies, cross-lane compiled
+test or resource output on source-set/Groovy compile/runtime classpaths, non-lane test classes, and non-lane JUnit result
+directories. CI keeps the Groovy-4/5 JUnit and JaCoCo reports as compatibility-lane evidence; Sonar consumes only the
+Groovy-3 baseline report so production classes are not counted once per lane.
+
 ## Test lanes
 
 | Gradle task | Groovy generation | Use |

--- a/docs/implementation/adr-0011-shared-multi-groovy-compatibility-contract.md
+++ b/docs/implementation/adr-0011-shared-multi-groovy-compatibility-contract.md
@@ -79,8 +79,10 @@ consumer generations.
 test-fixture source layout.
 
 **Work:** remove the cross-lane Groovy output edge; make a Java/resources-only sharing seam explicit where needed;
-recompile all Groovy fixtures per lane; ensure G4/G5 result and coverage evidence is discoverable. Preserve the one
-Groovy-3 production artifact and Java 17 toolchain.
+recompile all Groovy fixtures per lane; add `verifyTestLaneIsolation` to reject mismatched dependencies, cross-lane
+source-set/Groovy compile/runtime output, wrong test classes, or non-lane JUnit result locations; archive G4/G5 JUnit and
+JaCoCo evidence while Sonar uses only baseline coverage. Preserve the one Groovy-3 production artifact and Java 17
+toolchain.
 
 **Acceptance:** inspect the G4/G5 compile/runtime classpaths; run `test`, `groovy4Tests`, `groovy5Tests`, and `check` on
 Java 17; exercise the build cache; verify CI result paths/report tasks include all lanes. If the #391 fixture is touched,


### PR DESCRIPTION
Closes #496

## What changed

- Removes Groovy-3 test-output leakage from the Groovy 4/5 suites.
- Makes shared Java and resource test inputs explicit, while recompiling Groovy test sources and fixtures per lane.
- Adds `verifyTestLaneIsolation` to reject mismatched Groovy/Spock dependencies, cross-lane source-set/Groovy compile or runtime output, wrong test classes, and wrong JUnit result locations.
- Publishes Groovy 4/5 JUnit and JaCoCo evidence in CI; Sonar uses only the Groovy-3 baseline report to avoid triple-counting production coverage.

## Why

The compatibility suites previously received `sourceSets.test.output`, which can contain Groovy-3-compiled test classes. That invalidates independent Groovy 4/5 compatibility evidence.

## Validation

- `./gradlew test groovy4Tests groovy5Tests --build-cache`
- `./gradlew check --build-cache`
- Clean Groovy-4 test compilation restored `FROM-CACHE`.

No published coordinates, production compilation contract, or #391 JPMS design changes.