### PR TITLE
Remove obsolete FieldAstValidator TODO

### DIFF
--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
@@ -45,7 +45,6 @@ public class FieldAstValidator extends KlumCastCheck<Annotation> {
     @Override
     protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
         this.annotationToCheck = annotationToCheck;
-        // TODO move logic to klumCast
         if (target instanceof FieldNode)
             extraValidateField((FieldNode) target);
         else if (target instanceof MethodNode)


### PR DESCRIPTION
## Summary

Removes the obsolete `TODO move logic to klumCast` comment from `FieldAstValidator`.

## Why

The dispatch investigation concluded that this validation remains consumer-owned KlumAST behavior; a KlumCast helper is not planned.

## Impact

No production behavior or public API changes.

## Validation

- `git diff --check`
- Inspected the final one-line commit diff
