### PR TITLE
Prove asymmetric Jackson/YAML interoperability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,11 @@ This is a breaking release. See the [Builder-first construction migration](https
 - Added `KlumJacksonImporter` and `KlumJacksonInput` as the explicit Jackson 2 import seam. Caller-owned mapper/reader
   configuration is captured without mutation; root, value-only Template, active-session Builder, and existing-Builder
   application modes each consume one parser/tree/Map input ([#463](https://github.com/klum-dsl/klum-ast/issues/463)).
+- Added executable asymmetric YAML interoperability evidence: one foreign input is imported through one Builder lifecycle
+  and ordinary Jackson export emits an intentionally enriched, separately owned projection. Import/export fixtures cover
+  foreign aliases, composition, polymorphism, null and unknown-field policy, `LINK`, Templates, diagnostics, custom
+  serializers, and the absence of Klum wire metadata; no round-trip or Jackson-owned layering contract is introduced
+  ([#464](https://github.com/klum-dsl/klum-ast/issues/464)).
 - Jackson `LINK` import is reference-only. Explicit Jackson identities with `alwaysAsId`, custom property codecs, and
   custom `ObjectIdResolver`s preserve completed targets and same-session Builder identity across backward and forward
   references, including Collection and Map `LINK`s. Inline input fails with focused mapping errors. Export requires an

--- a/docs/adr/0009-jackson-interoperability.md
+++ b/docs/adr/0009-jackson-interoperability.md
@@ -14,8 +14,8 @@ Tracking issues:
 
 Implementation status: JSON-1 property-aware Builder binding is implemented by
 [#439](https://github.com/klum-dsl/klum-ast/issues/439), and JSON-2 identity/customization groundwork is implemented by
-[#440](https://github.com/klum-dsl/klum-ast/issues/440). The JSON-3/#463 public importer contract was confirmed on
-2026-07-17 and remains to be implemented; JSON-4/#464 owns interoperability compatibility closure. See the
+[#440](https://github.com/klum-dsl/klum-ast/issues/440). JSON-3/#463 delivers the public importer contract. JSON-4/#464
+adds the executable asymmetric YAML compatibility tracer and the role-oriented documentation closure. See the
 [implementation plan](../implementation/adr-0009-jackson-interoperability.md).
 
 Supersedes: [ADR 0007 — Jackson deserialization as configuration replay](0007-jackson-configuration-replay.md)

--- a/docs/implementation/adr-0009-jackson-interoperability.md
+++ b/docs/implementation/adr-0009-jackson-interoperability.md
@@ -4,28 +4,23 @@ This plan implements [ADR 0009](../adr/0009-jackson-interoperability.md) for can
 [#428](https://github.com/klum-dsl/klum-ast/issues/428). It retains the compatible JSON-1/#439 and JSON-2/#440 groundwork
 while replacing ADR 0007's cancelled JSON-3 round-trip closure.
 
-The JSON-3 public interface and behavior were confirmed on 2026-07-17. Production implementation remains pending.
+JSON-3/#463 delivers the confirmed public interface and managed behavior. JSON-4/#464 closes the compatibility story
+with separate import/export fixtures and the one-input YAML documentary tracer; it does not add source composition.
 
-## Current behavior and failure paths
+## Current behavior and evidence
 
-`KlumAstModule` currently replaces the root deserializer for DSL types. `KlumDeserializer` buffers an object, resolves
-effective Jackson properties, preallocates owned Builders, runs `PostCreate`, binds present values, runs `PostApply`, then
-starts one root lifecycle. Raw `ObjectMapper.readValue(DslType)` is the only public entry point.
+`KlumAstModule` replaces the root deserializer for DSL types. `KlumJacksonImporter` captures caller-owned reader
+configuration and provides root, value-only Template, active-session Builder, and existing-Builder modes. It normalizes
+one parser/tree/Map input into the resolved-property engine, which preallocates owned Builders, runs `PostCreate`, binds
+present values, runs `PostApply`, then starts one root lifecycle. Raw `ObjectMapper.readValue(DslType)` remains the
+discouraged standalone-root compatibility entry point.
 
 That implementation already proves renamed/aliased properties, naming strategies, mixins, views, unknown-property policy,
 formats, Simple Value codecs, polymorphic owned types, same-session identities, Template rejection, and explicit
 type-level deserializer opt-out. It also rejects inline `LINK` input and output lacking identity/custom property handling.
 
-The public seam is nevertheless incomplete for the confirmed use case:
-
-- a Schema Developer cannot explicitly read a root or Template through a Klum exception/diagnostic seam;
-- a Schema Developer cannot import a child Builder or apply structured input to an existing Builder;
-- raw DSL reads inside an active lifecycle can attempt a nested root instead of naming the correct import mode;
-- import I/O and mapping errors remain Jackson-first and do not contribute import-source or construction-path context;
-- construction-taking annotations do not yet fail with the complete actionable managed-import contract;
-- the wiki and release artifacts still describe persistence and round trips rather than external interoperability;
-- the module reports an unknown Jackson module version; and
-- no Klum wire metadata is emitted, but that absence is not yet documented as the deliberate compatibility contract.
+The delivered seam supplies the requested explicit modes, construction-path diagnostics, and construction-takeover guards.
+JSON-4 separately proves foreign YAML import and ordinary YAML export so neither fixture claims persistence or a round trip.
 
 ## Affected seams
 
@@ -37,7 +32,8 @@ The public seam is nevertheless incomplete for the confirmed use case:
 - generated API: `KlumFactory.BuilderFactory<T, B>` and the ADR 0005 `Foo_DSL.Builder` projection provide the precise
   Java return type. No generated import creator is added in 4.0.
 - tests: existing `ConfigurationReplaySpec`, `ConstructionOverrideSpec`, `JacksonCustomizationSpec`, `LinkIdentitySpec`,
-  and `JsonExportSpec`, plus focused importer, Java-consumer, static-Groovy, endpoint, and TestKit specifications.
+  `JsonExportSpec`, and `JacksonYamlInteroperabilityDocumentaryTest`, plus focused importer, Java-consumer, static-Groovy,
+  endpoint, and TestKit specifications.
 - user guidance: `wiki/Jackson-Integration.md`, migration navigation, and `CHANGES.md` as split between JSON-3 and JSON-4.
 
 ## Confirmed JSON-3 public interface

--- a/klum-ast-jackson/build.gradle
+++ b/klum-ast-jackson/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     // just to make intellij happy, base classes are actually included as sources
     testCompileOnly(testFixtures(project(':klum-ast')))
     testImplementation gradleTestKit()
+    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${providers.gradleProperty('jacksonVersion').getOrElse('2.14.2')}"
+    groovy4TestsImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${providers.gradleProperty('jacksonVersion').getOrElse('2.14.2')}"
+    groovy5TestsImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${providers.gradleProperty('jacksonVersion').getOrElse('2.14.2')}"
 }
 
 // Gradle TestKit embeds Groovy 3, which cannot share a compiler classpath with the

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonYamlInteroperabilityDocumentaryTest.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonYamlInteroperabilityDocumentaryTest.groovy
@@ -1,0 +1,295 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//file:noinspection GrPackage
+package com.blackbuild.klum.ast.jackson
+
+import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.blackbuild.klum.ast.util.KlumObjectSupport
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Issue("464")
+@Tag("documentary")
+class JacksonYamlInteroperabilityDocumentaryTest extends AbstractDSLSpec {
+
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Jackson-Integration.md#one-foreign-yaml-input-one-enriched-output")
+    def "imports one foreign YAML document through one Builder lifecycle and exports an enriched YAML projection"() {
+        given:
+        createInteroperabilitySchema()
+        def mapper = yamlMapper()
+        def importer = KlumJacksonImporter.using(mapper)
+        def input = '''
+legacy_deployment: storefront
+note: null
+tags: []
+services:
+  - id: api
+components:
+  - kind: worker
+    id: indexer
+    queue: products
+primary: api
+'''
+
+        when:
+        def deployment = importer.readRoot(clazz, KlumJacksonInput.parser(mapper.factory.createParser(input)).named("foreign-deployment.yaml"))
+        def output = mapper.readTree(mapper.writeValueAsString(deployment))
+
+        then: "one foreign input is adapted, rather than preserved as a Klum wire format"
+        deployment.name == "storefront"
+        deployment.note == null
+        deployment.tags.empty
+        deployment.services*.class*.simpleName == ["LinkTarget"]
+        deployment.components*.class*.simpleName == ["Worker"]
+        deployment.primary.is(deployment.services[0])
+        deployment.lifecycle == "ready:storefront"
+        getClass("pk.Deployment").events == ["create", "apply", "tree", "validate"]
+        KlumObjectSupport.of(deployment).structure.fullPath == ""
+
+        and: "ordinary Jackson export intentionally contains enriched, differently named data"
+        output.get("deployment_name").asText() == "storefront"
+        output.get("lifecycle").asText() == "ready:storefront"
+        output.get("primary").asText() == "api"
+        output.get("services").size() == 1
+        output.get("components").size() == 1
+        !output.has("legacy_deployment")
+        !output.has("producer")
+        !output.fieldNames().any { it.toLowerCase().contains("klum") }
+    }
+
+    def "foreign YAML import fixtures keep unknown fields, LINK resolution, Templates, and diagnostic paths explicit"() {
+        given:
+        createInteroperabilitySchema()
+        def mapper = yamlMapper()
+        def importer = KlumJacksonImporter.using(mapper)
+
+        when: "unknown fields follow the caller's configured policy"
+        importer.readRoot(clazz, yamlInput(mapper, "deployment_name: store\nunexpected: value\n"))
+
+        then:
+        RuntimeException unknown = thrown()
+        unknown.cause instanceof JsonMappingException
+        unknown.message.contains("unexpected")
+        unknown.message.contains("foreign-deployment.yaml")
+
+        when: "the same foreign document is accepted only when the caller opts into leniency"
+        def lenient = new ObjectMapper(new YAMLFactory()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).findAndRegisterModules()
+        def imported = KlumJacksonImporter.using(lenient).readRoot(clazz, yamlInput(lenient, "deployment_name: store\nunexpected: value\n"))
+
+        then:
+        imported.name == "store"
+
+        when: "an inline LINK is not silently converted to owned composition"
+        importer.readRoot(clazz, yamlInput(mapper, "deployment_name: store\nprimary: { id: api }\n"))
+
+        then:
+        RuntimeException linkFailure = thrown()
+        linkFailure.cause instanceof JsonMappingException
+        linkFailure.message.contains("LINK property")
+
+        when: "Template input remains value-only and does not start a lifecycle"
+        def eventsBeforeTemplate = getClass("pk.Deployment").events.size()
+        def template = importer.readTemplate(clazz, yamlInput(mapper, "deployment_name: template\n"))
+
+        then:
+        template.name == "template"
+        getClass("pk.Deployment").events.size() == eventsBeforeTemplate
+    }
+
+    def "export fixtures independently prove ordinary POJO projection, custom serializers, LINK projection, and Template rejection"() {
+        given:
+        createExportSchema()
+        def mapper = yamlMapper()
+        def Node = getClass("pk.ExportNode")
+        def TagValue = getClass("pk.TargetTag")
+        def external = Node.Create.With("api") {}
+        def exported = clazz.Create.With {
+            deploymentName "storefront"
+            primary external
+            targetTag TagValue.newInstance(value: "stable")
+            lifecycle "enriched"
+        }
+
+        when:
+        def output = mapper.readTree(mapper.writeValueAsString(exported))
+
+        then:
+        output.get("deployment_name").asText() == "storefront"
+        output.get("lifecycle").asText() == "enriched"
+        output.get("primary").asText() == "ref:api"
+        output.get("target_tag").asText() == "tag:stable"
+        !output.fieldNames().any { it.toLowerCase().contains("klum") }
+
+        when: "a marked Template cannot claim to be an ordinary external document"
+        def template = clazz.Template.Create { deploymentName "template" }
+        mapper.writeValueAsString(template)
+
+        then:
+        JsonMappingException rejected = thrown()
+        rejected.message.contains("Cannot serialize marked Template")
+    }
+
+    private static ObjectMapper yamlMapper() {
+        new ObjectMapper(new YAMLFactory()).findAndRegisterModules()
+    }
+
+    private static KlumJacksonInput yamlInput(ObjectMapper mapper, String source) {
+        KlumJacksonInput.parser(mapper.factory.createParser(source)).named("foreign-deployment.yaml")
+    }
+
+    private void createInteroperabilitySchema() {
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonAlias
+            import com.fasterxml.jackson.annotation.JsonIdentityInfo
+            import com.fasterxml.jackson.annotation.JsonIdentityReference
+            import com.fasterxml.jackson.annotation.JsonProperty
+            import com.fasterxml.jackson.annotation.JsonSubTypes
+            import com.fasterxml.jackson.annotation.JsonTypeInfo
+            import com.fasterxml.jackson.annotation.ObjectIdGenerators
+
+            @DSL
+            class Deployment {
+                static List<String> events = []
+
+                @JsonProperty("deployment_name")
+                @JsonAlias("legacy_deployment")
+                String name
+                String note = "default-note"
+                List<String> tags = ["default-tag"]
+                List<LinkTarget> services
+                List<Component> components
+
+                @JsonIdentityReference(alwaysAsId = true)
+                @Field(FieldType.LINK)
+                LinkTarget primary
+
+                @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+                String lifecycle
+
+                @PostCreate
+                void created() { events << "create" }
+
+                @PostApply
+                void applied() {
+                    events << "apply"
+                    lifecycle = "ready:$name"
+                }
+
+                @PostTree
+                void completedTree() { events << "tree" }
+
+                @Validate
+                void validated() { events << "validate" }
+            }
+
+            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+            @JsonSubTypes([
+                @JsonSubTypes.Type(value = Service, name = "service"),
+                @JsonSubTypes.Type(value = Worker, name = "worker")
+            ])
+            @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator, property = "id")
+            @DSL
+            abstract class Component {
+                @Key String id
+                @Owner Deployment deployment
+            }
+
+            @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator, property = "id")
+            @DSL
+            class LinkTarget {
+                @Key String id
+                @Owner Deployment deployment
+            }
+
+            @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator, property = "id")
+            @DSL
+            class Service extends Component {
+                int port
+            }
+
+            @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator, property = "id")
+            @DSL
+            class Worker extends Component {
+                String queue
+            }
+        ''')
+    }
+
+    private void createExportSchema() {
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.core.JsonGenerator
+            import com.fasterxml.jackson.annotation.JsonProperty
+            import com.fasterxml.jackson.databind.JsonSerializer
+            import com.fasterxml.jackson.databind.SerializerProvider
+            import com.fasterxml.jackson.databind.annotation.JsonSerialize
+
+            @DSL
+            class ExportRoot {
+                @JsonProperty("deployment_name")
+                String deploymentName
+                String lifecycle
+
+                @JsonSerialize(using = ExportNodeReferenceSerializer)
+                @Field(FieldType.LINK)
+                ExportNode primary
+
+                @JsonProperty("target_tag")
+                @JsonSerialize(using = TargetTagSerializer)
+                TargetTag targetTag
+            }
+
+            @DSL
+            class ExportNode {
+                @Key String id
+            }
+
+            class TargetTag {
+                String value
+            }
+
+            class ExportNodeReferenceSerializer extends JsonSerializer<ExportNode> {
+                @Override
+                void serialize(ExportNode value, JsonGenerator generator, SerializerProvider provider) {
+                    generator.writeString("ref:$value.id")
+                }
+            }
+
+            class TargetTagSerializer extends JsonSerializer<TargetTag> {
+                @Override
+                void serialize(TargetTag value, JsonGenerator generator, SerializerProvider provider) {
+                    generator.writeString("tag:$value.value")
+                }
+            }
+        ''')
+    }
+}

--- a/wiki/Builder-First-Migration.md
+++ b/wiki/Builder-First-Migration.md
@@ -166,3 +166,5 @@ annotations cannot replace the Klum Builder lifecycle.
 
 Do not treat JSON/YAML output as a Klum persistence or round-trip format. Completed models serialize through ordinary
 Jackson APIs, KlumAST adds no wire metadata, and external version properties remain Schema-controlled data.
+Each importer operation accepts one input and owns one lifecycle; YAML documents and exported projections never establish
+Jackson-owned composition or cross-input overwrite semantics.

--- a/wiki/Jackson-Integration.md
+++ b/wiki/Jackson-Integration.md
@@ -1,8 +1,8 @@
 Jackson Integration
 ===================
 
-__This feature is considered beta. The 4.0 interoperability contract is accepted, while its explicit importer API remains
-to be implemented under issue #428.__
+The 4.0 Jackson integration is an interoperability boundary, not a persistence format. Its explicit importer API is
+available through `KlumJacksonImporter`; issue #464 supplies the executable asymmetric YAML tracer.
 
 KlumAST provides optional Jackson integration in the `klum-ast-jackson` module. Its purpose is interoperability with
 externally owned JSON/YAML formats:
@@ -105,6 +105,30 @@ Owned nested DSL values are Builders in the same Construction session. Each impo
 `KlumJacksonInput` before lifecycle completion. Top-level arrays, Maps, and YAML multi-document streams are ordinary
 Jackson structures and do not implicitly create a shared Klum lifecycle; format-specific multi-document convenience and
 ordered heterogeneous composition are later source-neutral core work (#304), not Jackson importer behavior.
+
+# One foreign YAML input, one enriched output
+
+This is the deliberately asymmetric workflow. A Client Developer owns the YAML mapper and provides exactly one input;
+the Schema Developer owns foreign names, aliases, relationships, lifecycle enrichment, and the output projection.
+
+```groovy
+def mapper = new ObjectMapper(new YAMLFactory()).findAndRegisterModules()
+def deployment = KlumJacksonImporter.using(mapper).readRoot(
+        Deployment,
+        KlumJacksonInput.parser(mapper.factory.createParser('''
+legacy_deployment: storefront
+services: [{ id: api }]
+primary: api
+''')).named("foreign-deployment.yaml"))
+
+mapper.writeValue(output, deployment) // lifecycle-derived output is an intentional addition
+```
+
+The output is not input for another lifecycle and it need not retain `legacy_deployment`; it is an ordinary Jackson
+projection of the completed model. This exact contract is exercised by
+`JacksonYamlInteroperabilityDocumentaryTest#imports one foreign YAML document through one Builder lifecycle and exports an enriched YAML projection`.
+YAML streams, repeated importer calls, and combinations of inputs do not define layering or overwrite policy; the
+source-neutral coordinator remains [#304](https://github.com/klum-dsl/klum-ast/issues/304).
 
 # Mapping a foreign schema
 
@@ -214,4 +238,4 @@ substitute for managed import of a foreign format.
 
 `KlumAstModule` can be subclassed to customize module registration. Its Builder-backed deserializer remains an internal
 implementation detail. Supported extension seams are normal Jackson property/value configuration, explicit type-level
-serializer/deserializer opt-outs, converters, and the public importer once implemented.
+serializer/deserializer opt-outs, converters, and the public importer.

--- a/wiki/Migration.md
+++ b/wiki/Migration.md
@@ -9,6 +9,11 @@ See the dedicated [[Builder First Migration]] guide for the complete migration c
 [[Templates]], [[Copy Strategies]], and [[Model Phases]] for materialization boundaries and [[Jackson Integration]] for
 foreign-data import and ordinary POJO export.
 
+For a foreign YAML/JSON migration, configure one caller-owned Jackson mapper, import one input into one Builder lifecycle,
+and treat the completed-model export as a separately owned external projection. Do not feed it back as Klum persistence or
+use repeated imports as a Jackson-specific merge/layering mechanism; [#304](https://github.com/klum-dsl/klum-ast/issues/304)
+owns source-neutral composition.
+
 # to 2.2
 
 `toString()` methods are not automatically generated anymore, to restore the old behavior, add the `@ToString` annotation to the classes.

--- a/wiki/Terms.md
+++ b/wiki/Terms.md
@@ -19,7 +19,9 @@ validation-result handling, and downstream serialization.
 
 ## Model Writer
 
-Creates concrete configured models using Groovy DSL scripts, YAML/JSON inputs, Templates, or combinations of those inputs.
+Creates concrete configured models using Groovy DSL scripts, YAML/JSON inputs, Templates, or combinations of those
+authoring forms. A Jackson import operation always consumes one external input; source composition is not a Model Writer
+promise of the Jackson adapter.
 
 # Values
 In this documentation, we differentiate between three kinds of values:


### PR DESCRIPTION
## Summary

- add a documentation-linked YAML tracer that imports one foreign document through one Builder lifecycle and serializes an intentionally different enriched projection
- keep import and export fixtures independent while covering foreign aliases, composition, polymorphism, null and unknown-field policy, LINK behavior, Templates, diagnostics, custom serializers, and absence of Klum wire metadata
- align the Jackson guide, migration guidance, role vocabulary, ADR status, implementation plan, and 4.0 release notes

## Why

KlumAST's Jackson adapter is an interoperability boundary, not a persistence format. The executable example now demonstrates the primary workflow without promising round trips, YAML multi-document convenience, or Jackson-owned source layering. Source-neutral multi-input composition remains owned by #304.

## Impact

Schema and Client Developers get an executable one-input YAML example and explicit guidance for asymmetric import/export. The change adds only test-scoped YAML support and documentation; it does not change the production importer API.

## Validation

- `./gradlew :klum-ast-jackson:test`
- `./gradlew :klum-ast-jackson:groovy4Tests :klum-ast-jackson:groovy5Tests`
- `./gradlew :klum-ast-jackson:check`
- `git diff --check`

Closes #464.
