### PR TITLE
docs: add post-release orchestration evidence policy

### DIFF
--- a/.agents/skills/work-orchestrator/SKILL.md
+++ b/.agents/skills/work-orchestrator/SKILL.md
@@ -86,6 +86,22 @@ Keep a task's assigned execution scope separate from its repository delivery sta
 
 On a user report or orchestrator refresh, verify relevant issue, PR, and merge state and ask the task to update its title when that policy requires it. Tasks need not poll continuously. Do not archive or call work done while an actionable delivery step remains; use the repository's archive-safe status prefix only after its definition is satisfied.
 
+### 8. Record post-release orchestration evidence
+
+For a release or other bounded run, require every created worker to write an append-only, machine-readable evidence event stream and to include the local evidence-stream location in its callback report. This applies to both active and finished user-visible workers; the orchestrator backfills no inferred history. Use the exact schema and a minimal valid example in [the evidence reference](references/post-release-evidence.schema.json) and [example](references/post-release-evidence.example.json).
+
+Record only events observed by the worker or orchestrator. Assign stable opaque IDs to the release, run, worker, task, event, artifact, decision, and operation; use links or artifact categories instead of copied content. Never record secrets, credentials, raw private prompts, full command output, personal assessments, or unredacted sensitive paths.
+
+Use append-only semantics: add a new event; never edit or delete an already-recorded one. Correct factual errors with a `correction` event that identifies the superseded event and replacement values. Redact unsafe detail with a `redaction` event that identifies the event/field and reason, preserves the audit trail, and replaces the detail with a safe category or stable reference. A correction or redaction must not silently rewrite timing, authorization, or outcome history.
+
+Each worker must emit `worker_started` and `worker_finished` events. Its finished summary must capture UTC start/end, actual model and reasoning, purpose, expected and actual output, and all observable worker data: visible token/quota pressure (or explicitly `unavailable` when the platform does not expose it); human intervention points and waiting duration; retries, abandoned approaches, and duplicated investigation; requested, authorized, denied, and deferred repository/remote operations; meaningful artifacts read/written; spawn rationale and why existing workers could not continue; cross-library decisions with owner and receiver acknowledgements; and other encountered problems. Capture an AFK decision record with exactly: Trigger; why this worker was needed; why existing workers could not handle it; allowed repository scope; allowed operations; operations requiring later authorization; expected stopping condition; result.
+
+Treat “mental overload” only as optional, aggregate-safe operational telemetry: counts/timing of user-facing context switches and concurrent human-decision queues (for example, switches between unrelated grill sessions). Do not infer cognition, record personal traits, or capture prompt content.
+
+The creating orchestrator must provide the release/run IDs, evidence location, callback requirement, and a worker’s permitted scope. It records orchestration-level launches, routing, authorization friction, and human-queue changes; checks callback reports for the final event location; and reconciles missing or invalid records as an explicit audit gap rather than guessing. Workers retain their normal authorization boundaries: evidence collection neither grants repository/remote operations nor changes AFK restrictions.
+
+Use two layers of storage. Keep raw runtime event streams outside product repositories, partitioned by release and run, for example `<cross-repository-runtime-evidence>/<release-id>/<run-id>/`. At release close, aggregate only sanitized, human-reviewable findings and a machine-readable summary for the proposed engineering-baseline/release-governance location; do not create that runtime store, automate collection, or mutate a product repository merely to collect evidence. The aggregation calculates wall-clock and active/wait durations, observable quota efficiency, authorization/security friction, human task-switch/queue load, retries/duplication, and AFK-policy value, while preserving `unavailable` and audit-gap states rather than fabricating precision.
+
 ## Spawn template
 
 ```text
@@ -115,6 +131,8 @@ Before handing off an overview or an orchestrator task, verify:
 - [ ] Cross-cutting candidates were routed once with the required evidence and ownership fields, then deduplicated by receivers without triggering work, GitHub writes, repository changes, or feedback loops.
 - [ ] Refreshing and rendering made no repository, tracker, project, PR, release, or task-state mutation beyond a user-authorized task lifecycle action.
 - [ ] An AFK window, when active, records an explicit deadline, capacity mode, and model/reasoning ceiling; admission evidence is fresh; every launched task is a local-only worktree task within the capacity cap; and no recurring automation or remote mutation was used.
+- [ ] A release/run evidence stream exists outside the product repository for each created worker, has valid start/finish events or an explicit audit gap, and contains no prohibited sensitive content.
+- [ ] The release-close aggregation produces only a sanitized report and machine-readable summary for the proposed engineering-baseline/release-governance location; its measurements preserve unavailable/unknown states.
 
 ## KlumAST overlay
 

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0",
+  "event_id": "event-evid-pol-finished-001",
+  "recorded_at": "2026-07-20T10:15:00Z",
+  "release": {"release_id": "klum-ast-4.0", "reference": "release governance run"},
+  "run": {"run_id": "run-4.0-evidence-policy", "callback_thread_id": "019f7046-f4fb-7e01-b527-33f2938da753"},
+  "worker": {"worker_id": "worker-evid-pol", "task_id": "task-evid-pol"},
+  "event_type": "worker_finished",
+  "event": {
+    "occurred_at": "2026-07-20T10:15:00Z",
+    "timing": {"active_seconds": 180, "waiting_seconds": 0, "unclassified_seconds": 0},
+    "actual_output": "Local committed evidence-policy documentation and schema.",
+    "quota_pressure": {"availability": "unavailable", "summary": "Platform did not expose quota telemetry."},
+    "human_interventions": [],
+    "retries": {"retry_count": 0, "abandoned_approaches": [], "duplicated_investigation": []},
+    "operations": [{"operation_id": "op-local-commit", "target_category": "repository", "scope": "local policy branch", "state": "authorized"}],
+    "artifacts": [{"artifact_id": "artifact-work-orchestrator-skill", "direction": "written", "category": "orchestrator policy and schema reference"}],
+    "spawn": {"spawned": false, "rationale": "No additional worker was needed.", "existing_workers_could_not_continue": "Not applicable."},
+    "cross_library_decisions": [],
+    "problems": [],
+    "afk_decision": {
+      "Trigger": "Not an AFK admission.",
+      "why_this_worker_was_needed": "Create the cross-orchestrator evidence policy.",
+      "why_existing_workers_could_not_handle_it": "No existing worker owned this bounded policy task.",
+      "allowed_repository_scope": "KlumAST policy and skill artifacts only.",
+      "allowed_operations": ["local documentation edits", "local validation", "local commit"],
+      "operations_requiring_later_authorization": ["push", "pull request creation", "remote repository changes"],
+      "expected_stopping_condition": "Validated local commit.",
+      "result": "Completed locally."
+    }
+  }
+}

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://klum-dsl.org/schemas/post-release-orchestration-evidence/v1",
+  "title": "Post-release orchestration evidence event",
+  "description": "Append-only, privacy-preserving event for a cross-repository release/run audit.",
+  "type": "object",
+  "required": ["schema_version", "event_id", "recorded_at", "release", "run", "worker", "event_type", "event"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "event_id": {"$ref": "#/$defs/stableId"},
+    "recorded_at": {"$ref": "#/$defs/utcTimestamp"},
+    "release": {"$ref": "#/$defs/release"},
+    "run": {"$ref": "#/$defs/run"},
+    "worker": {"$ref": "#/$defs/worker"},
+    "event_type": {"enum": ["worker_started", "worker_finished", "orchestrator", "correction", "redaction"]},
+    "event": {"type": "object"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"event_type": {"const": "worker_started"}}},
+      "then": {"properties": {"event": {"$ref": "#/$defs/startedEvent"}}}
+    },
+    {
+      "if": {"properties": {"event_type": {"const": "worker_finished"}}},
+      "then": {"properties": {"event": {"$ref": "#/$defs/finishedEvent"}}}
+    },
+    {
+      "if": {"properties": {"event_type": {"const": "orchestrator"}}},
+      "then": {"properties": {"event": {"$ref": "#/$defs/orchestratorEvent"}}}
+    },
+    {
+      "if": {"properties": {"event_type": {"const": "correction"}}},
+      "then": {"properties": {"event": {"$ref": "#/$defs/correctionEvent"}}}
+    },
+    {
+      "if": {"properties": {"event_type": {"const": "redaction"}}},
+      "then": {"properties": {"event": {"$ref": "#/$defs/redactionEvent"}}}
+    }
+  ],
+  "$defs": {
+    "stableId": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$"},
+    "utcTimestamp": {"type": "string", "format": "date-time", "pattern": "Z$"},
+    "nonNegativeDuration": {"type": "integer", "minimum": 0, "description": "Duration in seconds."},
+    "safeText": {"type": "string", "minLength": 1, "maxLength": 500, "description": "Sanitized summary only; never a secret, credential, raw prompt, or command output."},
+    "safeTextList": {"type": "array", "items": {"$ref": "#/$defs/safeText"}},
+    "release": {
+      "type": "object",
+      "required": ["release_id"],
+      "additionalProperties": false,
+      "properties": {"release_id": {"$ref": "#/$defs/stableId"}, "reference": {"$ref": "#/$defs/safeText"}}
+    },
+    "run": {
+      "type": "object",
+      "required": ["run_id"],
+      "additionalProperties": false,
+      "properties": {"run_id": {"$ref": "#/$defs/stableId"}, "callback_thread_id": {"$ref": "#/$defs/stableId"}}
+    },
+    "worker": {
+      "type": "object",
+      "required": ["worker_id", "task_id"],
+      "additionalProperties": false,
+      "properties": {
+        "worker_id": {"$ref": "#/$defs/stableId"},
+        "task_id": {"$ref": "#/$defs/stableId"},
+        "parent_worker_id": {"$ref": "#/$defs/stableId"}
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["actual_model", "actual_reasoning"],
+      "additionalProperties": false,
+      "properties": {"actual_model": {"$ref": "#/$defs/safeText"}, "actual_reasoning": {"$ref": "#/$defs/safeText"}}
+    },
+    "startedEvent": {
+      "type": "object",
+      "required": ["occurred_at", "model", "purpose", "expected_output"],
+      "additionalProperties": false,
+      "properties": {
+        "occurred_at": {"$ref": "#/$defs/utcTimestamp"},
+        "model": {"$ref": "#/$defs/model"},
+        "purpose": {"$ref": "#/$defs/safeText"},
+        "expected_output": {"$ref": "#/$defs/safeText"}
+      }
+    },
+    "finishedEvent": {
+      "type": "object",
+      "required": ["occurred_at", "timing", "actual_output", "quota_pressure", "human_interventions", "retries", "operations", "artifacts", "spawn", "cross_library_decisions", "problems", "afk_decision"],
+      "additionalProperties": false,
+      "properties": {
+        "occurred_at": {"$ref": "#/$defs/utcTimestamp"},
+        "timing": {"$ref": "#/$defs/timing"},
+        "actual_output": {"$ref": "#/$defs/safeText"},
+        "quota_pressure": {"$ref": "#/$defs/quotaPressure"},
+        "human_interventions": {"type": "array", "items": {"$ref": "#/$defs/humanIntervention"}},
+        "retries": {"$ref": "#/$defs/retries"},
+        "operations": {"type": "array", "items": {"$ref": "#/$defs/operation"}},
+        "artifacts": {"type": "array", "items": {"$ref": "#/$defs/artifact"}},
+        "spawn": {"$ref": "#/$defs/spawn"},
+        "cross_library_decisions": {"type": "array", "items": {"$ref": "#/$defs/crossLibraryDecision"}},
+        "problems": {"type": "array", "items": {"$ref": "#/$defs/safeText"}},
+        "mental_overload": {"$ref": "#/$defs/mentalOverload"},
+        "afk_decision": {"$ref": "#/$defs/afkDecision"}
+      }
+    },
+    "quotaPressure": {
+      "type": "object",
+      "required": ["availability"],
+      "additionalProperties": false,
+      "properties": {
+        "availability": {"enum": ["observable", "unavailable"]},
+        "summary": {"$ref": "#/$defs/safeText"},
+        "visible_remaining_percent": {"type": "number", "minimum": 0, "maximum": 100}
+      },
+      "allOf": [{"if": {"properties": {"availability": {"const": "unavailable"}}}, "then": {"not": {"required": ["visible_remaining_percent"]}}}]
+    },
+    "timing": {
+      "description": "Observed worker-time accounting in seconds; wall-clock duration is derived from start/finish UTC timestamps.",
+      "type": "object",
+      "required": ["active_seconds", "waiting_seconds", "unclassified_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "active_seconds": {"$ref": "#/$defs/nonNegativeDuration"},
+        "waiting_seconds": {"$ref": "#/$defs/nonNegativeDuration"},
+        "unclassified_seconds": {"$ref": "#/$defs/nonNegativeDuration"}
+      }
+    },
+    "humanIntervention": {
+      "type": "object",
+      "required": ["point", "wait_seconds"],
+      "additionalProperties": false,
+      "properties": {"point": {"$ref": "#/$defs/safeText"}, "wait_seconds": {"$ref": "#/$defs/nonNegativeDuration"}}
+    },
+    "retries": {
+      "type": "object",
+      "required": ["retry_count", "abandoned_approaches", "duplicated_investigation"],
+      "additionalProperties": false,
+      "properties": {
+        "retry_count": {"type": "integer", "minimum": 0},
+        "abandoned_approaches": {"$ref": "#/$defs/safeTextList"},
+        "duplicated_investigation": {"$ref": "#/$defs/safeTextList"}
+      }
+    },
+    "operation": {
+      "type": "object",
+      "required": ["operation_id", "target_category", "scope", "state"],
+      "additionalProperties": false,
+      "properties": {
+        "operation_id": {"$ref": "#/$defs/stableId"},
+        "target_category": {"enum": ["repository", "remote", "tracker", "pull_request", "release", "credentials", "other"]},
+        "scope": {"$ref": "#/$defs/safeText"},
+        "state": {"enum": ["requested", "authorized", "denied", "deferred", "completed"]},
+        "reference": {"$ref": "#/$defs/safeText"}
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["artifact_id", "direction", "category"],
+      "additionalProperties": false,
+      "properties": {
+        "artifact_id": {"$ref": "#/$defs/stableId"},
+        "direction": {"enum": ["read", "written"]},
+        "category": {"$ref": "#/$defs/safeText"},
+        "reference": {"$ref": "#/$defs/safeText"}
+      }
+    },
+    "spawn": {
+      "type": "object",
+      "required": ["spawned", "rationale", "existing_workers_could_not_continue"],
+      "additionalProperties": false,
+      "properties": {
+        "spawned": {"type": "boolean"},
+        "rationale": {"$ref": "#/$defs/safeText"},
+        "existing_workers_could_not_continue": {"$ref": "#/$defs/safeText"}
+      }
+    },
+    "crossLibraryDecision": {
+      "type": "object",
+      "required": ["decision_id", "decision", "owner", "receiver_acknowledgements"],
+      "additionalProperties": false,
+      "properties": {
+        "decision_id": {"$ref": "#/$defs/stableId"},
+        "decision": {"$ref": "#/$defs/safeText"},
+        "owner": {"$ref": "#/$defs/stableId"},
+        "receiver_acknowledgements": {"type": "array", "items": {"$ref": "#/$defs/stableId"}}
+      }
+    },
+    "mentalOverload": {
+      "description": "Optional aggregate-safe operational telemetry; never inferred cognition or prompt content.",
+      "type": "object",
+      "required": ["user_facing_context_switches", "concurrent_human_decision_queue_peak"],
+      "additionalProperties": false,
+      "properties": {
+        "user_facing_context_switches": {"type": "integer", "minimum": 0},
+        "concurrent_human_decision_queue_peak": {"type": "integer", "minimum": 0},
+        "window_started_at": {"$ref": "#/$defs/utcTimestamp"},
+        "window_ended_at": {"$ref": "#/$defs/utcTimestamp"}
+      }
+    },
+    "afkDecision": {
+      "type": "object",
+      "required": ["Trigger", "why_this_worker_was_needed", "why_existing_workers_could_not_handle_it", "allowed_repository_scope", "allowed_operations", "operations_requiring_later_authorization", "expected_stopping_condition", "result"],
+      "additionalProperties": false,
+      "properties": {
+        "Trigger": {"$ref": "#/$defs/safeText"},
+        "why_this_worker_was_needed": {"$ref": "#/$defs/safeText"},
+        "why_existing_workers_could_not_handle_it": {"$ref": "#/$defs/safeText"},
+        "allowed_repository_scope": {"$ref": "#/$defs/safeText"},
+        "allowed_operations": {"$ref": "#/$defs/safeTextList"},
+        "operations_requiring_later_authorization": {"$ref": "#/$defs/safeTextList"},
+        "expected_stopping_condition": {"$ref": "#/$defs/safeText"},
+        "result": {"$ref": "#/$defs/safeText"}
+      }
+    },
+    "orchestratorEvent": {
+      "type": "object",
+      "required": ["occurred_at", "kind", "summary"],
+      "additionalProperties": false,
+      "properties": {"occurred_at": {"$ref": "#/$defs/utcTimestamp"}, "kind": {"enum": ["launch", "routing", "authorization_friction", "human_queue_change", "audit_gap"]}, "summary": {"$ref": "#/$defs/safeText"}}
+    },
+    "correctionEvent": {
+      "type": "object",
+      "required": ["occurred_at", "supersedes_event_id", "replacement_values", "reason"],
+      "additionalProperties": false,
+      "properties": {"occurred_at": {"$ref": "#/$defs/utcTimestamp"}, "supersedes_event_id": {"$ref": "#/$defs/stableId"}, "replacement_values": {"type": "object", "additionalProperties": {"$ref": "#/$defs/safeText"}}, "reason": {"$ref": "#/$defs/safeText"}}
+    },
+    "redactionEvent": {
+      "type": "object",
+      "required": ["occurred_at", "target_event_id", "field", "reason", "safe_replacement"],
+      "additionalProperties": false,
+      "properties": {"occurred_at": {"$ref": "#/$defs/utcTimestamp"}, "target_event_id": {"$ref": "#/$defs/stableId"}, "field": {"$ref": "#/$defs/safeText"}, "reason": {"$ref": "#/$defs/safeText"}, "safe_replacement": {"$ref": "#/$defs/safeText"}}
+    }
+  }
+}

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -56,3 +56,17 @@ issue-tracker and authorization wording above remains local.
 The reusable AFK-window protocol is also a candidate for that same baseline issue. Its KlumAST overlay remains local:
 resource-sensitive concurrency reduction, license-policy hard stops, and human ownership of uncertain classification and
 all GitHub changes.
+
+## Post-release orchestration evidence overlay
+
+For KlumAST 4.0, every cross-orchestrator evidence stream must carry stable `release_id` `klum-ast-4.0` and a distinct
+`run_id` (for example, the release-orchestrator run or AFK-window identifier). The reusable event contract, including its
+privacy boundary and AFK decision record, lives in the authoritative
+[`work-orchestrator` skill](../../.agents/skills/work-orchestrator/SKILL.md) and its linked schema; do not copy the schema
+into this overlay.
+
+Keep runtime records outside the KlumAST checkout, organized by release/run. A release-close result is only a proposed,
+sanitized human-reviewable report plus machine-readable summary for the engineering-baseline/release-governance location.
+This policy does not authorize creating that store, automating collection, or mutating this product repository, its
+tracker, or its remotes to gather evidence. Preserve KlumAST's normal human ownership of classification, GitHub changes,
+and publication authority.


### PR DESCRIPTION
## Summary

- define an append-only, privacy-preserving cross-orchestrator evidence protocol
- add a versioned JSON Schema and representative record
- add the KlumAST 4.0 release/run correlation and no-product-mutation overlay

## Why

This makes future post-release audits evidence-led while preserving authorization boundaries and unavailable/audit-gap states.

## Validation

- schema references and representative record validated
- policy links validated
- `git diff --check`

No runtime evidence store or collection automation is created by this pull request.