### PR TITLE
Add factory construction documentary test

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -131,6 +131,12 @@ Keep the feature issue, documentary test, and user documentation mutually tracea
   refers to the documentary test file and feature method. Align the example with the test where practical so executable
   coverage guards the documented usage.
 
+When the outcome itself clarifies the contract, the documentation may also show an abbreviated `then:` assertion from the
+documentary test. For a more complex resulting graph, a concise logical representation of the completed model may be
+clearer than executable assertions. This is optional: omit it when the configured model is already self-explanatory, but
+consider it for behavior such as automatic creation, default values, or owner-provided defaults where the resulting state
+is the important part of the example.
+
 This policy applies prospectively. Do not expand unrelated feature work by retrofitting the existing suite; the existing
 documentation and test audit is tracked in [issue #491](https://github.com/klum-dsl/klum-ast/issues/491). This policy is
 KlumAST-specific because it connects the project's DSL behavior, Spock suite, GitHub issues, and user documentation.

--- a/docs/implementation/issue-491-documentary-test-audit.md
+++ b/docs/implementation/issue-491-documentary-test-audit.md
@@ -1,0 +1,61 @@
+# Issue 491 — Documentary-test audit inventory
+
+Tracking issue: [#491 — Audit DSL documentation for documentary test coverage and traceability](https://github.com/klum-dsl/klum-ast/issues/491)
+
+This is the repository-side inventory for the deliberate documentary-test audit. It records the evidence available on
+`master` before this slice and avoids reclassifying legacy regression tests as user documentation merely because they
+exercise the same implementation. #456 owns the eventual versioned documentation URL and hosting policy; until then,
+source links use the current `wiki/` path on `master`.
+
+## Current documentary evidence
+
+Before this slice, the executable suite contained one `@Tag("documentary")` marker:
+
+| Documentation element | Responsible issue | Executable evidence | Audit result |
+| --- | --- | --- | --- |
+| [`Layer3.md` — Automatic creation and linking](../../wiki/Layer3.md#automatic-creation-and-linking) | #474 | `OptionalLinkRelationshipTest.optional relationships retain local composition and aggregation identity for single List and Map entries` | Already aligned with `@Issue`, `@Tag("documentary")`, and `@See`. #454 owns the wider Layer 3 terminology rewrite. |
+| [`Basics.md` — Factory construction](../../wiki/Basics.md#factory-construction) | #76 (closed: move creator methods into a creator class) | `FactoryTest` exercised the generated factory but did not provide a readable linked documentary example. | Aligned by this slice with `FactoryConstructionTest.builds a completed deployment configuration with Create.With`. |
+
+## In-scope user-visible DSL inventory
+
+The following maps the current feature-oriented wiki corpus to the best local historical issue evidence. `Not yet
+aligned` means the documentation and executable behavior exist, but this audit has not yet established a readable,
+annotated documentary path. It is a queue for a later #491 slice, not a new behavioral contract.
+
+| Documentation element | Responsible issue evidence | Executable coverage evidence | Status / next audit action |
+| --- | --- | --- | --- |
+| `Basics.md` — DSL object, fields, keys, owners, relationships, field types | Historical transformation issues in `TransformSpec` (including #21, #22, #35, #54, #56, #58, #80, #121, #126–#128, #172, #249–#250) | `TransformSpec`, `OwnerReferencesSpec`, `RWClassSpec` | Factory construction aligned here; split the remaining broad page by stable heading before adding documentary examples. |
+| `Alternatives-Syntax.md` | #77, #270 | `AlternativesSpec` | Not yet aligned. |
+| `Convenience-Factories.md` | #114, #195, #198 | `ConvenienceFactoriesSpec` | Not yet aligned. |
+| `Converters.md` | #148, #198, #243, #300, #319 | `ConverterSpec` | Not yet aligned. |
+| `Copy-Strategies.md` | #36, #309, #348, #374, #400 | `CopyHandlerTest`, `CopyHandlerRuntimeTest`, `OverwriteStrategyTest` | Not yet aligned. |
+| `Default-Values.md` | #318, #361, #370 | `DefaultValuesSpec` | Not yet aligned. |
+| `Inheritance.md` | #130, #138 | `InheritanceSpec` | Not yet aligned. |
+| `Templates.md` | #82, #322, #368, #376 | `TemplatesSpec`, `BoundTemplatesSpec` | Not yet aligned; replace the stale `TemplateSpec` reference when this page is selected. |
+| `Validation.md` | #25, #125, #145, #221, #223, #276, #381, #395, #406–#407, #409, #415 | `ValidationSpec` | Not yet aligned. |
+| `Model-Phases.md` | #64, #138, #376 | `LifecycleSpec`, phase tests | Not yet aligned. |
+| `Layer3.md` | #454 owns terminology/documentation placement; #474 owns the existing optional-link example | `OptionalLinkRelationshipTest` | One narrow section aligned; defer broader example changes until #454's required terminology grilling. |
+| `Completed-Object-Support.md` | ADR 0006 implementation record; issue mapping needs confirmation | `KlumObjectSupport` tests | Contract-to-issue mapping is unclear; require human triage before adding a documentary test. |
+| `Builder-First-Migration.md` | Builder-first migration issues, including #474 | `BuilderFirstSpec`, `OptionalLinkRelationshipTest` | Not yet aligned; preserve migration wording and avoid overlapping JSON-4 documentation. |
+| `Factory-Classes.md`, `Static-Models.md`, `Advanced-Techniques.md`, `Javadoc.md` | Local legacy source does not establish one unambiguous owning issue | Focused tests exist but are not linked to these pages | Queue human triage for the governing issue before documentary conversion. |
+| `Terms.md`, `Exception-Handling.md`, `FAQ.md` | Reference material, not one discrete feature contract | Focused behavior tests exist where applicable | Excluded from the first feature-example roster; select only after a maintainer identifies a stable, user-facing happy path. |
+
+## Explicit exclusions and coordination boundaries
+
+- `Jackson-Integration.md` and all Jackson/YAML executable coverage are owned by concurrent JSON-4 under #464. This
+  audit records that mapping only; it does not edit those files, examples, or tests.
+- `Usage.md`, `Home.md`, `Gradle-Plugins.md`, release/migration navigation, and adopter journeys are documentation or
+  onboarding coordination surfaces. #456 owns versioned placement, while #469 owns task-oriented onboarding. They are
+  not substitutes for feature-level documentary tests.
+- `Roadmap.md`, `Migration.md`, `_Sidebar.md`, and `_Footer.md` are release, migration, or navigation material rather
+  than user-visible DSL feature elements. They do not require a feature documentary test of their own.
+- #454's Layer 3 terminology rewrite remains a product/documentation-placement dependency. The existing #474 example is
+  retained, but this audit does not broaden it.
+
+## Follow-up queue for human action
+
+No GitHub issues were created by this local-only slice. Before a subsequent #491 implementation slice, a maintainer
+should choose the next stable documentation heading and either confirm its governing historical issue or create a
+focused follow-up for an unclear contract. The clearest candidates are `Templates.md`, `Default-Values.md`, and
+`Convenience-Factories.md`; `Completed-Object-Support.md` and the legacy technique pages need ownership confirmation
+first.

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/FactoryConstructionTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/FactoryConstructionTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+class FactoryConstructionTest extends AbstractDSLSpec {
+
+    @Issue("76")
+    @Tag("documentary")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Basics.md#factory-construction")
+    def "builds a completed deployment configuration with Create.With"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Deployment {
+                @Key String name
+                String environment
+                Service service
+            }
+
+            @DSL
+            class Service {
+                String image
+            }
+        '''
+
+        when:
+        def deployment = clazz.Create.With('catalog') {
+            environment 'production'
+            service {
+                image 'catalog:1.0'
+            }
+        }
+
+        then:
+        deployment.name == 'catalog'
+        deployment.environment == 'production'
+        deployment.service.image == 'catalog:1.0'
+    }
+}

--- a/wiki/Basics.md
+++ b/wiki/Basics.md
@@ -74,6 +74,32 @@ Config.Create.With(name: 'Dieter', age: 15)
 
 Of course, named parameters and regular calls inside the closure can be combined ad lib.
 
+For example, a keyed deployment and its owned service can be configured together:
+
+```groovy
+@DSL
+class Deployment {
+    @Key String name
+    String environment
+    Service service
+}
+
+@DSL
+class Service {
+    String image
+}
+
+def deployment = Deployment.Create.With('catalog') {
+    environment 'production'
+    service {
+        image 'catalog:1.0'
+    }
+}
+```
+
+`deployment` is the completed DSL Object. The same example is executable in
+`FactoryConstructionTest.groovy`, feature `builds a completed deployment configuration with Create.With`.
+
 There are also a couple of [[Convenience Factories]] to load a model into client code.
 
 ## Lifecycle Methods


### PR DESCRIPTION
## Summary

- add the first non-Jackson documentary-test audit slice for Factory construction
- record the current DSL documentation/test traceability inventory and explicit JSON-4/#464 boundary
- align the `Basics.md` `Create.With` example with an executable, linked happy-path test

## Why

Issue #491 requires deliberate, durable traceability between user-facing DSL documentation, its responsible issue, and readable executable coverage. This slice uses the stable historical Factory-owner issue #76 without pre-empting the documentation-placement work in #456 or the Layer 3/onboarding work in #454 and #469.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.groovy.configdsl.transform.FactoryConstructionTest`
- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `git diff --check origin/master...HEAD`
- local standards and specification reviews: no findings

Related: #491

The audit intentionally leaves Jackson/YAML examples and tests to concurrent JSON-4 work under #464.
