### PR TITLE
docs: record shared prerelease channel policy

### DIFF
--- a/docs/adr/0012-shared-prerelease-channel-policy.md
+++ b/docs/adr/0012-shared-prerelease-channel-policy.md
@@ -1,0 +1,72 @@
+# Shared prerelease-channel policy
+
+Date: 2026-07-19
+
+Status: Accepted
+
+Related work: [#488 — Audit, document, and improve the release and publishing process](https://github.com/klum-dsl/klum-ast/issues/488),
+[KlumCast #38 — Codify release and prerelease procedures](https://github.com/klum-dsl/klum-cast/issues/38), and
+[AnnoDocimal #44](https://github.com/blackbuild/anno-docimal/issues/44),
+[#45](https://github.com/blackbuild/anno-docimal/issues/45), and
+[#47](https://github.com/blackbuild/anno-docimal/issues/47).
+
+## Context
+
+KlumAST 4.0 needs validation from clean, external consumers after KlumCast 0.4 and AnnoDocimal 1.0 are available.
+The three repositories publish different artifact sets and retain local release machinery, but an incompatible vocabulary
+for prereleases would make a claimed consumer validation result ambiguous. The earlier 4.0 release-plan record made the
+same policy locally; this ADR is the durable shared baseline.
+
+## Decision
+
+### Channel roles
+
+| Channel | Shared role |
+| --- | --- |
+| Snapshot, development snapshot, immutable snapshot | Developer integration only; never the named remote consumer-validation result. |
+| Central/Nexus staging | Signing and repository-acceptance gate; not an external-consumer channel. |
+| Release candidate (RC) | The sole supported public prerelease channel. Every published product coordinate and applicable plugin marker is publicly resolvable, immutable, and validated by a clean external consumer. |
+| Final | The formal release, published and independently re-verified. |
+| Alpha / beta | Unsupported unless a later, explicit cross-repository decision defines their purpose and recovery rules. |
+
+An RC validates its source commit and release configuration; it does not prove that differently versioned final artifacts
+are byte-identical. RCs are short-lived validation artifacts, normally only a small number per release. There is no hard
+cap: an unusually complex release such as KlumAST 4.0 may need more. They are not a long-term production release channel.
+
+### Version, promotion, and recovery
+
+Nebula Release's monotonic candidate identity is the shared model: `X.Y.Z-rc.N` uses an immutable tag and a strictly
+increasing `N`. RCs are never relabelled, replaced, or promoted. A final `X.Y.Z` is a distinct publication from the exact
+commit accepted for the last RC. A substantive source or release-configuration change requires the next RC; a
+documentation-only change may proceed without another RC. Any other exception requires an explicit recorded decision
+stating the changed validation claim and compensating evidence.
+
+Publication must make the complete product available as atomically as each registry permits; no partial artifact set or
+plugin-marker set is a successful candidate. Used artifact versions are burned. A published or tagged RC is never
+recovered: a rejected or partial RC remains immutable, is recorded as failed or superseded, and the next attempt uses
+`rc.N+1`. A final's remote tag may exceptionally be deleted only by an explicit human decision when no artifact was ever
+published. Local runbooks must state the registry-specific staging, abort, and retry mechanics without weakening these
+rules.
+
+### Authorization and validation
+
+Every public RC and final release requires explicit human authorization through a protected release path. Ordinary CI
+performs unprivileged validation. After authorization it may automate release steps, but signing and publishing credentials
+exist only in protected environments and must never be exposed to pull-request/fork workflows or logs. Final authorization
+is separate from RC authorization.
+
+External consumers pin the exact published version, use clean caches and no composite build, `mavenLocal`, local
+repository, or unpublished included build, and resolve each repository's complete public product from its real consumer
+repositories. KlumCast additionally proves its Groovy 3/4/5, classpath, and JPMS consumer contracts; AnnoDocimal proves
+its six artifacts and two plugin markers; KlumAST proves all Maven artifacts and both plugin IDs.
+
+## Ownership
+
+This ADR defines only the shared vocabulary and safety boundary. It does not standardize Gradle commands, credentials,
+release branches, documentation hosting, or registry implementation.
+
+- KlumAST #488 owns its `RELEASING.md`, protected publication path, consumer fixtures, and recovery procedure.
+- KlumCast #38 owns `docs/agents/releases.md`, the three-artifact procedure, and its public consumer evidence.
+- AnnoDocimal #44, #45, and #47 own publication smoke tests, the rehearsed runbook, and its 1.0 release gate.
+
+Each local record links here rather than reproducing this policy.

--- a/docs/implementation/issue-curation/release-4.0.md
+++ b/docs/implementation/issue-curation/release-4.0.md
@@ -58,35 +58,24 @@ generated surface.
 
 ## Confirmed pre-release validation policy
 
-**Decision (2026-07-19):** Use a public, immutable release candidate as the sole 4.0 remote external-consumer
-validation channel. A candidate is not evidence that its differently versioned final artifact is byte-identical; it is
-evidence for the candidate's source commit and release configuration. The final release must therefore use the exact
-commit validated by the last candidate. A documentation-only change may proceed without another candidate. Any other
-exception, such as an intentional support-matrix transition for which no suitable candidate consumer exists, requires an
-explicit recorded release decision naming the changed validation claim and compensating evidence.
+The shared [ADR 0012 — shared prerelease-channel policy](../../adr/0012-shared-prerelease-channel-policy.md) is
+authoritative. It upgrades the local policy recorded by PR #505 into the shared KlumAST, KlumCast, and AnnoDocimal
+baseline: public immutable RCs are the sole prerelease validation channel; snapshots are developer-only; staging is a
+publication gate; and a final is a distinct, re-verified publication from the accepted RC commit.
 
-| Channel | 4.0 role | Publication and consumer contract |
-|---|---|---|
-| Alpha / beta | Not supported. | Nebula Release is currently configured with no alpha/beta policy or mechanism; introducing either is separate work and must not be implied by an RC. |
-| Snapshot / dev snapshot / immutable snapshot | Developer integration only. | They may help development, but their mutable or non-release-tagged nature makes them insufficient for the required named, cross-network complete-product validation. |
-| RC | Required remote validation channel. | Nebula `candidate` creates an immutable tagged `4.0.0-rc.N`. Publish all KlumAST Maven artifacts and both Gradle plugin IDs at that one version to the public repositories, then verify a clean external consumer resolves only those remote coordinates. |
-| Central/Nexus staging repository | Publication gate, not a consumer channel. | Use staging to validate signing and repository acceptance before promotion, but do not call it external-consumer validation: a closed/open staging repository alone does not provide the intended public, cross-network, complete-product resolve-back test. |
-| Final | Formal 4.0 release. | Publish a distinct final version from the last RC's commit (or the documented exception). Re-run release verification against the final coordinates; do not describe it as promotion of identical artifact bytes. |
-
-The external consumer must pin the exact RC version, resolve Maven modules through Maven Central, and resolve the two
-plugins through `pluginManagement` with the Gradle Plugin Portal. It must use a clean Gradle cache and no composite build,
-`mavenLocal`, local repository, or unpublished included build. The smoke suite must prove all published Maven modules and
-both plugin markers resolve at the same candidate version, then compile/run the agreed consumer cases from a different
-machine or network.
+For 4.0, the clean external consumer pins the exact RC, resolves Maven modules through Maven Central and both plugins
+through `pluginManagement` with the Gradle Plugin Portal, and uses no composite build, `mavenLocal`, local repository, or
+unpublished included build. It proves all published Maven modules and both plugin markers at one candidate version from a
+different machine or network. #488 owns the local runbook and delivery path.
 
 ### Required sequence and owners
 
 1. KlumCast publishes its final 0.4.x artifact set and independently proves its remote Groovy 3/4/5, classpath, JPMS,
-   package, and module consumer cases. Its release-channel policy/runbook remains KlumCast-owned; it is not work for
-   KlumAST #459 or KlumCast #30.
+   package, and module consumer cases. KlumCast #38 owns its local policy/runbook adoption; it is not work for KlumAST
+   #459 or KlumCast #30.
 2. AnnoDocimal completes #47 and publishes final 1.0.0 after its #45 runbook rehearsal, #44 clean publication/consumer
-   smoke tests, and documentation gate. A named preview must cover its six Maven artifacts and two plugin IDs at one
-   version. This is a prerequisite for #461, not a shared KlumAST publication operation.
+   smoke tests, and documentation gate. A named RC must cover its six Maven artifacts and two plugin IDs at one version.
+   This is a prerequisite for #461, not a shared KlumAST publication operation.
 3. KlumAST #459 and #461 consume those final dependencies; all 4.0 blockers and the normal Groovy 3/4/5 release gates
    complete.
 4. KlumAST #488 owns the smallest necessary delivery slice: a reviewed `RELEASING.md`, protected credential and
@@ -97,7 +86,8 @@ machine or network.
    issue a new RC. The final's own remote-coordinate verification remains mandatory.
 
 AnnoDoc Support is optional fixture-only external evidence after KlumAST public coordinates exist; it is neither a 4.0
-prerequisite nor a shared publication owner. Any alpha/beta/staging extension there needs separately authorized work.
+prerequisite nor a shared publication owner. Any alpha/beta/staging extension needs separately authorized work under ADR
+0012.
 
 ## 4.0 nice-to-have
 


### PR DESCRIPTION
## Summary

Records the maintainer-confirmed prerelease policy as ADR 0012 and makes the 4.0 release record link to that shared baseline.

- Defines RC as the sole public prerelease validation channel.
- Keeps snapshots developer-only and staging as a publication gate.
- Records immutable versioning, recovery, authorization, credential, and external-consumer boundaries.
- Names KlumAST #488, KlumCast #38, and AnnoDocimal #44/#45/#47 as the respective local adoption owners.

## Scope

Policy and documentation only. This pull request does not publish artifacts, change credentials, or implement any local release runbook.

Related: #488

## Validation

- `git diff --check`
- Reviewed the staged documentation diff