### PR TITLE
Document @Default field defaults for issue #491

### DIFF
--- a/docs/implementation/issue-491-documentary-test-audit.md
+++ b/docs/implementation/issue-491-documentary-test-audit.md
@@ -15,6 +15,7 @@ Before this slice, the executable suite contained one `@Tag("documentary")` mark
 | --- | --- | --- | --- |
 | [`Layer3.md` — Automatic creation and linking](../../wiki/Layer3.md#automatic-creation-and-linking) | #474 | `OptionalLinkRelationshipTest.optional relationships retain local composition and aggregation identity for single List and Map entries` | Already aligned with `@Issue`, `@Tag("documentary")`, and `@See`. #454 owns the wider Layer 3 terminology rewrite. |
 | [`Basics.md` — Factory construction](../../wiki/Basics.md#factory-construction) | #76 (closed: move creator methods into a creator class) | `FactoryTest` exercised the generated factory but did not provide a readable linked documentary example. | Aligned by this slice with `FactoryConstructionTest.builds a completed deployment configuration with Create.With`. |
+| [`Default-Values.md` — Other fields (`field`)](../../wiki/Default-Values.md#other-fields-field) | #318 (closed: make `@Default` a lifecycle method) | `DefaultValuesSpec` covered field defaults but did not provide a linked, user-oriented happy path. | Aligned by this slice with `DefaultValuesDocumentaryTest.defaults a release identifier from its configured name`. |
 
 ## In-scope user-visible DSL inventory
 
@@ -29,7 +30,7 @@ annotated documentary path. It is a queue for a later #491 slice, not a new beha
 | `Convenience-Factories.md` | #114, #195, #198 | `ConvenienceFactoriesSpec` | Not yet aligned. |
 | `Converters.md` | #148, #198, #243, #300, #319 | `ConverterSpec` | Not yet aligned. |
 | `Copy-Strategies.md` | #36, #309, #348, #374, #400 | `CopyHandlerTest`, `CopyHandlerRuntimeTest`, `OverwriteStrategyTest` | Not yet aligned. |
-| `Default-Values.md` | #318, #361, #370 | `DefaultValuesSpec` | Not yet aligned. |
+| `Default-Values.md` — Other fields (`field`) | #318 | `DefaultValuesSpec`, `DefaultValuesDocumentaryTest` | Aligned with `DefaultValuesDocumentaryTest.defaults a release identifier from its configured name`. The Layer 3 annotation variants remain separate follow-ups under #361 and #370. |
 | `Inheritance.md` | #130, #138 | `InheritanceSpec` | Not yet aligned. |
 | `Templates.md` | #82, #322, #368, #376 | `TemplatesSpec`, `BoundTemplatesSpec` | Not yet aligned; replace the stale `TemplateSpec` reference when this page is selected. |
 | `Validation.md` | #25, #125, #145, #221, #223, #276, #381, #395, #406–#407, #409, #415 | `ValidationSpec` | Not yet aligned. |
@@ -56,6 +57,6 @@ annotated documentary path. It is a queue for a later #491 slice, not a new beha
 
 No GitHub issues were created by this local-only slice. Before a subsequent #491 implementation slice, a maintainer
 should choose the next stable documentation heading and either confirm its governing historical issue or create a
-focused follow-up for an unclear contract. The clearest candidates are `Templates.md`, `Default-Values.md`, and
-`Convenience-Factories.md`; `Completed-Object-Support.md` and the legacy technique pages need ownership confirmation
-first.
+focused follow-up for an unclear contract. The clearest candidates are `Templates.md` and
+`Convenience-Factories.md`; the Layer 3 annotation variants in `Default-Values.md` remain bounded by #361/#370, while
+`Completed-Object-Support.md` and the legacy technique pages need ownership confirmation first.

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesDocumentaryTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class DefaultValuesDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("318")
+    @Tag("documentary")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/wiki/Default-Values.md#other-fields-field")
+    def "defaults a release identifier from its configured name"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Release {
+                String name
+
+                @Default(field = 'name')
+                String identifier
+            }
+        '''
+
+        when:
+        def release = clazz.Create.With {
+            name 'spring-catalog'
+        }
+
+        then:
+        release.name == 'spring-catalog'
+        release.identifier == 'spring-catalog'
+    }
+}

--- a/wiki/Default-Values.md
+++ b/wiki/Default-Values.md
@@ -28,6 +28,27 @@ def config = Config.Create.With {
 assert config.id == 'Hans' // defaults to name 
 ```
 
+For example, a release can derive an identifier from its configured name during the default phase:
+
+```groovy
+@DSL
+class Release {
+    String name
+
+    @Default(field = 'name')
+    String identifier
+}
+
+def release = Release.Create.With {
+    name 'spring-catalog'
+}
+
+assert release.identifier == 'spring-catalog'
+```
+
+The same happy path is executable in `DefaultValuesDocumentaryTest.groovy`, feature
+`defaults a release identifier from its configured name`.
+
 # Delegate fields (delegate)
 
 The default value is taken from a property with the same name of the targeted delegate. This is especially 


### PR DESCRIPTION
## Summary

- add an executable documentary happy path for `@Default(field = ...)`
- link the test, `Default-Values.md`, and the #491 audit inventory
- retain the Layer 3 annotation variants (#361/#370) as bounded follow-up work

This advances one settled, non-Jackson traceability slice of issue #491; the issue remains open for the wider audit.

## Impact

Users gain a concise, executable example showing a release identifier defaulted from its configured name. No runtime behavior changes.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `git diff --check`

Related: #491
