### PR TITLE
Add explicit Jackson importer modes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,9 @@ This is a breaking release. See the [Builder-first construction migration](https
   [#251](https://github.com/klum-dsl/klum-ast/issues/251),
   [ADR 0009](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0009-jackson-interoperability.md)).
   Explicit type-level custom deserializers remain the opt-out.
+- Added `KlumJacksonImporter` and `KlumJacksonInput` as the explicit Jackson 2 import seam. Caller-owned mapper/reader
+  configuration is captured without mutation; root, value-only Template, active-session Builder, and existing-Builder
+  application modes each consume one parser/tree/Map input ([#463](https://github.com/klum-dsl/klum-ast/issues/463)).
 - Jackson `LINK` import is reference-only. Explicit Jackson identities with `alwaysAsId`, custom property codecs, and
   custom `ObjectIdResolver`s preserve completed targets and same-session Builder identity across backward and forward
   references, including Collection and Map `LINK`s. Inline input fails with focused mapping errors. Export requires an

--- a/klum-ast-jackson/build.gradle
+++ b/klum-ast-jackson/build.gradle
@@ -16,6 +16,26 @@ dependencies {
     sharedTests project(':klum-ast')
     // just to make intellij happy, base classes are actually included as sources
     testCompileOnly(testFixtures(project(':klum-ast')))
+    testImplementation gradleTestKit()
+}
+
+// Gradle TestKit embeds Groovy 3, which cannot share a compiler classpath with the
+// Groovy 4/5 Spock lanes. The TestKit acceptance spec compiles Java and static-Groovy
+// consumers at both Jackson endpoints in the baseline lane; importer behavior itself
+// remains covered in all three project Groovy lanes by KlumJacksonImporterSpec.
+["groovy4Tests", "groovy5Tests"].each { lane ->
+    sourceSets.named(lane) {
+        groovy.exclude "com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy"
+    }
+}
+
+tasks.named("test") {
+    dependsOn(":klum-ast:jar", ":klum-ast-annotations:jar", ":klum-ast-runtime:jar", "jar")
+    systemProperty("klumAstJar", project(":klum-ast").tasks.named("jar").flatMap { it.archiveFile }.get().asFile)
+    systemProperty("klumAnnotationsJar", project(":klum-ast-annotations").tasks.named("jar")
+            .flatMap { it.archiveFile }.get().asFile)
+    systemProperty("klumRuntimeJar", project(":klum-ast-runtime").tasks.named("jar").flatMap { it.archiveFile }.get().asFile)
+    systemProperty("klumJacksonJar", tasks.named("jar").flatMap { it.archiveFile }.get().asFile)
 }
 
 publishing {

--- a/klum-ast-jackson/build.gradle
+++ b/klum-ast-jackson/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 //    api project(':klum-ast-annotations')
     api project(':klum-ast-runtime')
 
-    api 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    api "com.fasterxml.jackson.core:jackson-databind:${providers.gradleProperty('jacksonVersion').getOrElse('2.14.2')}"
 
     sharedTests project(':klum-ast')
     // just to make intellij happy, base classes are actually included as sources

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -36,6 +36,7 @@ import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumModelException;
 import com.blackbuild.klum.ast.util.LifecycleHelper;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -302,7 +303,8 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
             ignored.add(objectIdInfo.getPropertyName().getSimpleName());
         description.getClassInfo().fields().forEach(field -> addIgnoredFieldName(field, ignored, context));
         description.findProperties().forEach(definition -> {
-            Optional<ResolvedProperty> resolved = definition.couldDeserialize() && visibleInActiveView(definition, context)
+            Optional<ResolvedProperty> resolved = acceptsConfiguration(definition, context)
+                    && visibleInActiveView(definition, context)
                     ? toResolvedProperty(currentType, definition, context)
                     : Optional.empty();
             Stream<String> names = Stream.concat(
@@ -318,6 +320,28 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
                 .getDefaultPropertyIgnorals(currentType, description.getClassInfo());
         ignored.addAll(ignorals.findIgnoredForDeserialization());
         return new ResolvedProperties(bindable, ignored, ignorals.getIgnoreUnknown());
+    }
+
+    /**
+     * Klum configuration binds generated Builder fields, which do not expose Jackson bean mutators. Jackson 2.21 no
+     * longer reports such field-backed properties as {@code couldDeserialize()}, even though their metadata remains
+     * the correct configured input surface. Honour explicit read-only and ignore annotations instead.
+     */
+    private static boolean acceptsConfiguration(BeanPropertyDefinition property, DeserializationContext context) {
+        return Stream.of(property.getPrimaryMember(), property.getField(), property.getGetter(), property.getSetter())
+                .filter(Objects::nonNull)
+                .distinct()
+                .noneMatch(member -> context.getAnnotationIntrospector().hasIgnoreMarker(member)
+                        || isReadOnly(member, context));
+    }
+
+    private static boolean isReadOnly(AnnotatedMember member, DeserializationContext context) {
+        JsonProperty.Access access = context.getAnnotationIntrospector().findPropertyAccess(member);
+        if (access == null) {
+            JsonProperty property = member.getAnnotation(JsonProperty.class);
+            access = property == null ? null : property.access();
+        }
+        return access == JsonProperty.Access.READ_ONLY;
     }
 
     private static boolean visibleInActiveView(BeanPropertyDefinition property, DeserializationContext context) {
@@ -357,7 +381,7 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
     private Optional<ResolvedProperty> toResolvedProperty(Class<?> currentType, BeanPropertyDefinition property,
                                                            DeserializationContext context) {
         Optional<Field> schemaField = DslHelper.getField(currentType, property.getInternalName());
-        if (schemaField.isEmpty() || !isConfigurable(schemaField.get()))
+        if (schemaField.isEmpty() || !isConfigurable(schemaField.get()) || isReadOnly(schemaField.get()))
             return Optional.empty();
         AnnotatedMember contextualMember = Stream.of(
                         property.getField(), property.getSetter(), property.getGetter(), property.getPrimaryMember())
@@ -380,6 +404,11 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
                 beanProperty,
                 schemaField.get()
         ));
+    }
+
+    private static boolean isReadOnly(Field field) {
+        JsonProperty property = field.getAnnotation(JsonProperty.class);
+        return property != null && property.access() == JsonProperty.Access.READ_ONLY;
     }
 
     private static String resolveKey(Class<?> currentType, ObjectNode configuration, Object keyHint,

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -168,9 +168,9 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
             return null;
         if (!parser.isExpectedStartObjectToken())
             return context.handleUnexpectedToken(modelType, parser);
-        ObjectNode configuration = readObject(parser, context);
         try {
             request.markHandled();
+            ObjectNode configuration = readObject(parser, context);
             return switch (request.mode()) {
                 case ROOT -> replay(configuration, parser, context);
                 case TEMPLATE -> replayTemplate(configuration, parser, context);

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -754,6 +754,7 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
             return mode;
         }
 
+        @SuppressWarnings("java:S1452") // a managed request may target any generated Builder model type
         KlumBuilder<?> target() {
             return target;
         }

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumDeserializer.java
@@ -32,6 +32,8 @@ import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.util.DslHelper;
 import com.blackbuild.klum.ast.util.FactoryHelper;
 import com.blackbuild.klum.ast.util.InternalKlumBuilder;
+import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.KlumModelException;
 import com.blackbuild.klum.ast.util.LifecycleHelper;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -84,6 +86,8 @@ import java.util.stream.Stream;
  */
 final class KlumDeserializer extends StdDeserializer<Object> implements ContextualDeserializer {
 
+    private static final ThreadLocal<ManagedRequest> MANAGED_REQUEST = new ThreadLocal<>();
+
     /**
      * Carries the replay session only across the synchronous re-entry caused by
      * {@link ReplaySession#discoverPolymorphicBuilder(ObjectNode, JavaType, TypeDeserializer, Object)} calling
@@ -122,6 +126,9 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
 
     @Override
     public Object deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        ManagedRequest managedRequest = MANAGED_REQUEST.get();
+        if (managedRequest != null && !managedRequest.wasHandled() && managedRequest.matches(modelType))
+            return deserializeManaged(parser, context, managedRequest);
         OwnedBuilderRequest request = OWNED_BUILDER_REQUEST.get();
         if (request != null && request.context() == context)
             return request.session().addOwnedBuilder(
@@ -139,6 +146,38 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
         } catch (RuntimeException exception) {
             throw JsonMappingException.from(parser, "Could not replay configuration for " + modelType.getName()
                     + " through its Builder lifecycle", exception);
+        }
+    }
+
+    static <T> T withManagedRequest(ManagedRequest request, ThrowingSupplier<T> action) throws IOException {
+        ManagedRequest previous = MANAGED_REQUEST.get();
+        MANAGED_REQUEST.set(request);
+        try {
+            return action.get();
+        } finally {
+            if (previous == null)
+                MANAGED_REQUEST.remove();
+            else
+                MANAGED_REQUEST.set(previous);
+        }
+    }
+
+    private Object deserializeManaged(JsonParser parser, DeserializationContext context, ManagedRequest request)
+            throws IOException {
+        if (parser.currentToken() == JsonToken.VALUE_NULL)
+            return null;
+        if (!parser.isExpectedStartObjectToken())
+            return context.handleUnexpectedToken(modelType, parser);
+        ObjectNode configuration = readObject(parser, context);
+        try {
+            request.markHandled();
+            return switch (request.mode()) {
+                case ROOT -> replay(configuration, parser, context);
+                case TEMPLATE -> replayTemplate(configuration, parser, context);
+                case BUILDER, APPLY -> replayInto(internalBuilder(request.target()), configuration, parser, context);
+            };
+        } catch (UncheckedIOException failure) {
+            throw failure.getCause();
         }
     }
 
@@ -168,8 +207,34 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
         ReplaySession replaySession = new ReplaySession(source, context);
         return PhaseDriver.withBuilderLifecycle(
                 () -> FactoryHelper.createBuilder(modelType, key),
-                builder -> replaySession.replay(builder, configuration, properties)
+                builder -> replaySession.replay(builder, configuration, properties, true)
         );
+    }
+
+    private Object replayTemplate(ObjectNode configuration, JsonParser source, DeserializationContext context) {
+        InternalKlumBuilder<?> builder = internalBuilder(FactoryHelper.createTemplateBuilderForImport(modelType));
+        return replayInto(builder, configuration, source, context, true);
+    }
+
+    private Object replayInto(InternalKlumBuilder<?> builder, ObjectNode configuration, JsonParser source,
+                              DeserializationContext context) {
+        return replayInto(builder, configuration, source, context, false);
+    }
+
+    private Object replayInto(InternalKlumBuilder<?> builder, ObjectNode configuration, JsonParser source,
+                              DeserializationContext context, boolean template) {
+        if (builder == null)
+            throw new KlumModelException("Managed Jackson import did not receive a Builder target");
+        ResolvedProperties properties = resolveProperties(modelType, context);
+        ReplaySession replaySession = new ReplaySession(source, context);
+        replaySession.replay(builder, configuration, properties, !template);
+        return template ? InternalKlumBuilder.materializeTemplateForImport(builder) : builder;
+    }
+
+    private static InternalKlumBuilder<?> internalBuilder(KlumBuilder<?> builder) {
+        if (builder instanceof InternalKlumBuilder<?> internalBuilder)
+            return internalBuilder;
+        throw new KlumModelException("Managed Jackson import requires an active generated Builder implementation");
     }
 
     private static Collection<Object> createCollection(JavaType type) {
@@ -361,17 +426,20 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
             this.context = context;
         }
 
-        private void replay(InternalKlumBuilder<?> root, ObjectNode configuration, ResolvedProperties properties) {
+        private void replay(InternalKlumBuilder<?> root, ObjectNode configuration, ResolvedProperties properties,
+                            boolean runLifecycle) {
             try {
                 addBuilder(root, configuration, properties);
-                for (PendingBuilder pending : pendingBuilders) {
-                    pending.builder().setCurrentTemplates(Collections.emptyMap());
-                    LifecycleHelper.executeLifecycleMethods(pending.builder(), PostCreate.class);
-                }
+                if (runLifecycle)
+                    for (PendingBuilder pending : pendingBuilders) {
+                        pending.builder().setCurrentTemplates(Collections.emptyMap());
+                        LifecycleHelper.executeLifecycleMethods(pending.builder(), PostCreate.class);
+                    }
                 for (PendingBuilder pending : pendingBuilders)
                     bindConfiguration(pending);
-                for (PendingBuilder pending : pendingBuilders)
-                    LifecycleHelper.executeLifecycleMethods(pending.builder(), PostApply.class);
+                if (runLifecycle)
+                    for (PendingBuilder pending : pendingBuilders)
+                        LifecycleHelper.executeLifecycleMethods(pending.builder(), PostApply.class);
             } catch (IOException exception) {
                 throw new UncheckedIOException(exception);
             }
@@ -622,6 +690,57 @@ final class KlumDeserializer extends StdDeserializer<Object> implements Contextu
             pending.configuration().fields().forEachRemaining(entry -> bind(
                     pending.builder(), entry.getKey(), entry.getValue(), pending.properties(), pending.ownedValues()));
         }
+    }
+
+    enum ManagedMode {
+        ROOT("readRoot"), TEMPLATE("readTemplate"), BUILDER("readBuilder"), APPLY("applyToBuilder");
+
+        private final String operation;
+
+        ManagedMode(String operation) {
+            this.operation = operation;
+        }
+
+        String operation() {
+            return operation;
+        }
+    }
+
+    static final class ManagedRequest {
+        private final ManagedMode mode;
+        private final KlumBuilder<?> target;
+        private boolean handled;
+
+        ManagedRequest(ManagedMode mode, KlumBuilder<?> target) {
+            this.mode = mode;
+            this.target = target;
+        }
+
+        private boolean matches(Class<?> type) {
+            return target == null || target instanceof InternalKlumBuilder<?> builder
+                    && builder.getModelType().equals(type);
+        }
+
+        ManagedMode mode() {
+            return mode;
+        }
+
+        KlumBuilder<?> target() {
+            return target;
+        }
+
+        boolean wasHandled() {
+            return handled;
+        }
+
+        void markHandled() {
+            handled = true;
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingSupplier<T> {
+        T get() throws IOException;
     }
 
     private record PendingBuilder(InternalKlumBuilder<?> builder, ObjectNode configuration, ResolvedProperties properties,

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
@@ -1,0 +1,146 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.jackson;
+
+import com.blackbuild.klum.ast.util.KlumBuilder;
+import com.blackbuild.klum.ast.util.KlumException;
+import com.blackbuild.klum.ast.util.KlumFactory;
+import com.blackbuild.klum.ast.util.KlumModelException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+/**
+ * Explicit, Builder-first Jackson import operations.
+ *
+ * <p>The importer captures one untyped {@link ObjectReader}; it never mutates a mapper or registers a module. Configure
+ * Jackson, including {@link KlumAstModule}, before creating it. Each method consumes exactly one
+ * {@link KlumJacksonInput}; parser lifecycle remains with the caller.</p>
+ */
+public final class KlumJacksonImporter {
+
+    private final ObjectReader reader;
+
+    private KlumJacksonImporter(ObjectReader reader) {
+        this.reader = reader;
+    }
+
+    /** Captures {@link ObjectMapper#reader()} once without changing the mapper. */
+    public static KlumJacksonImporter using(ObjectMapper mapper) {
+        return new KlumJacksonImporter(Objects.requireNonNull(mapper, "mapper").reader());
+    }
+
+    /** Captures an untyped, non-updating reader while preserving all of its caller configuration. */
+    public static KlumJacksonImporter using(ObjectReader reader) {
+        Objects.requireNonNull(reader, "reader");
+        if (reader.getValueType() != null || valueToUpdate(reader) != null)
+            throw new IllegalArgumentException("reader must be untyped and must not update an existing value");
+        return new KlumJacksonImporter(reader);
+    }
+
+    /** Reads one root DSL Object through its normal Builder lifecycle. */
+    public <T> T readRoot(Class<T> type, KlumJacksonInput input) {
+        return read(type, input, KlumDeserializer.ManagedMode.ROOT, null);
+    }
+
+    /** Reads a value-only Template without running lifecycle callbacks or phases. */
+    public <T> T readTemplate(Class<T> type, KlumJacksonInput input) {
+        return read(type, input, KlumDeserializer.ManagedMode.TEMPLATE, null);
+    }
+
+    /** Reads one owned Builder in the current Construction session without materializing it. */
+    public <T, B extends KlumBuilder<T>> B readBuilder(KlumFactory.BuilderFactory<T, B> factory,
+                                                        KlumJacksonInput input) {
+        Objects.requireNonNull(factory, "factory");
+        return read(factory.$modelTypeForImport(), input, KlumDeserializer.ManagedMode.BUILDER,
+                factory.$createForImport());
+    }
+
+    /** Applies one input to the same unsealed Builder in its active Construction session. */
+    public <B extends KlumBuilder<?>> B applyToBuilder(B builder, KlumJacksonInput input) {
+        Objects.requireNonNull(builder, "builder");
+        return read(builder.getModelType(), input, KlumDeserializer.ManagedMode.APPLY, builder);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, R> R read(Class<T> type, KlumJacksonInput input, KlumDeserializer.ManagedMode mode,
+                          KlumBuilder<?> target) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(input, "input");
+        KlumDeserializer.ManagedRequest request = new KlumDeserializer.ManagedRequest(mode, target);
+        try (KlumJacksonInput.InputParser source = input.open(reader)) {
+            JsonParser parser = source.parser();
+            R result = (R) KlumDeserializer.withManagedRequest(request,
+                    () -> reader.forType(type).readValue(parser));
+            if (!request.wasHandled())
+                throw new KlumModelException("Jackson " + mode.operation() + " import requires KlumAstModule for "
+                        + type.getName());
+            return result;
+        } catch (KlumException exception) {
+            throw exception;
+        } catch (IOException exception) {
+            if (!request.wasHandled())
+                throw missingModule(type, exception);
+            throw importFailure(mode, type, input, exception);
+        } catch (RuntimeException exception) {
+            if (exception.getCause() instanceof KlumException klumException)
+                throw klumException;
+            throw importFailure(mode, type, input, exception);
+        }
+    }
+
+    private static KlumModelException missingModule(Class<?> type, Throwable cause) {
+        return new KlumModelException("Managed Jackson import requires KlumAstModule for " + type.getName(), cause);
+    }
+
+    private static KlumModelException importFailure(KlumDeserializer.ManagedMode mode, Class<?> type,
+                                                     KlumJacksonInput input, Throwable cause) {
+        Throwable directCause = cause instanceof JsonMappingException mapping && mapping.getCause() != null
+                ? mapping.getCause()
+                : cause;
+        return new KlumModelException("Jackson " + mode.operation() + " import of " + type.getName()
+                + " failed: " + cause.getMessage() + " at " + diagnosticPath(type, mode, input), directCause);
+    }
+
+    private static String diagnosticPath(Class<?> type, KlumDeserializer.ManagedMode mode, KlumJacksonInput input) {
+        return "$/" + type.getSimpleName() + "." + mode.operation() + ":jackson(" + input.sourceName() + ")";
+    }
+
+    private static Object valueToUpdate(ObjectReader reader) {
+        try {
+            Field field = ObjectReader.class.getDeclaredField("_valueToUpdate");
+            if (!field.trySetAccessible())
+                throw new IllegalArgumentException("reader value-to-update configuration cannot be inspected");
+            return field.get(reader);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalArgumentException("reader value-to-update configuration cannot be inspected", exception);
+        }
+    }
+}

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
@@ -23,15 +23,14 @@
  */
 package com.blackbuild.klum.ast.jackson;
 
+import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.blackbuild.klum.ast.util.InternalKlumBuilder;
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumException;
 import com.blackbuild.klum.ast.util.KlumFactory;
 import com.blackbuild.klum.ast.util.KlumModelException;
-import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -149,13 +148,13 @@ public final class KlumJacksonImporter {
                     () -> reader.forType(type).readValue(parser));
             if (!request.wasHandled() && mode == KlumDeserializer.ManagedMode.ROOT && hasTypeLevelCustomDeserializer(type))
                 return result;
-            if (!request.wasHandled())
+            if (!request.wasHandled()) {
                 if (hasTypeLevelCustomDeserializer(type))
                     throw new KlumModelException("Jackson " + mode.operation()
                             + " import does not support a type-level custom deserializer for " + type.getName());
-                else
                 throw new KlumModelException("Jackson " + mode.operation() + " import requires KlumAstModule for "
                         + type.getName());
+            }
             return result;
         } catch (KlumException exception) {
             throw exception;

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
@@ -23,6 +23,7 @@
  */
 package com.blackbuild.klum.ast.jackson;
 
+import com.blackbuild.klum.ast.util.InternalKlumBuilder;
 import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumException;
 import com.blackbuild.klum.ast.util.KlumFactory;
@@ -126,7 +127,9 @@ public final class KlumJacksonImporter {
      */
     public <B extends KlumBuilder<?>> B applyToBuilder(B builder, KlumJacksonInput input) {
         Objects.requireNonNull(builder, "builder");
-        return read(builder.getModelType(), input, KlumDeserializer.ManagedMode.APPLY, builder);
+        if (!(builder instanceof InternalKlumBuilder<?> internalBuilder))
+            throw new KlumModelException("Jackson applyToBuilder import requires an active generated Builder");
+        return read(internalBuilder.getModelType(), input, KlumDeserializer.ManagedMode.APPLY, builder);
     }
 
     @SuppressWarnings("unchecked")

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
@@ -52,12 +52,23 @@ public final class KlumJacksonImporter {
         this.reader = reader;
     }
 
-    /** Captures {@link ObjectMapper#reader()} once without changing the mapper. */
+    /**
+     * Captures {@link ObjectMapper#reader()} once without changing the mapper.
+     *
+     * @param mapper caller-configured mapper
+     * @return immutable importer using the mapper's current reader configuration
+     */
     public static KlumJacksonImporter using(ObjectMapper mapper) {
         return new KlumJacksonImporter(Objects.requireNonNull(mapper, "mapper").reader());
     }
 
-    /** Captures an untyped, non-updating reader while preserving all of its caller configuration. */
+    /**
+     * Captures an untyped, non-updating reader while preserving all of its caller configuration.
+     *
+     * @param reader caller-configured untyped reader
+     * @return immutable importer retaining that reader
+     * @throws IllegalArgumentException if the reader is typed or updates an existing value
+     */
     public static KlumJacksonImporter using(ObjectReader reader) {
         Objects.requireNonNull(reader, "reader");
         if (reader.getValueType() != null || valueToUpdate(reader) != null)
@@ -65,17 +76,39 @@ public final class KlumJacksonImporter {
         return new KlumJacksonImporter(reader);
     }
 
-    /** Reads one root DSL Object through its normal Builder lifecycle. */
+    /**
+     * Reads one root DSL Object through its normal Builder lifecycle.
+     *
+     * @param type DSL model type
+     * @param input one caller-owned Jackson input
+     * @param <T> completed DSL model type
+     * @return the completed root model
+     */
     public <T> T readRoot(Class<T> type, KlumJacksonInput input) {
         return read(type, input, KlumDeserializer.ManagedMode.ROOT, null);
     }
 
-    /** Reads a value-only Template without running lifecycle callbacks or phases. */
+    /**
+     * Reads a value-only Template without running lifecycle callbacks or phases.
+     *
+     * @param type DSL model type
+     * @param input one caller-owned Jackson input
+     * @param <T> completed DSL model type
+     * @return marked value-only Template
+     */
     public <T> T readTemplate(Class<T> type, KlumJacksonInput input) {
         return read(type, input, KlumDeserializer.ManagedMode.TEMPLATE, null);
     }
 
-    /** Reads one owned Builder in the current Construction session without materializing it. */
+    /**
+     * Reads one owned Builder in the current Construction session without materializing it.
+     *
+     * @param factory generated Builder-producing factory
+     * @param input one caller-owned Jackson input
+     * @param <T> DSL model type
+     * @param <B> precise generated Builder type
+     * @return unsealed Builder from the active session
+     */
     public <T, B extends KlumBuilder<T>> B readBuilder(KlumFactory.BuilderFactory<T, B> factory,
                                                         KlumJacksonInput input) {
         Objects.requireNonNull(factory, "factory");
@@ -83,7 +116,14 @@ public final class KlumJacksonImporter {
                 factory.$createForImport());
     }
 
-    /** Applies one input to the same unsealed Builder in its active Construction session. */
+    /**
+     * Applies one input to the same unsealed Builder in its active Construction session.
+     *
+     * @param builder active unsealed Builder
+     * @param input one caller-owned Jackson input
+     * @param <B> precise Builder type
+     * @return the identical Builder instance
+     */
     public <B extends KlumBuilder<?>> B applyToBuilder(B builder, KlumJacksonInput input) {
         Objects.requireNonNull(builder, "builder");
         return read(builder.getModelType(), input, KlumDeserializer.ManagedMode.APPLY, builder);

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonImporter.java
@@ -28,14 +28,19 @@ import com.blackbuild.klum.ast.util.KlumBuilder;
 import com.blackbuild.klum.ast.util.KlumException;
 import com.blackbuild.klum.ast.util.KlumFactory;
 import com.blackbuild.klum.ast.util.KlumModelException;
+import com.blackbuild.klum.ast.process.PhaseDriver;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -113,8 +118,8 @@ public final class KlumJacksonImporter {
     public <T, B extends KlumBuilder<T>> B readBuilder(KlumFactory.BuilderFactory<T, B> factory,
                                                         KlumJacksonInput input) {
         Objects.requireNonNull(factory, "factory");
-        return read(factory.$modelTypeForImport(), input, KlumDeserializer.ManagedMode.BUILDER,
-                factory.$createForImport());
+        B builder = factory.FromMap(Collections.emptyMap());
+        return read(internalBuilder(builder).getModelType(), input, KlumDeserializer.ManagedMode.BUILDER, builder);
     }
 
     /**
@@ -127,8 +132,8 @@ public final class KlumJacksonImporter {
      */
     public <B extends KlumBuilder<?>> B applyToBuilder(B builder, KlumJacksonInput input) {
         Objects.requireNonNull(builder, "builder");
-        if (!(builder instanceof InternalKlumBuilder<?> internalBuilder))
-            throw new KlumModelException("Jackson applyToBuilder import requires an active generated Builder");
+        InternalKlumBuilder<?> internalBuilder = internalBuilder(builder);
+        PhaseDriver.requireCurrentConstructionSession(internalBuilder);
         return read(internalBuilder.getModelType(), input, KlumDeserializer.ManagedMode.APPLY, builder);
     }
 
@@ -142,17 +147,25 @@ public final class KlumJacksonImporter {
             JsonParser parser = source.parser();
             R result = (R) KlumDeserializer.withManagedRequest(request,
                     () -> reader.forType(type).readValue(parser));
+            if (!request.wasHandled() && mode == KlumDeserializer.ManagedMode.ROOT && hasTypeLevelCustomDeserializer(type))
+                return result;
             if (!request.wasHandled())
+                if (hasTypeLevelCustomDeserializer(type))
+                    throw new KlumModelException("Jackson " + mode.operation()
+                            + " import does not support a type-level custom deserializer for " + type.getName());
+                else
                 throw new KlumModelException("Jackson " + mode.operation() + " import requires KlumAstModule for "
                         + type.getName());
             return result;
         } catch (KlumException exception) {
             throw exception;
         } catch (IOException exception) {
+            rethrowKlumException(exception);
             if (!request.wasHandled())
                 throw missingModule(type, exception);
             throw importFailure(mode, type, input, exception);
         } catch (RuntimeException exception) {
+            rethrowKlumException(exception);
             if (exception.getCause() instanceof KlumException klumException)
                 throw klumException;
             throw importFailure(mode, type, input, exception);
@@ -163,17 +176,64 @@ public final class KlumJacksonImporter {
         return new KlumModelException("Managed Jackson import requires KlumAstModule for " + type.getName(), cause);
     }
 
-    private static KlumModelException importFailure(KlumDeserializer.ManagedMode mode, Class<?> type,
-                                                     KlumJacksonInput input, Throwable cause) {
-        Throwable directCause = cause instanceof JsonMappingException mapping && mapping.getCause() != null
-                ? mapping.getCause()
-                : cause;
-        return new KlumModelException("Jackson " + mode.operation() + " import of " + type.getName()
-                + " failed: " + cause.getMessage() + " at " + diagnosticPath(type, mode, input), directCause);
+    private static InternalKlumBuilder<?> internalBuilder(KlumBuilder<?> builder) {
+        if (builder instanceof InternalKlumBuilder<?> internalBuilder)
+            return internalBuilder;
+        throw new KlumModelException("Jackson Builder import requires an active generated Builder");
     }
 
-    private static String diagnosticPath(Class<?> type, KlumDeserializer.ManagedMode mode, KlumJacksonInput input) {
-        return "$/" + type.getSimpleName() + "." + mode.operation() + ":jackson(" + input.sourceName() + ")";
+    private static boolean hasTypeLevelCustomDeserializer(Class<?> type) {
+        JsonDeserialize annotation = type.getAnnotation(JsonDeserialize.class);
+        return annotation != null && annotation.using() != JsonDeserializer.None.class;
+    }
+
+    private static KlumModelException importFailure(KlumDeserializer.ManagedMode mode, Class<?> type,
+                                                     KlumJacksonInput input, Throwable cause) {
+        rethrowKlumException(cause);
+        return new KlumModelException("Jackson " + mode.operation() + " import of " + type.getName()
+                + " failed: " + conciseCause(cause) + " at " + diagnosticPath(type, mode, input, cause), cause);
+    }
+
+    private static void rethrowKlumException(Throwable failure) {
+        if (failure instanceof KlumException exception)
+            throw exception;
+        if (failure.getCause() instanceof KlumException exception)
+            throw exception;
+    }
+
+    private static String conciseCause(Throwable cause) {
+        if (cause instanceof JsonProcessingException processingException)
+            return processingException.getOriginalMessage();
+        return cause.getMessage();
+    }
+
+    private static String diagnosticPath(Class<?> type, KlumDeserializer.ManagedMode mode, KlumJacksonInput input,
+                                         Throwable cause) {
+        return "$/" + type.getSimpleName() + "." + mode.operation() + ":jackson(" + input.sourceName() + ")"
+                + inputPointer(cause) + syntaxLocation(cause);
+    }
+
+    private static String inputPointer(Throwable cause) {
+        if (!(cause instanceof JsonMappingException mappingException) || mappingException.getPath().isEmpty())
+            return "";
+        String pointer = mappingException.getPath().stream()
+                .map(reference -> reference.getFieldName() != null ? escapePointer(reference.getFieldName())
+                        : Integer.toString(reference.getIndex()))
+                .reduce("", (path, segment) -> path + "/" + segment);
+        return "/input(#" + pointer + ")";
+    }
+
+    private static String escapePointer(String value) {
+        return value.replace("~", "~0").replace("/", "~1");
+    }
+
+    private static String syntaxLocation(Throwable cause) {
+        if (!(cause instanceof JsonProcessingException processingException) || processingException.getLocation() == null)
+            return "";
+        var location = processingException.getLocation();
+        if (location.getLineNr() < 1 || location.getColumnNr() < 1)
+            return "";
+        return ":line " + location.getLineNr() + ", column " + location.getColumnNr();
     }
 
     private static Object valueToUpdate(ObjectReader reader) {

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
@@ -77,7 +77,10 @@ public final class KlumJacksonInput {
             return new InputParser(parser, false);
         if (tree != null)
             return new InputParser(tree.traverse(reader.getFactory().getCodec()), true);
-        JsonNode mapTree = new ObjectMapper().valueToTree(map);
+        ObjectMapper mapper = reader.getFactory().getCodec() instanceof ObjectMapper configuredMapper
+                ? configuredMapper
+                : new ObjectMapper();
+        JsonNode mapTree = reader.readTree(mapper.writeValueAsBytes(map));
         return new InputParser(mapTree.traverse(reader.getFactory().getCodec()), true);
     }
 

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One caller-owned Jackson input for a {@link KlumJacksonImporter} operation.
+ *
+ * <p>A parser remains owned by its caller and is neither rewound nor closed. Tree and map inputs are read without
+ * changing the supplied value. Call {@link #named(String)} to attach an opaque source name to diagnostics.</p>
+ */
+public final class KlumJacksonInput {
+
+    private final JsonParser parser;
+    private final JsonNode tree;
+    private final Map<?, ?> map;
+    private final String source;
+
+    private KlumJacksonInput(JsonParser parser, JsonNode tree, Map<?, ?> map, String source) {
+        this.parser = parser;
+        this.tree = tree;
+        this.map = map;
+        this.source = source;
+    }
+
+    /** Borrows one single-pass parser. The importer never closes it. */
+    public static KlumJacksonInput parser(JsonParser parser) {
+        return new KlumJacksonInput(Objects.requireNonNull(parser, "parser"), null, null, null);
+    }
+
+    /** Uses an immutable view of a caller-owned Jackson tree. */
+    public static KlumJacksonInput tree(JsonNode node) {
+        return new KlumJacksonInput(null, Objects.requireNonNull(node, "node"), null, null);
+    }
+
+    /** Uses a caller-owned Map without mutating it. */
+    public static KlumJacksonInput map(Map<?, ?> values) {
+        return new KlumJacksonInput(null, null, Objects.requireNonNull(values, "values"), null);
+    }
+
+    /** Returns this input with an opaque source identity used only for diagnostics. */
+    public KlumJacksonInput named(String source) {
+        return new KlumJacksonInput(parser, tree, map, Objects.requireNonNull(source, "source"));
+    }
+
+    InputParser open(ObjectReader reader) throws IOException {
+        if (parser != null)
+            return new InputParser(parser, false);
+        if (tree != null)
+            return new InputParser(tree.traverse(reader.getFactory().getCodec()), true);
+        JsonNode mapTree = new ObjectMapper().valueToTree(map);
+        return new InputParser(mapTree.traverse(reader.getFactory().getCodec()), true);
+    }
+
+    String sourceName() {
+        if (source != null)
+            return source;
+        if (parser != null)
+            return "parser";
+        if (tree != null)
+            return "tree";
+        return "map";
+    }
+
+    record InputParser(JsonParser parser, boolean closeWhenDone) implements AutoCloseable {
+        @Override
+        public void close() throws IOException {
+            if (closeWhenDone)
+                parser.close();
+        }
+    }
+}

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/KlumJacksonInput.java
@@ -52,22 +52,42 @@ public final class KlumJacksonInput {
         this.source = source;
     }
 
-    /** Borrows one single-pass parser. The importer never closes it. */
+    /**
+     * Borrows one single-pass parser. The importer never closes it.
+     *
+     * @param parser caller-owned parser
+     * @return immutable parser input
+     */
     public static KlumJacksonInput parser(JsonParser parser) {
         return new KlumJacksonInput(Objects.requireNonNull(parser, "parser"), null, null, null);
     }
 
-    /** Uses an immutable view of a caller-owned Jackson tree. */
+    /**
+     * Uses an immutable view of a caller-owned Jackson tree.
+     *
+     * @param node caller-owned tree
+     * @return immutable tree input
+     */
     public static KlumJacksonInput tree(JsonNode node) {
         return new KlumJacksonInput(null, Objects.requireNonNull(node, "node"), null, null);
     }
 
-    /** Uses a caller-owned Map without mutating it. */
+    /**
+     * Uses a caller-owned Map without mutating it.
+     *
+     * @param values caller-owned values
+     * @return immutable map input
+     */
     public static KlumJacksonInput map(Map<?, ?> values) {
         return new KlumJacksonInput(null, null, Objects.requireNonNull(values, "values"), null);
     }
 
-    /** Returns this input with an opaque source identity used only for diagnostics. */
+    /**
+     * Returns this input with an opaque source identity used only for diagnostics.
+     *
+     * @param source opaque source name
+     * @return equivalent input with that diagnostic source name
+     */
     public KlumJacksonInput named(String source) {
         return new KlumJacksonInput(parser, tree, map, Objects.requireNonNull(source, "source"));
     }

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
@@ -45,14 +45,16 @@ class JacksonImporterConsumerTest extends Specification {
             import com.blackbuild.klum.ast.jackson.KlumJacksonInput;
             import com.fasterxml.jackson.databind.ObjectMapper;
 
+            import java.util.Map;
+
             class JavaConsumer {
                 static ExternalValue importValue(ObjectMapper mapper) {
                     KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
-                    ExternalValue root = importer.readRoot(ExternalValue.class, KlumJacksonInput.map(java.util.Map.of()));
-                    ExternalValue template = importer.readTemplate(ExternalValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    ExternalValue root = importer.readRoot(ExternalValue.class, KlumJacksonInput.map(Map.of()));
+                    ExternalValue template = importer.readTemplate(ExternalValue.class, KlumJacksonInput.map(Map.of()));
                     ExternalValue_DSL.Builder builder = importer.readBuilder(
-                            ExternalValue.Create.getAsBuilder(), KlumJacksonInput.map(java.util.Map.of()));
-                    ExternalValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(java.util.Map.of()));
+                            ExternalValue.Create.getAsBuilder(), KlumJacksonInput.map(Map.of()));
+                    ExternalValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(Map.of()));
                     return root;
                 }
             }

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
@@ -1,0 +1,154 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.jackson
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.TempDir
+
+@Issue("463")
+class JacksonImporterConsumerTest extends Specification {
+
+    @TempDir
+    File projectDir
+
+    def "an external Java 17 consumer compiles every importer mode against Jackson 2.14"() {
+        given:
+        writeBuild('2.14.2', 'java')
+        writeModel()
+        writeSource('consumer/src/main/java/example/JavaConsumer.java', '''
+            package example;
+
+            import com.blackbuild.klum.ast.jackson.KlumJacksonImporter;
+            import com.blackbuild.klum.ast.jackson.KlumJacksonInput;
+            import com.fasterxml.jackson.databind.ObjectMapper;
+
+            class JavaConsumer {
+                static ExternalValue importValue(ObjectMapper mapper) {
+                    KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
+                    ExternalValue root = importer.readRoot(ExternalValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    ExternalValue template = importer.readTemplate(ExternalValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    ExternalValue_DSL.Builder builder = importer.readBuilder(
+                            ExternalValue.Create.getAsBuilder(), KlumJacksonInput.map(java.util.Map.of()));
+                    ExternalValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(java.util.Map.of()));
+                    return root;
+                }
+            }
+        ''')
+
+        expect:
+        build()
+    }
+
+    def "an external static Groovy consumer compiles every importer mode against Jackson 2.21"() {
+        given:
+        writeBuild('2.21.0', 'groovy')
+        writeModel()
+        writeSource('consumer/src/main/groovy/example/StaticConsumer.groovy', '''
+            package example
+
+            import com.blackbuild.klum.ast.jackson.KlumJacksonImporter
+            import com.blackbuild.klum.ast.jackson.KlumJacksonInput
+            import com.fasterxml.jackson.databind.ObjectMapper
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticConsumer {
+                static ExternalValue importValue(ObjectMapper mapper) {
+                    KlumJacksonImporter importer = KlumJacksonImporter.using(mapper)
+                    ExternalValue root = importer.readRoot(ExternalValue, KlumJacksonInput.map([:]))
+                    ExternalValue template = importer.readTemplate(ExternalValue, KlumJacksonInput.map([:]))
+                    ExternalValue_DSL.Builder builder = importer.readBuilder(
+                            ExternalValue.Create.AsBuilder, KlumJacksonInput.map([:]))
+                    ExternalValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map([:]))
+                    root
+                }
+            }
+        ''')
+
+        expect:
+        build()
+    }
+
+    private void writeBuild(String jacksonVersion, String consumerLanguage) {
+        writeSource('settings.gradle', """
+            rootProject.name = 'jackson-importer-consumer'
+            include 'model', 'consumer'
+        """)
+        writeSource('model/build.gradle', buildScript(jacksonVersion, 'groovy', null))
+        writeSource('consumer/build.gradle', buildScript(jacksonVersion, consumerLanguage, "implementation project(':model')"))
+    }
+
+    private static String buildScript(String jacksonVersion, String language, String projectDependency) {
+        return """
+            plugins {
+                id '${language}'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                ${projectDependency ?: ''}
+                implementation files(
+                        System.getProperty('klumAstJar'),
+                        System.getProperty('klumAnnotationsJar'),
+                        System.getProperty('klumRuntimeJar'),
+                        System.getProperty('klumJacksonJar'))
+                implementation 'com.blackbuild.annodocimal:anno-docimal-ast:0.7.1'
+                implementation 'org.codehaus.groovy:groovy:3.0.25'
+                implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+            }
+        """.stripIndent()
+    }
+
+    private void writeModel() {
+        writeSource('model/src/main/groovy/example/ExternalValue.groovy', '''
+            package example
+
+            import com.blackbuild.groovy.configdsl.transform.DSL
+
+            @DSL
+            class ExternalValue {
+                String value
+            }
+        ''')
+    }
+
+    private void writeSource(String relativePath, String content) {
+        File target = new File(projectDir, relativePath)
+        target.parentFile.mkdirs()
+        target.text = content.stripIndent().trim() + System.lineSeparator()
+    }
+
+    private boolean build() {
+        GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(':consumer:classes', '--stacktrace')
+                .build()
+        return true
+    }
+}

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -1,0 +1,143 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//file:noinspection GrPackage
+package com.blackbuild.klum.ast.jackson
+
+import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.blackbuild.klum.ast.process.PhaseDriver
+import com.blackbuild.klum.ast.util.FactoryHelper
+import com.blackbuild.klum.ast.util.TemplateManager
+import com.fasterxml.jackson.databind.ObjectMapper
+
+class KlumJacksonImporterSpec extends AbstractDSLSpec {
+
+    def "readRoot applies one captured input through the generated Builder lifecycle"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class ImportedValue {
+                @JsonProperty("public")
+                String value
+                String lifecycle
+
+                @PostCreate
+                void created() { lifecycle = "created" }
+
+                @PostApply
+                void applied() { lifecycle += "-applied" }
+            }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+        def importer = KlumJacksonImporter.using(mapper)
+
+        when:
+        def imported = importer.readRoot(clazz, KlumJacksonInput.tree(mapper.readTree('{"public":"Ada"}').deepCopy()))
+
+        then:
+        imported.value == "Ada"
+        imported.lifecycle == "created-applied"
+    }
+
+    def "readTemplate returns a marked value-only Template without lifecycle callbacks"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class ImportedTemplate {
+                String value
+                boolean callbackRan
+
+                @PostCreate
+                void created() { callbackRan = true }
+            }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+
+        when:
+        def imported = KlumJacksonImporter.using(mapper).readTemplate(clazz, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        imported.value == "Ada"
+        !imported.callbackRan
+        TemplateManager.isTemplate(imported)
+    }
+
+    def "the importer requires a caller-configured Klum module without mutating the mapper"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class UnconfiguredImport { String value }
+        ''')
+        def mapper = new ObjectMapper()
+
+        when:
+        KlumJacksonImporter.using(mapper).readRoot(clazz, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("requires KlumAstModule")
+        mapper.registeredModuleIds.empty
+    }
+
+    def "Builder modes stay in the active Construction session and preserve Builder identity"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class ImportedParent {
+                ImportedChild child
+            }
+
+            @DSL
+            class ImportedChild {
+                String value
+            }
+        ''')
+        def parentType = clazz
+        def childType = getClass("pk.ImportedChild")
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+
+        when:
+        PhaseDriver.withBuilderLifecycle(
+                { FactoryHelper.createBuilder(parentType, null) },
+                { parentBuilder ->
+                    def child = importer.readBuilder(childType.Create.AsBuilder, KlumJacksonInput.map([value: "first"]))
+                    def applied = importer.applyToBuilder(child, KlumJacksonInput.map([value: "second"]))
+                    assert applied.is(child)
+                    assert child.value == "second"
+                }
+        )
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -27,7 +27,9 @@ package com.blackbuild.klum.ast.jackson
 import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
 import com.blackbuild.klum.ast.process.PhaseDriver
 import com.blackbuild.klum.ast.util.FactoryHelper
+import com.blackbuild.klum.ast.util.KlumBuilder
 import com.blackbuild.klum.ast.util.TemplateManager
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Issue
@@ -145,6 +147,99 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         imported.value == "custom:Ada"
     }
 
+    def "Template mode rejects a type-level custom Jackson deserializer"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.core.JsonParser
+            import com.fasterxml.jackson.databind.DeserializationContext
+            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+            import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+            @JsonDeserialize(using = TemplateOptOutDeserializer)
+            @DSL
+            class TemplateOptOutValue { String value }
+
+            class TemplateOptOutDeserializer extends StdDeserializer<TemplateOptOutValue> {
+                TemplateOptOutDeserializer() { super(TemplateOptOutValue) }
+
+                @Override
+                TemplateOptOutValue deserialize(JsonParser parser, DeserializationContext context) {
+                    TemplateOptOutValue.Create.With { value "custom" }
+                }
+            }
+        ''')
+
+        when:
+        KlumJacksonImporter.using(new ObjectMapper()).readTemplate(clazz, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("does not support a type-level custom deserializer")
+    }
+
+    def "reader capture rejects typed and updating readers while retaining an untyped reader"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class ReaderImportedValue { String value }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+
+        when:
+        def imported = KlumJacksonImporter.using(mapper.reader()).readRoot(clazz, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        imported.value == "Ada"
+
+        when:
+        KlumJacksonImporter.using(mapper.readerFor(clazz))
+
+        then:
+        def typedException = thrown(IllegalArgumentException)
+        typedException.message.contains("untyped")
+
+        when:
+        KlumJacksonImporter.using(mapper.readerForUpdating([:]))
+
+        then:
+        def updatingException = thrown(IllegalArgumentException)
+        updatingException.message.contains("untyped")
+    }
+
+    def "input adapters preserve caller ownership and stable identities"() {
+        given:
+        def mapper = new ObjectMapper()
+        def tree = mapper.readTree('{"value":"Ada"}')
+        def values = [value: "Ada"]
+        def parser = mapper.factory.createParser('{"value":"Ada"}')
+        def treeInput = KlumJacksonInput.tree(tree)
+        def mapInput = KlumJacksonInput.map(values)
+        def parserInput = KlumJacksonInput.parser(parser)
+
+        when:
+        def treeSource = treeInput.open(mapper.reader())
+        def mapSource = mapInput.open(mapper.reader())
+        def parserSource = parserInput.open(mapper.reader())
+        treeSource.close()
+        mapSource.close()
+        parserSource.close()
+
+        then:
+        treeInput.sourceName() == "tree"
+        mapInput.sourceName() == "map"
+        parserInput.sourceName() == "parser"
+        mapInput.named("config.yaml").sourceName() == "config.yaml"
+        tree.get("value").asText() == "Ada"
+        values == [value: "Ada"]
+        treeSource.parser.closed
+        mapSource.parser.closed
+        !parser.closed
+    }
+
     def "borrowed parsers remain open and named sources appear in import diagnostics"() {
         given:
         createClass('''
@@ -170,6 +265,58 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         exception.message.contains('$/ParserImportedValue.readRoot:jackson(config.yaml)')
         exception.message.contains(":line ")
         exception.cause instanceof JsonProcessingException
+    }
+
+    def "mapping failures use escaped external JSON pointers"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class PointerImportedValue { String value }
+        ''')
+
+        when:
+        KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+                .readRoot(clazz, KlumJacksonInput.map(["unknown/value~field": "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.cause instanceof JsonMappingException
+        exception.message.contains("/input(#/unknown~1value~0field)")
+    }
+
+    def "unexpected custom binding failures are wrapped once with their direct cause"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.core.JsonParser
+            import com.fasterxml.jackson.databind.DeserializationContext
+            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+            import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+            @JsonDeserialize(using = ExplodingImportedValueDeserializer)
+            @DSL
+            class ExplodingImportedValue { String value }
+
+            class ExplodingImportedValueDeserializer extends StdDeserializer<ExplodingImportedValue> {
+                ExplodingImportedValueDeserializer() { super(ExplodingImportedValue) }
+
+                @Override
+                ExplodingImportedValue deserialize(JsonParser parser, DeserializationContext context) {
+                    throw new IllegalStateException("custom binding failed")
+                }
+            }
+        ''')
+
+        when:
+        KlumJacksonImporter.using(new ObjectMapper()).readRoot(clazz, KlumJacksonInput.map([:]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.startsWith("Jackson readRoot import of pk.ExplodingImportedValue failed: custom binding failed")
+        exception.cause instanceof IllegalStateException
     }
 
     def "Builder modes stay in the active Construction session and preserve Builder identity"() {
@@ -264,6 +411,41 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         then:
         def exception = thrown(RuntimeException)
         exception.message.contains("active Construction session")
+    }
+
+    def "applyToBuilder rejects a non-generated Builder capability"() {
+        given:
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+        def builder = new KlumBuilder<Object>() { }
+
+        when:
+        importer.applyToBuilder(builder, KlumJacksonInput.map([:]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("active generated Builder")
+    }
+
+    def "applyToBuilder rejects a Builder from a different active Construction session"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class SessionImportedValue { String value }
+        ''')
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+        def unownedBuilder = FactoryHelper.createBuilder(clazz, null)
+
+        when:
+        PhaseDriver.withBuilderLifecycle(
+                { FactoryHelper.createBuilder(clazz, null) },
+                { importer.applyToBuilder(unownedBuilder, KlumJacksonInput.map([value: "Ada"])) }
+        )
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("belongs to no active Construction session")
     }
 
     def "Java consumers compile against every importer descriptor"() {

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -29,9 +29,11 @@ import com.blackbuild.klum.ast.process.PhaseDriver
 import com.blackbuild.klum.ast.util.FactoryHelper
 import com.blackbuild.klum.ast.util.TemplateManager
 import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Issue
 
 import javax.tools.ToolProvider
 
+@Issue("463")
 class KlumJacksonImporterSpec extends AbstractDSLSpec {
 
     def "readRoot applies one captured input through the generated Builder lifecycle"() {
@@ -169,7 +171,48 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         noExceptionThrown()
     }
 
-    def "Java consumers compile against the root and Template importer descriptors"() {
+    def "readBuilder rejects calls outside an active Construction session"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class DetachedImportedValue { String value }
+        ''')
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+
+        when:
+        importer.readBuilder(clazz.Create.AsBuilder, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("active Construction session")
+    }
+
+    def "applyToBuilder rejects a Builder after its Construction session completes"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class SealedImportedValue { String value }
+        ''')
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+        def builder
+        PhaseDriver.withBuilderLifecycle(
+                { FactoryHelper.createBuilder(clazz, null) },
+                { builder = it }
+        )
+
+        when:
+        importer.applyToBuilder(builder, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("after its Construction session has completed")
+    }
+
+    def "Java consumers compile against every importer descriptor"() {
         given:
         createClass('''
             package pk
@@ -186,18 +229,22 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
             import com.blackbuild.klum.ast.jackson.KlumJacksonInput;
             import com.fasterxml.jackson.databind.ObjectMapper;
             import pk.JavaImportedValue;
+            import pk.JavaImportedValue_DSL;
 
             class JacksonConsumer {
                 void importValue(ObjectMapper mapper) {
                     KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
                     JavaImportedValue root = importer.readRoot(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
                     JavaImportedValue template = importer.readTemplate(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    JavaImportedValue_DSL.Builder builder = importer.readBuilder(
+                            JavaImportedValue.Create.getAsBuilder(), KlumJacksonInput.map(java.util.Map.of()));
+                    JavaImportedValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(java.util.Map.of()));
                 }
             }
         ''')
     }
 
-    def "statically compiled Groovy consumers infer root and Template types"() {
+    def "statically compiled Groovy consumers infer every importer type"() {
         given:
         createClass('''
             package pk
@@ -223,6 +270,13 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
 
                 static StaticImportedValue template(ObjectMapper mapper) {
                     KlumJacksonImporter.using(mapper).readTemplate(StaticImportedValue, KlumJacksonInput.map([value: "template"]))
+                }
+
+                static StaticImportedValue_DSL.Builder builder(ObjectMapper mapper) {
+                    KlumJacksonImporter importer = KlumJacksonImporter.using(mapper)
+                    StaticImportedValue_DSL.Builder builder = importer.readBuilder(
+                            StaticImportedValue.Create.AsBuilder, KlumJacksonInput.map([value: "builder"]))
+                    importer.applyToBuilder(builder, KlumJacksonInput.map([value: "applied"]))
                 }
             }
         ''', 'pk/StaticJacksonConsumer.groovy')

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -30,6 +30,8 @@ import com.blackbuild.klum.ast.util.FactoryHelper
 import com.blackbuild.klum.ast.util.TemplateManager
 import com.fasterxml.jackson.databind.ObjectMapper
 
+import javax.tools.ToolProvider
+
 class KlumJacksonImporterSpec extends AbstractDSLSpec {
 
     def "readRoot applies one captured input through the generated Builder lifecycle"() {
@@ -139,5 +141,45 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
 
         then:
         noExceptionThrown()
+    }
+
+    def "Java consumers compile against the root and Template importer descriptors"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class JavaImportedValue { String value }
+        ''')
+
+        expect:
+        compileJavaConsumer('''
+            package sample;
+
+            import com.blackbuild.klum.ast.jackson.KlumJacksonImporter;
+            import com.blackbuild.klum.ast.jackson.KlumJacksonInput;
+            import com.fasterxml.jackson.databind.ObjectMapper;
+            import pk.JavaImportedValue;
+
+            class JacksonConsumer {
+                void importValue(ObjectMapper mapper) {
+                    KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
+                    JavaImportedValue root = importer.readRoot(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    JavaImportedValue template = importer.readTemplate(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                }
+            }
+        ''')
+    }
+
+    private void compileJavaConsumer(String source) {
+        File sourceFile = new File(tempFolder.root, 'sample/JacksonConsumer.java')
+        sourceFile.parentFile.mkdirs()
+        sourceFile.text = source.stripIndent()
+        String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
+                .join(File.pathSeparator)
+        def errors = new ByteArrayOutputStream()
+        int result = ToolProvider.systemJavaCompiler.run(null, null, errors, '-classpath', classpath,
+                '-d', compilerConfiguration.targetDirectory.absolutePath, sourceFile.absolutePath)
+        assert result == 0: errors.toString()
     }
 }

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -109,6 +109,32 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         mapper.registeredModuleIds.empty
     }
 
+    def "borrowed parsers remain open and named sources appear in import diagnostics"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class ParserImportedValue { String value }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+        def importer = KlumJacksonImporter.using(mapper)
+        def validParser = mapper.factory.createParser('{"value":"Ada"}')
+        def invalidParser = mapper.factory.createParser('{')
+
+        when:
+        def imported = importer.readRoot(clazz, KlumJacksonInput.parser(validParser))
+        importer.readRoot(clazz, KlumJacksonInput.parser(invalidParser).named("config.yaml"))
+
+        then:
+        imported.value == "Ada"
+        !validParser.closed
+        def exception = thrown(RuntimeException)
+        exception.message.startsWith("Jackson readRoot import of pk.ParserImportedValue failed:")
+        exception.message.contains('$/ParserImportedValue.readRoot:jackson(config.yaml)')
+        exception.cause != null
+    }
+
     def "Builder modes stay in the active Construction session and preserve Builder identity"() {
         given:
         createClass('''
@@ -169,6 +195,40 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
                 }
             }
         ''')
+    }
+
+    def "statically compiled Groovy consumers infer root and Template types"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class StaticImportedValue { String value }
+        ''')
+
+        when:
+        Class<?> consumer = createSecondaryClass('''
+            package pk
+
+            import com.blackbuild.klum.ast.jackson.KlumJacksonImporter
+            import com.blackbuild.klum.ast.jackson.KlumJacksonInput
+            import com.fasterxml.jackson.databind.ObjectMapper
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticJacksonConsumer {
+                static StaticImportedValue root(ObjectMapper mapper) {
+                    KlumJacksonImporter.using(mapper).readRoot(StaticImportedValue, KlumJacksonInput.map([value: "root"]))
+                }
+
+                static StaticImportedValue template(ObjectMapper mapper) {
+                    KlumJacksonImporter.using(mapper).readTemplate(StaticImportedValue, KlumJacksonInput.map([value: "template"]))
+                }
+            }
+        ''', 'pk/StaticJacksonConsumer.groovy')
+
+        then:
+        consumer != null
     }
 
     private void compileJavaConsumer(String source) {

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -28,6 +28,7 @@ import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
 import com.blackbuild.klum.ast.process.PhaseDriver
 import com.blackbuild.klum.ast.util.FactoryHelper
 import com.blackbuild.klum.ast.util.TemplateManager
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Issue
 
@@ -111,6 +112,39 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         mapper.registeredModuleIds.empty
     }
 
+    def "readRoot honours a type-level custom Jackson deserializer as an explicit opt-out"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.core.JsonParser
+            import com.fasterxml.jackson.databind.DeserializationContext
+            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+            import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+            @JsonDeserialize(using = CustomImportedValueDeserializer)
+            @DSL
+            class CustomImportedValue { String value }
+
+            class CustomImportedValueDeserializer extends StdDeserializer<CustomImportedValue> {
+                CustomImportedValueDeserializer() { super(CustomImportedValue) }
+
+                @Override
+                CustomImportedValue deserialize(JsonParser parser, DeserializationContext context) {
+                    def tree = parser.codec.readTree(parser)
+                    return CustomImportedValue.Create.With { value "custom:${tree.value.asText()}" }
+                }
+            }
+        ''')
+        def importer = KlumJacksonImporter.using(new ObjectMapper())
+
+        when:
+        def imported = importer.readRoot(clazz, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        imported.value == "custom:Ada"
+    }
+
     def "borrowed parsers remain open and named sources appear in import diagnostics"() {
         given:
         createClass('''
@@ -134,7 +168,8 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         def exception = thrown(RuntimeException)
         exception.message.startsWith("Jackson readRoot import of pk.ParserImportedValue failed:")
         exception.message.contains('$/ParserImportedValue.readRoot:jackson(config.yaml)')
-        exception.cause != null
+        exception.message.contains(":line ")
+        exception.cause instanceof JsonProcessingException
     }
 
     def "Builder modes stay in the active Construction session and preserve Builder identity"() {
@@ -209,7 +244,26 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
 
         then:
         def exception = thrown(RuntimeException)
-        exception.message.contains("after its Construction session has completed")
+        exception.message.contains("active Construction session")
+    }
+
+    def "applyToBuilder rejects an unowned Builder without an active Construction session"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class UnownedImportedValue { String value }
+        ''')
+        def importer = KlumJacksonImporter.using(new ObjectMapper().findAndRegisterModules())
+        def builder = FactoryHelper.createBuilder(clazz, null)
+
+        when:
+        importer.applyToBuilder(builder, KlumJacksonInput.map([value: "Ada"]))
+
+        then:
+        def exception = thrown(RuntimeException)
+        exception.message.contains("active Construction session")
     }
 
     def "Java consumers compile against every importer descriptor"() {
@@ -231,14 +285,16 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
             import pk.JavaImportedValue;
             import pk.JavaImportedValue_DSL;
 
+            import java.util.Map;
+
             class JacksonConsumer {
                 void importValue(ObjectMapper mapper) {
                     KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
-                    JavaImportedValue root = importer.readRoot(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
-                    JavaImportedValue template = importer.readTemplate(JavaImportedValue.class, KlumJacksonInput.map(java.util.Map.of()));
+                    JavaImportedValue root = importer.readRoot(JavaImportedValue.class, KlumJacksonInput.map(Map.of()));
+                    JavaImportedValue template = importer.readTemplate(JavaImportedValue.class, KlumJacksonInput.map(Map.of()));
                     JavaImportedValue_DSL.Builder builder = importer.readBuilder(
-                            JavaImportedValue.Create.getAsBuilder(), KlumJacksonInput.map(java.util.Map.of()));
-                    JavaImportedValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(java.util.Map.of()));
+                            JavaImportedValue.Create.getAsBuilder(), KlumJacksonInput.map(Map.of()));
+                    JavaImportedValue_DSL.Builder applied = importer.applyToBuilder(builder, KlumJacksonInput.map(Map.of()));
                 }
             }
         ''')

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/process/PhaseDriver.java
@@ -173,6 +173,15 @@ public class PhaseDriver {
                     + "use Create.With, Create.One, or Create.From for a standalone completed DSL Object.");
     }
 
+    /** Rejects use of a Builder from a missing, completed, or different Construction session. */
+    public static void requireCurrentConstructionSession(InternalKlumBuilder<?> builder) {
+        requireActiveConstructionSession();
+        PhaseDriver driver = INSTANCE.get();
+        if (!builder.$isInActiveConstructionSession(driver.constructionSession))
+            throw new KlumModelException("Builder belongs to no active Construction session on this thread. "
+                    + "Create it with Create.AsBuilder inside the owning root Builder lifecycle.");
+    }
+
     public static void enter(Object object) {
         PhaseDriver driver = getInstance();
         if (driver.activeObjectPointer == 0) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/FactoryHelper.java
@@ -105,6 +105,11 @@ public class FactoryHelper extends GroovyObjectSupport {
         return builder;
     }
 
+    /** Internal adapter hook for importing a value-only Template without a Groovy configuration source. */
+    public static <T> KlumBuilder<T> createTemplateBuilderForImport(Class<T> type) {
+        return createTemplateBuilder(type);
+    }
+
     @SuppressWarnings("java:S1452") // the concrete generated Builder type is selected from the recipe at runtime
     static InternalKlumBuilder<?> createRecipeBuilder(Class<?> declaredType, Object recipe, Object keyHint, boolean template) {
         return createRecipeBuilder(declaredType, recipe, keyHint, template, null);

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumBuilder.java
@@ -30,6 +30,7 @@ import com.blackbuild.groovy.configdsl.transform.PostApply;
 import com.blackbuild.klum.ast.KlumModelObject;
 import com.blackbuild.klum.ast.process.BreadcrumbCollector;
 import com.blackbuild.klum.ast.process.ConstructionSession;
+import com.blackbuild.klum.ast.process.ConstructionSession;
 import com.blackbuild.klum.ast.process.DefaultKlumPhase;
 import com.blackbuild.klum.ast.process.KlumPhase;
 import com.blackbuild.klum.ast.process.PhaseDriver;
@@ -128,6 +129,11 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
     public final void $completeConstructionSession(ConstructionSession session) {
         if (constructionSession == session)
             constructionSessionActive = false;
+    }
+
+    /** Internal hook used by {@link PhaseDriver} to keep Builder adapters in their owning session. */
+    public final boolean $isInActiveConstructionSession(ConstructionSession session) {
+        return constructionSession == session && constructionSessionActive;
     }
 
     public final Class<M> getModelType() {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/InternalKlumBuilder.java
@@ -213,6 +213,11 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
         return root.getCompletedModel();
     }
 
+    /** Internal adapter hook that materializes a value-only Template graph without lifecycle phases. */
+    public static Object materializeTemplateForImport(InternalKlumBuilder<?> root) {
+        return materializeGraph(root);
+    }
+
     /** Internal Builder hook that assigns one completed relationship without exposing a model mutator. */
     protected final void $assignMaterializedRelationship(String fieldName) {
         CachedField target = DslHelper.getCachedField(completedModel.getClass(), fieldName)

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
@@ -24,7 +24,6 @@
 package com.blackbuild.klum.ast.util;
 
 import com.blackbuild.annodocimal.annotations.InlineJavadocs;
-import com.blackbuild.klum.ast.process.PhaseDriver;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.lang.Script;
@@ -79,16 +78,6 @@ public class KlumFactory<T> {
             return (B) builder;
         }
 
-        /** Internal bridge for managed import adapters; clients use the adapter's typed operation instead. */
-        public final Class<T> $modelTypeForImport() {
-            return type;
-        }
-
-        /** Internal bridge for managed import adapters; creates an unsealed Builder in the active session. */
-        public final B $createForImport() {
-            PhaseDriver.requireActiveConstructionSession();
-            return asPublicBuilder(FactoryHelper.createBuilder(type, null));
-        }
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumFactory.java
@@ -24,6 +24,7 @@
 package com.blackbuild.klum.ast.util;
 
 import com.blackbuild.annodocimal.annotations.InlineJavadocs;
+import com.blackbuild.klum.ast.process.PhaseDriver;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.lang.Script;
@@ -76,6 +77,17 @@ public class KlumFactory<T> {
         @SuppressWarnings("unchecked")
         protected final B asPublicBuilder(InternalKlumBuilder<T> builder) {
             return (B) builder;
+        }
+
+        /** Internal bridge for managed import adapters; clients use the adapter's typed operation instead. */
+        public final Class<T> $modelTypeForImport() {
+            return type;
+        }
+
+        /** Internal bridge for managed import adapters; creates an unsealed Builder in the active session. */
+        public final B $createForImport() {
+            PhaseDriver.requireActiveConstructionSession();
+            return asPublicBuilder(FactoryHelper.createBuilder(type, null));
         }
     }
 

--- a/wiki/Jackson-Integration.md
+++ b/wiki/Jackson-Integration.md
@@ -64,18 +64,30 @@ modules, and data-format factories stay under the integration's control.
 
 # Managed import
 
-The existing internal `KlumDeserializer` resolves Jackson properties and binds them to generated Builders rather than
-partially initialized DSL Objects. The final 4.0 API adds a public, data-format-neutral `KlumJacksonImporter` with four
-explicit modes:
+`KlumJacksonImporter` resolves Jackson properties and binds them to generated Builders rather than partially initialized
+DSL Objects. Configure the caller-owned mapper with `KlumAstModule`, then capture one importer and provide one input per
+operation:
+
+```java
+KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
+Order order = importer.readRoot(Order.class, KlumJacksonInput.parser(parser));
+Order recipe = importer.readTemplate(Order.class, KlumJacksonInput.tree(tree));
+Child_DSL.Builder child = importer.readBuilder(Child.Create.getAsBuilder(), KlumJacksonInput.map(values));
+Child_DSL.Builder sameChild = importer.applyToBuilder(child, KlumJacksonInput.map(overrides));
+```
+
+Groovy may use `Child.Create.AsBuilder`. The four operations are explicit:
 
 1. read a root and run one complete lifecycle;
 2. read a value-only Template without running lifecycle processing;
 3. create an imported Builder inside an active Construction session;
 4. apply an input to an existing unsealed Builder.
 
-The exact method signatures are finalized in the importer tracer bullet. Until that implementation lands, raw
-`ObjectMapper.readValue(DslType)` remains the beta standalone-root path; do not use it to start a DSL root inside an active
-Construction session.
+The importer is immutable and retains a snapshot `mapper.reader()` or an untyped, non-updating `ObjectReader`. It never
+registers a module or changes mapper configuration. Parsers remain open and caller-owned; tree and Map inputs are not
+mutated. `named("config.yaml")` adds an opaque diagnostic source name. Typed or updating readers are rejected. Raw
+`ObjectMapper.readValue(DslType)` remains a discouraged standalone-root compatibility path; do not use it to start a DSL
+root inside an active Construction session.
 
 Root import uses this order:
 


### PR DESCRIPTION
Closes #463

## Summary

- add the final `KlumJacksonImporter` and `KlumJacksonInput` API with explicit root, Template, Builder, and apply modes
- preserve caller-owned Jackson configuration, lifecycle/session boundaries, diagnostics, and type-level root custom-deserializer opt-outs
- document the API and validate external Java 17/static-Groovy consumers with Jackson 2.14.2 and 2.21.0

## Validation

- `./gradlew --no-daemon :klum-ast-jackson:check`
- `./gradlew --no-daemon -PjacksonVersion=2.21.0 :klum-ast-jackson:test :klum-ast-jackson:groovy4Tests :klum-ast-jackson:groovy5Tests`

Out of scope: JSON-4 and source-neutral multi-input composition (#304).

Related: #464, #467, #468.