### PR TITLE
Teach target-contract modeling through an executable Helm journey

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This is a breaking release. See the [Builder-first construction migration](https
 ## Builder-first construction
 
 - Added a task-oriented Gradle onboarding preview, portable `start-klum-project`, `author-klum-model`, and `feature-advisor` Agent Skills, plus an executable minimal fixture. `feature-advisor` also assesses whether KlumAST or its skill distribution needs an update ([#470](https://github.com/klum-dsl/klum-ast/issues/470)).
+- Added the portable `build-target-contract-schema` skill and an executable direct-schema Helm journey. It renders two validated service models as human-readable values files with semantic golden-contract evidence, makes the Layer 3 decision explicit, and keeps resource-backed defaults and ordered configuration composition with #79 and #304 ([#472](https://github.com/klum-dsl/klum-ast/issues/472)).
 
 - Replaced mutable generated RW objects with generated Builders inheriting from `KlumBuilder`, while preserving DSL inheritance. Builders own field initializers, relationship state, mutators, and lifecycle work through `POST_TREE` ([#416](https://github.com/klum-dsl/klum-ast/issues/416), [#266](https://github.com/klum-dsl/klum-ast/issues/266)).
 - Added the `INSTANTIATE` phase at ordinal 40. It materializes the complete graph before validation, including cycles and self-links, then runs validation against completed DSL Objects.

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -10,6 +10,7 @@ Copy only the directories you want into the skill-discovery directory used by yo
 cp -R start-klum-project <your-agent-skill-directory>/
 cp -R author-klum-model <your-agent-skill-directory>/
 cp -R feature-advisor <your-agent-skill-directory>/
+cp -R build-target-contract-schema <your-agent-skill-directory>/
 ```
 
 Each directory is a standard skill: its portable `SKILL.md` is the workflow. Agent clients choose their own discovery location and UI metadata, so keep client-specific installation instructions outside these directories. In Codex, use its configured skills directory; other clients should use their documented discovery location.
@@ -27,3 +28,11 @@ Use documentation that matches the KlumAST version you are adopting. The linked 
 ```
 
 The fixture uses a composite build so it validates the checked-out KlumAST 4.0 sources. A real adopter project should use the released plugin version selected by `start-klum-project` instead.
+
+`fixtures/helm-target-contract` is the target-contract companion: it creates readable Helm values for two services, compares their parsed meaning to representative and golden target artifacts, and records why a direct-schema authoring model is appropriate. Run its Groovy 3 baseline with:
+
+```shell
+./gradlew -p agent-skills/fixtures/helm-target-contract test
+```
+
+The portable `build-target-contract-schema` workflow points to this fixture and its later [field-test starting point](field-tests/target-contract-helm/).

--- a/agent-skills/build-target-contract-schema/SKILL.md
+++ b/agent-skills/build-target-contract-schema/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: build-target-contract-schema
+description: Build a KlumAST authoring Schema for an authoritative external contract. Use when an adopter is replacing or simplifying Helm values, another configuration document, or a target-specific API contract while keeping that contract authoritative.
+---
+
+# Build a target-contract Schema
+
+Use the documentation for the KlumAST version being adopted as the authority. This workflow creates a convenient authoring layer for one external target; it does not define a universal import/export format.
+
+1. Collect two or more representative target artifacts and name the target, its owning team, supported versions, and the values that are intentionally stable. For Helm, retain the chart name/version and values files. Treat the target contract—not its incidental YAML formatting—as authoritative.
+2. Identify the repeated concepts, defaults, validity rules, and awkward combinations in those artifacts. Propose a small authoring vocabulary that reduces real repetition. Do not mechanically copy every map, list, or spelling from YAML into classes.
+3. Decide independently whether the project is direct-schema or Layer 3. Choose direct-schema when the Schema Developer also owns the consumer-facing types and no separate stable Domain API is needed. Choose Layer 3 only when clients must compile against a distinct Domain API; do not introduce it for hypothetical flexibility. Record the rationale in the project README or architecture note.
+4. Create `@DSL` Schema types that express the chosen authoring vocabulary. Add meaningful defaults, validation, and at least one higher-level convenience only where it reduces a demonstrated target-contract burden. Keep generated Builders inside one root construction lifecycle.
+5. Implement a narrow renderer or adapter that maps completed models to the target contract. The adapter may intentionally expand one authoring concept into several target fields. It must make every non-obvious mapping visible in tests or documentation.
+6. Add representative configured models and generate target artifacts from them. Compare the generated artifacts semantically with golden target-contract files; keep the golden files human-readable. Do not make byte ordering, YAML formatting, Klum metadata, or a YAML/KlumAST round trip the compatibility promise.
+7. Keep current capabilities separate from future migration conveniences. Resource-backed defaults remain [#79](https://github.com/klum-dsl/klum-ast/issues/79); ordered base/override composition remains [#304](https://github.com/klum-dsl/klum-ast/issues/304). If the target cannot be expressed without one, record a focused follow-up rather than broadening this onboarding workflow.
+8. Run the fixture's normal Gradle test with the chosen Groovy line, then exercise its supported Groovy 4 and 5 variants before handoff. Refresh generated source mirrors only when IntelliJ completion is useful; they are not build inputs.
+
+The executable [Helm target-contract fixture](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills/fixtures/helm-target-contract) demonstrates the direct-schema decision, two service values contracts, defaults, validation, a convenience mapping, and semantic golden-file checks. Follow [Target Contract Modeling](https://github.com/klum-dsl/klum-ast/wiki/Target-Contract-Modeling) for the task-oriented explanation, and use the [field-test starting artifact](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills/field-tests/target-contract-helm) when applying this preview to a real project.

--- a/agent-skills/field-tests/target-contract-helm/README.md
+++ b/agent-skills/field-tests/target-contract-helm/README.md
@@ -1,0 +1,7 @@
+# Target-contract field test (4.0 preview)
+
+Use this prompt after a real project has selected `build-target-contract-schema`. It evaluates the current onboarding path; it does not prescribe extra skills or expand the 4.0 preview scope.
+
+> Bring two or three representative Helm values files, the chart versions they target, and one real configuration change that is painful today. Use `target-contract-inventory.md` to record the contract owner, stable concepts, direct-schema or Layer 3 decision, intentional Klum-to-Helm mappings, generated-artifact checks, and any unmet need. Build the smallest validated authoring model that produces golden-tested values files. Report where the workflow was unclear or where a missing KlumAST capability blocked progress; describe that need precisely without designing a future workflow.
+
+Keep target artifacts and generated golden files with the adopter project. File separate, focused follow-ups only for genuinely missing capabilities; the known resource-default and ordered-composition boundaries remain #79 and #304.

--- a/agent-skills/field-tests/target-contract-helm/target-contract-inventory.md
+++ b/agent-skills/field-tests/target-contract-helm/target-contract-inventory.md
@@ -1,0 +1,31 @@
+# Target-contract field-test inventory
+
+## Context
+
+- Target system and chart/version:
+- Target-contract owner and compatibility expectation:
+- Representative values files reviewed:
+- Painful repeated or error-prone configuration:
+
+## Modeling decisions
+
+- Schema driver: target-contract
+- Consumer shape: direct-schema or Layer 3
+- Rationale for that consumer shape:
+- Stable concepts retained in the authoring model:
+- Intentional Klum-to-target mappings and defaults:
+- Validation rules and the target failure each prevents:
+
+## Evidence
+
+- Configured service examples:
+- Generated target artifact locations:
+- Golden-contract comparison command and result:
+- Groovy version and Gradle version:
+
+## Findings
+
+- What was clear or useful:
+- What required interpretation:
+- Missing capability, if any, and its smallest concrete use case:
+- Is it resource-backed defaults (#79), ordered composition (#304), or a distinct follow-up:

--- a/agent-skills/fixtures/helm-target-contract/.gitignore
+++ b/agent-skills/fixtures/helm-target-contract/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/agent-skills/fixtures/helm-target-contract/README.md
+++ b/agent-skills/fixtures/helm-target-contract/README.md
@@ -1,0 +1,33 @@
+# Helm target-contract onboarding fixture
+
+This is the executable journey for `build-target-contract-schema`. It models the authoritative values contracts for the `catalog` and `billing` services with a direct-schema KlumAST authoring layer.
+
+## Target contract
+
+The Acme Platform deployment team owns the `acme-service` Helm chart at version `3.2.1`. Its supported values contract for that chart version is represented by the checked-in `catalog` and `billing` values files. The generated values must preserve their parsed Helm meaning; YAML comments, key order, and other formatting are not compatibility promises.
+
+## Why direct-schema
+
+The same team owns the Schema and the deployment configuration in this small target-specific project. There is no separate client-facing Domain API to stabilize, so Layer 3 would add ceremony without protecting a real consumer boundary. `ServiceRelease` is therefore the direct authoring type, while `toHelmValues()` is the intentional adapter to the Helm contract.
+
+The authoring model earns that seam by deriving image repositories and public hosts from the stable service key, supplying common resource defaults, validating deployment-safe tags and ports, and expanding `publiclyReachable` into Helm ingress values. It is not a generic Helm object model and must not be used to infer a YAML/KlumAST round trip.
+
+## Contract evidence
+
+`src/test/resources/helm/representative/` contains the target-owner examples for two services. `src/test/resources/helm/golden/` is the checked-in generated-contract expectation. `HelmTargetContractDocumentaryTest` renders each configured model to `build/generated-values/`, parses the human-readable YAML, and compares its meaning with both artifacts.
+
+Run the fixture inside this repository with:
+
+```shell
+./gradlew -p agent-skills/fixtures/helm-target-contract test
+./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=4
+./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=5
+```
+
+The composite build intentionally uses the checked-out KlumAST 4.x source baseline. A real adopter should use the released plugin version selected by `start-klum-project`.
+
+## Boundaries
+
+This fixture does not read defaults from a YAML resource; that deferred migration convenience belongs to [#79](https://github.com/klum-dsl/klum-ast/issues/79). It also does not compose base, environment, and override files; ordered composition belongs to [#304](https://github.com/klum-dsl/klum-ast/issues/304). Record either need as a focused follow-up instead of making this onboarding example promise unavailable behavior.
+
+See [Target Contract Modeling](https://github.com/klum-dsl/klum-ast/wiki/Target-Contract-Modeling) for the task guide and [`../../field-tests/target-contract-helm/`](../../field-tests/target-contract-helm/) for the later real-project evaluation starting point.

--- a/agent-skills/fixtures/helm-target-contract/README.md
+++ b/agent-skills/fixtures/helm-target-contract/README.md
@@ -10,7 +10,7 @@ The Acme Platform deployment team owns the `acme-service` Helm chart at version 
 
 The same team owns the Schema and the deployment configuration in this small target-specific project. There is no separate client-facing Domain API to stabilize, so Layer 3 would add ceremony without protecting a real consumer boundary. `ServiceRelease` is therefore the direct authoring type, while `toHelmValues()` is the intentional adapter to the Helm contract.
 
-The authoring model earns that seam by deriving image repositories and public hosts from the stable service key, validating deployment-safe tags and ports, and expanding `publiclyReachable` into Helm ingress values. It models `resources` as an owned inner object with explicit `requests` and `limits` children; a memory limit different from its request records a warning without rejecting the release. It is not a generic Helm object model and must not be used to infer a YAML/KlumAST round trip.
+The authoring model earns that seam by deriving image repositories and public hosts from the stable service key, validating deployment-safe tags and ports, and expanding `publiclyReachable` into Helm ingress values. It models `resources` as an owned inner object with explicit `requests` and `limits` children; absent limits default to a fresh copy of the request, while a different memory limit records a warning without rejecting the release. It is not a generic Helm object model and must not be used to infer a YAML/KlumAST round trip.
 
 ## Contract evidence
 

--- a/agent-skills/fixtures/helm-target-contract/README.md
+++ b/agent-skills/fixtures/helm-target-contract/README.md
@@ -10,7 +10,7 @@ The Acme Platform deployment team owns the `acme-service` Helm chart at version 
 
 The same team owns the Schema and the deployment configuration in this small target-specific project. There is no separate client-facing Domain API to stabilize, so Layer 3 would add ceremony without protecting a real consumer boundary. `ServiceRelease` is therefore the direct authoring type, while `toHelmValues()` is the intentional adapter to the Helm contract.
 
-The authoring model earns that seam by deriving image repositories and public hosts from the stable service key, supplying common resource defaults, validating deployment-safe tags and ports, and expanding `publiclyReachable` into Helm ingress values. It is not a generic Helm object model and must not be used to infer a YAML/KlumAST round trip.
+The authoring model earns that seam by deriving image repositories and public hosts from the stable service key, validating deployment-safe tags and ports, and expanding `publiclyReachable` into Helm ingress values. It models `resources` as an owned inner object with explicit `requests` and `limits` children; a memory limit different from its request records a warning without rejecting the release. It is not a generic Helm object model and must not be used to infer a YAML/KlumAST round trip.
 
 ## Contract evidence
 

--- a/agent-skills/fixtures/helm-target-contract/build.gradle
+++ b/agent-skills/fixtures/helm-target-contract/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'com.blackbuild.klum-ast-schema'
+}
+
+repositories {
+    mavenCentral()
+}
+
+klumSchema {
+    groovyVersion = findProperty('fixtureGroovyVersion') ?: '3'
+}
+
+dependencies {
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
+}

--- a/agent-skills/fixtures/helm-target-contract/build.gradle
+++ b/agent-skills/fixtures/helm-target-contract/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.blackbuild.convention.groovy'
     id 'com.blackbuild.klum-ast-schema'
 }
 
@@ -6,8 +7,11 @@ repositories {
     mavenCentral()
 }
 
-klumSchema {
-    groovyVersion = findProperty('fixtureGroovyVersion') ?: '3'
+groovyDependencies {
+    // Groovy 3 is KlumAST's documented adopter baseline. The convention is
+    // inherited by every fixture module; -PfixtureGroovyVersion=4 or =5
+    // validates a coherent compatibility lane.
+    groovyVersion = providers.gradleProperty('fixtureGroovyVersion').getOrElse('3')
 }
 
 dependencies {

--- a/agent-skills/fixtures/helm-target-contract/settings.gradle
+++ b/agent-skills/fixtures/helm-target-contract/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    includeBuild('../../..')
+}
+
+rootProject.name = 'klum-helm-target-contract-fixture'
+
+includeBuild('../../..') {
+    dependencySubstitution {
+        substitute module('com.blackbuild.klum.ast:klum-ast-bom') using project(':klum-ast-bom')
+        substitute module('com.blackbuild.klum.ast:klum-ast-runtime') using project(':klum-ast-runtime')
+        substitute module('com.blackbuild.klum.ast:klum-ast') using project(':klum-ast')
+    }
+}

--- a/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
@@ -24,8 +24,7 @@ class ServiceRelease {
     @Default(code = { publiclyReachable ? "${name}.example.test" : null })
     String hostname
 
-    String cpuRequest = '250m'
-    String memoryRequest = '256Mi'
+    ResourceRequirements resources
 
     /**
      * Expands the concise authoring model into the Helm values contract.
@@ -36,7 +35,7 @@ class ServiceRelease {
         values.replicaCount = replicaCount
         values.image = [repository: imageRepository, tag: imageTag]
         values.service = [type: 'ClusterIP', port: containerPort, targetPort: containerPort]
-        values.resources = [requests: [cpu: cpuRequest, memory: memoryRequest]]
+        values.resources = resources.toHelmValues()
         Map<String, Object> ingress = [enabled: publiclyReachable]
         if (publiclyReachable) {
             ingress.put('hosts', [[host: hostname, paths: [[path: '/', pathType: 'Prefix']]]])
@@ -55,6 +54,54 @@ class ServiceRelease {
         }
         if (publiclyReachable && !hostname) {
             Validator.addError('publicly reachable releases need a hostname')
+        }
+        if (!resources) {
+            Validator.addError('resources with requests and limits are required')
+        }
+    }
+}
+
+@DSL
+class ResourceRequirements {
+
+    ResourceValues requests
+    ResourceValues limits
+
+    Map<String, Object> toHelmValues() {
+        [requests: requests.toHelmValues(), limits: limits.toHelmValues()]
+    }
+
+    @Validate
+    void validatesRequestsAndLimits() {
+        if (!requests) {
+            Validator.addError('resource requests are required')
+        }
+        if (!limits) {
+            Validator.addError('resource limits are required')
+        }
+        if (requests && limits && requests.memory != limits.memory) {
+            Validator.addIssue('memory limit differs from memory request', Validate.Level.WARNING)
+        }
+    }
+}
+
+@DSL
+class ResourceValues {
+
+    String cpu
+    String memory
+
+    Map<String, String> toHelmValues() {
+        [cpu: cpu, memory: memory]
+    }
+
+    @Validate
+    void requiresCpuAndMemory() {
+        if (!cpu) {
+            Validator.addError('resource cpu is required')
+        }
+        if (!memory) {
+            Validator.addError('resource memory is required')
         }
     }
 }

--- a/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
@@ -1,0 +1,60 @@
+package onboarding.helm
+
+import com.blackbuild.groovy.configdsl.transform.DSL
+import com.blackbuild.groovy.configdsl.transform.Default
+import com.blackbuild.groovy.configdsl.transform.Key
+import com.blackbuild.groovy.configdsl.transform.Validate
+import com.blackbuild.klum.ast.validation.Validator
+
+@DSL
+class ServiceRelease {
+
+    @Key String name
+
+    String imageRegistry = 'ghcr.io/acme'
+
+    @Default(code = { "$imageRegistry/$name" })
+    String imageRepository
+
+    String imageTag
+    int replicaCount = 2
+    int containerPort = 8080
+    boolean publiclyReachable
+
+    @Default(code = { publiclyReachable ? "${name}.example.test" : null })
+    String hostname
+
+    String cpuRequest = '250m'
+    String memoryRequest = '256Mi'
+
+    /**
+     * Expands the concise authoring model into the Helm values contract.
+     * The target contract owns these field names and nesting.
+     */
+    Map<String, Object> toHelmValues() {
+        Map<String, Object> values = new LinkedHashMap<>()
+        values.replicaCount = replicaCount
+        values.image = [repository: imageRepository, tag: imageTag]
+        values.service = [type: 'ClusterIP', port: containerPort, targetPort: containerPort]
+        values.resources = [requests: [cpu: cpuRequest, memory: memoryRequest]]
+        Map<String, Object> ingress = [enabled: publiclyReachable]
+        if (publiclyReachable) {
+            ingress.put('hosts', [[host: hostname, paths: [[path: '/', pathType: 'Prefix']]]])
+        }
+        values.ingress = ingress
+        values
+    }
+
+    @Validate
+    void requiresDeployableHelmValues() {
+        if (!(imageTag ==~ /\d+\.\d+\.\d+/)) {
+            Validator.addError('imageTag must be a semantic version such as 1.4.0')
+        }
+        if (!(containerPort in 1..65535)) {
+            Validator.addError('containerPort must be between 1 and 65535')
+        }
+        if (publiclyReachable && !hostname) {
+            Validator.addError('publicly reachable releases need a hostname')
+        }
+    }
+}

--- a/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
@@ -3,6 +3,7 @@ package onboarding.helm
 import com.blackbuild.groovy.configdsl.transform.DSL
 import com.blackbuild.groovy.configdsl.transform.Default
 import com.blackbuild.groovy.configdsl.transform.Key
+import com.blackbuild.groovy.configdsl.transform.Required
 import com.blackbuild.groovy.configdsl.transform.Validate
 import com.blackbuild.klum.ast.validation.Validator
 
@@ -67,6 +68,16 @@ class ResourceRequirements {
     ResourceValues requests
     ResourceValues limits
 
+    @Default
+    void defaultsLimitsFromRequests() {
+        if (requests && !limits) {
+            def requested = requests
+            limits {
+                copyFrom requested
+            }
+        }
+    }
+
     Map<String, Object> toHelmValues() {
         [requests: requests.toHelmValues(), limits: limits.toHelmValues()]
     }
@@ -75,9 +86,6 @@ class ResourceRequirements {
     void validatesRequestsAndLimits() {
         if (!requests) {
             Validator.addError('resource requests are required')
-        }
-        if (!limits) {
-            Validator.addError('resource limits are required')
         }
         if (requests && limits && requests.memory != limits.memory) {
             Validator.addIssue('memory limit differs from memory request', Validate.Level.WARNING)
@@ -88,20 +96,10 @@ class ResourceRequirements {
 @DSL
 class ResourceValues {
 
-    String cpu
-    String memory
+    @Required String cpu
+    @Required String memory
 
     Map<String, String> toHelmValues() {
         [cpu: cpu, memory: memory]
-    }
-
-    @Validate
-    void requiresCpuAndMemory() {
-        if (!cpu) {
-            Validator.addError('resource cpu is required')
-        }
-        if (!memory) {
-            Validator.addError('resource memory is required')
-        }
     }
 }

--- a/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/main/groovy/onboarding/helm/ServiceRelease.groovy
@@ -5,6 +5,7 @@ import com.blackbuild.groovy.configdsl.transform.Default
 import com.blackbuild.groovy.configdsl.transform.Key
 import com.blackbuild.groovy.configdsl.transform.Required
 import com.blackbuild.groovy.configdsl.transform.Validate
+import com.blackbuild.klum.ast.util.layer3.annotations.AutoCreate
 import com.blackbuild.klum.ast.validation.Validator
 
 @DSL
@@ -68,7 +69,7 @@ class ResourceRequirements {
     ResourceValues requests
     ResourceValues limits
 
-    @Default
+    @AutoCreate
     void defaultsLimitsFromRequests() {
         if (requests && !limits) {
             def requested = requests

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
@@ -29,7 +29,7 @@ class HelmTargetContractDocumentaryTest extends Specification {
         catalog.imageRepository == 'ghcr.io/acme/catalog'
         catalog.resources.requests.cpu == '250m'
         catalog.resources.requests.memory == '256Mi'
-        catalog.resources.limits.cpu == '500m'
+        catalog.resources.limits.cpu == '250m'
         catalog.resources.limits.memory == '256Mi'
         catalog.hostname == 'catalog.example.test'
         catalog.toHelmValues().ingress == [
@@ -84,6 +84,22 @@ class HelmTargetContractDocumentaryTest extends Specification {
         error.message.contains('imageTag must be a semantic version')
         error.message.contains('containerPort must be between 1 and 65535')
         error.message.contains('resources with requests and limits are required')
+    }
+
+    def 'requires CPU and memory on each resource value through its field contract'() {
+        when:
+        ServiceRelease.Create.With('catalog') {
+            imageTag '1.4.0'
+            resources {
+                requests {
+                    cpu '250m'
+                }
+            }
+        }
+
+        then:
+        KlumValidationException error = thrown()
+        error.message.contains('memory')
     }
 
     private String resourceText(String path) {

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
@@ -1,0 +1,74 @@
+package onboarding.helm
+
+import com.blackbuild.klum.ast.util.KlumValidationException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Specification
+import spock.lang.Tag
+import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+@Issue('472')
+@Tag('documentary')
+@See('https://github.com/klum-dsl/klum-ast/blob/master/wiki/Target-Contract-Modeling.md#executable-helm-journey')
+class HelmTargetContractDocumentaryTest extends Specification {
+
+    private final ObjectMapper yaml = new ObjectMapper(new YAMLFactory())
+
+    def 'uses direct-schema authoring defaults and a Helm-specific convenience'() {
+        when:
+        ServiceRelease catalog = RepresentativeReleases.all().first()
+
+        then:
+        catalog.imageRepository == 'ghcr.io/acme/catalog'
+        catalog.cpuRequest == '250m'
+        catalog.memoryRequest == '256Mi'
+        catalog.hostname == 'catalog.example.test'
+        catalog.toHelmValues().ingress == [
+            enabled: true,
+            hosts  : [[host: 'catalog.example.test', paths: [[path: '/', pathType: 'Prefix']]]]
+        ]
+    }
+
+    @Unroll
+    def 'generates human-readable #release.name Helm values that conform to the golden contract'() {
+        when:
+        String generated = yaml.writeValueAsString(release.toHelmValues())
+        Path generatedValues = Path.of('build', 'generated-values', "${release.name}.values.yaml")
+        Files.createDirectories(generatedValues.parent)
+        Files.writeString(generatedValues, generated)
+        def targetExample = yaml.readTree(resourceText("helm/representative/${release.name}.values.yaml"))
+        def expected = yaml.readTree(resourceText("helm/golden/${release.name}.values.yaml"))
+        def actual = yaml.readTree(generated)
+
+        then: 'the generated file is readable YAML and has the same Helm meaning as both checked-in target artifacts'
+        generated.contains('image:')
+        generated.contains('resources:')
+        actual == targetExample
+        actual == expected
+
+        where:
+        release << RepresentativeReleases.all()
+    }
+
+    def 'rejects values that cannot satisfy the Helm contract'() {
+        when:
+        ServiceRelease.Create.With('catalog') {
+            imageTag 'latest'
+            containerPort 0
+        }
+
+        then:
+        KlumValidationException error = thrown()
+        error.message.contains('imageTag must be a semantic version')
+        error.message.contains('containerPort must be between 1 and 65535')
+    }
+
+    private String resourceText(String path) {
+        getClass().getClassLoader().getResource(path).text
+    }
+}

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy
@@ -1,8 +1,10 @@
 package onboarding.helm
 
 import com.blackbuild.klum.ast.util.KlumValidationException
+import com.blackbuild.klum.ast.util.KlumObjectSupport
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.blackbuild.groovy.configdsl.transform.Validate
 import spock.lang.Issue
 import spock.lang.See
 import spock.lang.Specification
@@ -25,13 +27,28 @@ class HelmTargetContractDocumentaryTest extends Specification {
 
         then:
         catalog.imageRepository == 'ghcr.io/acme/catalog'
-        catalog.cpuRequest == '250m'
-        catalog.memoryRequest == '256Mi'
+        catalog.resources.requests.cpu == '250m'
+        catalog.resources.requests.memory == '256Mi'
+        catalog.resources.limits.cpu == '500m'
+        catalog.resources.limits.memory == '256Mi'
         catalog.hostname == 'catalog.example.test'
         catalog.toHelmValues().ingress == [
             enabled: true,
             hosts  : [[host: 'catalog.example.test', paths: [[path: '/', pathType: 'Prefix']]]]
         ]
+    }
+
+    def 'retains a completed model while nested resources warn about a memory limit mismatch'() {
+        when:
+        ServiceRelease billing = RepresentativeReleases.all().last()
+        def issues = KlumObjectSupport.of(billing.resources).validation.result.issues
+
+        then:
+        billing.resources.requests.memory == '256Mi'
+        billing.resources.limits.memory == '512Mi'
+        issues.any { issue ->
+            issue.level == Validate.Level.WARNING && issue.message == 'memory limit differs from memory request'
+        }
     }
 
     @Unroll
@@ -66,6 +83,7 @@ class HelmTargetContractDocumentaryTest extends Specification {
         KlumValidationException error = thrown()
         error.message.contains('imageTag must be a semantic version')
         error.message.contains('containerPort must be between 1 and 65535')
+        error.message.contains('resources with requests and limits are required')
     }
 
     private String resourceText(String path) {

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
@@ -7,11 +7,19 @@ class RepresentativeReleases {
             ServiceRelease.Create.With('catalog') {
                 imageTag '1.4.0'
                 publiclyReachable true
+                resources {
+                    requests { cpu '250m'; memory '256Mi' }
+                    limits { cpu '500m'; memory '256Mi' }
+                }
             },
             ServiceRelease.Create.With('billing') {
                 imageTag '2.1.3'
                 replicaCount 1
                 containerPort 8081
+                resources {
+                    requests { cpu '250m'; memory '256Mi' }
+                    limits { cpu '500m'; memory '512Mi' }
+                }
             }
         ]
     }

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
@@ -9,7 +9,6 @@ class RepresentativeReleases {
                 publiclyReachable true
                 resources {
                     requests { cpu '250m'; memory '256Mi' }
-                    limits { cpu '500m'; memory '256Mi' }
                 }
             },
             ServiceRelease.Create.With('billing') {

--- a/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
+++ b/agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/RepresentativeReleases.groovy
@@ -1,0 +1,18 @@
+package onboarding.helm
+
+class RepresentativeReleases {
+
+    static List<ServiceRelease> all() {
+        [
+            ServiceRelease.Create.With('catalog') {
+                imageTag '1.4.0'
+                publiclyReachable true
+            },
+            ServiceRelease.Create.With('billing') {
+                imageTag '2.1.3'
+                replicaCount 1
+                containerPort 8081
+            }
+        ]
+    }
+}

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/billing.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/billing.values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/acme/billing
+  tag: 2.1.3
+service:
+  type: ClusterIP
+  port: 8081
+  targetPort: 8081
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+ingress:
+  enabled: false

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/billing.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/billing.values.yaml
@@ -10,5 +10,8 @@ resources:
   requests:
     cpu: 250m
     memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 ingress:
   enabled: false

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
@@ -10,6 +10,9 @@ resources:
   requests:
     cpu: 250m
     memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
 ingress:
   enabled: true
   hosts:

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 2
+image:
+  repository: ghcr.io/acme/catalog
+  tag: 1.4.0
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+ingress:
+  enabled: true
+  hosts:
+    - host: catalog.example.test
+      paths:
+        - path: /
+          pathType: Prefix

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/golden/catalog.values.yaml
@@ -11,7 +11,7 @@ resources:
     cpu: 250m
     memory: 256Mi
   limits:
-    cpu: 500m
+    cpu: 250m
     memory: 256Mi
 ingress:
   enabled: true

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/billing.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/billing.values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/acme/billing
+  tag: 2.1.3
+service:
+  type: ClusterIP
+  port: 8081
+  targetPort: 8081
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+ingress:
+  enabled: false

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/billing.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/billing.values.yaml
@@ -10,5 +10,8 @@ resources:
   requests:
     cpu: 250m
     memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 ingress:
   enabled: false

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
@@ -10,6 +10,9 @@ resources:
   requests:
     cpu: 250m
     memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
 ingress:
   enabled: true
   hosts:

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 2
+image:
+  repository: ghcr.io/acme/catalog
+  tag: 1.4.0
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+ingress:
+  enabled: true
+  hosts:
+    - host: catalog.example.test
+      paths:
+        - path: /
+          pathType: Prefix

--- a/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
+++ b/agent-skills/fixtures/helm-target-contract/src/test/resources/helm/representative/catalog.values.yaml
@@ -11,7 +11,7 @@ resources:
     cpu: 250m
     memory: 256Mi
   limits:
-    cpu: 500m
+    cpu: 250m
     memory: 256Mi
 ingress:
   enabled: true

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -15,7 +15,7 @@ Before creating a Schema, answer two independent questions.
 
 Record the choices near the project architecture. Layer 3 is a modeling pattern, not a requirement for every Gradle project.
 
-`author-klum-model` is the Model Writer workflow: it creates and tests a representative configured model and may adapt the Schema types needed for that model. It is not a dedicated Schema Developer path. `start-klum-project` establishes the Schema project and its selected structure, while `feature-advisor` reviews both Schemas and configured models for supported improvements. This is the #470 baseline; later journeys can deepen either role without redefining their boundary.
+`author-klum-model` is the Model Writer workflow: it creates and tests a representative configured model and may adapt the Schema types needed for that model. It is not a dedicated Schema Developer path. `start-klum-project` establishes the Schema project and its selected structure, while `feature-advisor` reviews both Schemas and configured models for supported improvements. `build-target-contract-schema` is the target-contract Schema Developer route; its [[Target Contract Modeling|executable Helm journey]] demonstrates intentional external mappings without redefining these role boundaries.
 
 ## Create the Gradle project
 
@@ -70,8 +70,10 @@ Quick Documentation for compiled declarations is separate from these mirrors. [A
 
 ## Portable adopter skills
 
-The repository's [`agent-skills/`](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills) distribution contains portable, task-oriented workflows for `start-klum-project`, `author-klum-model`, and `feature-advisor`. Copy selected standard skill directories into the discovery location supported by your agent client; do not copy repository-maintainer skills from `.agents/skills/`.
+The repository's [`agent-skills/`](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills) distribution contains portable, task-oriented workflows for `start-klum-project`, `author-klum-model`, `feature-advisor`, and `build-target-contract-schema`. Copy selected standard skill directories into the discovery location supported by your agent client; do not copy repository-maintainer skills from `.agents/skills/`.
 
 `feature-advisor` is a KlumAST-specific, evidence-based improvement review. It first assesses whether the adopted KlumAST version and installed skill distribution are needed, recommended, unnecessary, or unknown updates, then reviews supported features. It stays read-only unless you request selected changes, then explains the supported feature, fit, benefit, trade-offs, confidence, migration risk, effort, documentation source, and validation result.
 
 The minimal fixture at `agent-skills/fixtures/minimal-gradle-project` exercises the baseline locally against the 4.0 sources. Its `ADOPTER-DRY-RUN.md` captures the setup, Model Writer, and feature-advisor field-test flow, including a deliberately improvable Schema case.
+
+For an external target such as Helm, start from two representative values files, retain the target contract as authoritative, and use `build-target-contract-schema` to choose intentional mappings. [[Target Contract Modeling]] uses the same `agent-skills/fixtures/helm-target-contract` fixture as the skill, including its direct-schema rationale, golden generated values, and later field-test prompt.

--- a/wiki/Target-Contract-Modeling.md
+++ b/wiki/Target-Contract-Modeling.md
@@ -24,7 +24,7 @@ ServiceRelease.Create.With('catalog') {
 }
 ```
 
-The fixture derives `ghcr.io/acme/catalog` and `catalog.example.test`, validates a deployable image tag and port, and expands `publiclyReachable` into the Helm ingress map. Its owned `resources` object has explicit `requests` and `limits` children; when their memory values differ, its internal validation stores a warning without rejecting the release. This is direct-schema because the same deployment team owns the authoring types and its target values; a separate Domain API would add no real client boundary.
+The fixture derives `ghcr.io/acme/catalog` and `catalog.example.test`, validates a deployable image tag and port, and expands `publiclyReachable` into the Helm ingress map. Its owned `resources` object has explicit `requests` and `limits` children; absent limits default to a fresh copy of requests, while different memory values store a warning without rejecting the release. This is direct-schema because the same deployment team owns the authoring types and its target values; a separate Domain API would add no real client boundary.
 
 `HelmTargetContractDocumentaryTest`, tagged `documentary` and linked to this page, writes human-readable YAML under `build/generated-values/`. It parses each generated file and compares its meaning to both representative target inputs and golden expected artifacts. Run the established fixture baseline and compatibility variants:
 

--- a/wiki/Target-Contract-Modeling.md
+++ b/wiki/Target-Contract-Modeling.md
@@ -1,0 +1,49 @@
+# Target-contract modeling (4.0 preview)
+
+> This onboarding route is a 4.0 preview pending field testing. It targets one authoritative external contract at a time; use documentation matched to the KlumAST version you adopt.
+
+## Choose the authoring seam
+
+Use target-contract modeling when an existing system such as a Helm chart owns the compatible external values shape. The Klum Schema is then a better authoring language for that contract: it may reduce repeated configuration, introduce validated defaults, and expand a convenient concept into several target values. It does not turn YAML into KlumAST persistence or make every Helm field a public object-model property.
+
+Make the consumer-shape decision independently:
+
+- Choose **direct-schema** when the Schema Developer also owns the authors who consume the types, and there is no separate stable Domain API to protect.
+- Choose **Layer 3** only when client developers must compile against a distinct Domain API rather than Schema types.
+
+Do not add Layer 3 merely as insurance for a future client. Record the selected shape and the reason in the project architecture note.
+
+## Executable Helm journey
+
+[`agent-skills/fixtures/helm-target-contract`](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills/fixtures/helm-target-contract) is the common executable example for this guide and the portable `build-target-contract-schema` skill. It starts with the `catalog` and `billing` Helm values contracts and uses one direct-schema `ServiceRelease` type:
+
+```groovy
+ServiceRelease.Create.With('catalog') {
+    imageTag '1.4.0'
+    publiclyReachable true
+}
+```
+
+The fixture derives `ghcr.io/acme/catalog` and `catalog.example.test`, supplies resource-request defaults, validates a deployable image tag and port, and expands `publiclyReachable` into the Helm ingress map. This is direct-schema because the same deployment team owns the authoring types and its target values; a separate Domain API would add no real client boundary.
+
+`HelmTargetContractDocumentaryTest`, tagged `documentary` and linked to this page, writes human-readable YAML under `build/generated-values/`. It parses each generated file and compares its meaning to both representative target inputs and golden expected artifacts. Run the established fixture baseline and compatibility variants:
+
+```shell
+./gradlew -p agent-skills/fixtures/helm-target-contract test
+./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=4
+./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=5
+```
+
+This is a target-contract conformance check, not a promise that KlumAST can import arbitrary Helm YAML, preserve YAML formatting, or round trip its own model through YAML.
+
+## Apply the workflow
+
+Install `build-target-contract-schema` from the portable `agent-skills/` distribution. It guides the Schema Developer to inventory representative artifacts, identify stable concepts and intentional mappings, make the direct-schema-versus-Layer-3 decision explicit, and compare generated output to readable golden values files. The workflow links back to this fixture instead of copying a larger example.
+
+If a migration needs a value read from an external resource, keep that need with [#79](https://github.com/klum-dsl/klum-ast/issues/79), resource-backed defaults. If it needs base, environment, and override documents to apply in order, keep it with [#304](https://github.com/klum-dsl/klum-ast/issues/304), ordered configuration composition. Neither capability is implied by this journey.
+
+## Field-test starting point
+
+When applying this preview to a real project, use the fixture's [`field-tests/target-contract-helm`](https://github.com/klum-dsl/klum-ast/tree/master/agent-skills/field-tests/target-contract-helm) prompt and inventory. Record the chart/version, target-contract owner, representative values, authoring decisions, golden evidence, and any smallest unmet capability. The prompt intentionally does not prescribe a later skill: field-test findings should become focused follow-up issues only when a real project needs them.
+
+The executable evidence is `agent-skills/fixtures/helm-target-contract/src/test/groovy/onboarding/helm/HelmTargetContractDocumentaryTest.groovy`, feature `generates human-readable #release.name Helm values that conform to the golden contract`.

--- a/wiki/Target-Contract-Modeling.md
+++ b/wiki/Target-Contract-Modeling.md
@@ -24,7 +24,7 @@ ServiceRelease.Create.With('catalog') {
 }
 ```
 
-The fixture derives `ghcr.io/acme/catalog` and `catalog.example.test`, supplies resource-request defaults, validates a deployable image tag and port, and expands `publiclyReachable` into the Helm ingress map. This is direct-schema because the same deployment team owns the authoring types and its target values; a separate Domain API would add no real client boundary.
+The fixture derives `ghcr.io/acme/catalog` and `catalog.example.test`, validates a deployable image tag and port, and expands `publiclyReachable` into the Helm ingress map. Its owned `resources` object has explicit `requests` and `limits` children; when their memory values differ, its internal validation stores a warning without rejecting the release. This is direct-schema because the same deployment team owns the authoring types and its target values; a separate Domain API would add no real client boundary.
 
 `HelmTargetContractDocumentaryTest`, tagged `documentary` and linked to this page, writes human-readable YAML under `build/generated-values/`. It parses each generated file and compares its meaning to both representative target inputs and golden expected artifacts. Run the established fixture baseline and compatibility variants:
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -5,6 +5,7 @@
   * [[Usage]]
   * [[Gradle Plugins]]
   * [[Getting Started]]
+  * [[Target Contract Modeling]]
   * [[Basics]]
   * [[Model Phases]]
   * [[Exception Handling]]


### PR DESCRIPTION
## Summary

- Add the portable `build-target-contract-schema` onboarding skill and a direct-schema Helm fixture for catalog and billing services.
- Render human-readable Helm values and compare their parsed meaning with representative and golden target contracts.
- Model nested resource requests and limits, including a non-fatal warning when a memory limit differs from its request.
- Add the task-oriented wiki route, field-test prompt/inventory, sidebar link, and release note.

## Boundaries

The fixture keeps Helm values authoritative. It does not promise generic YAML/KlumAST round trips, resource-backed defaults (#79), or ordered configuration composition (#304).

## Validation

- `./gradlew -p agent-skills/fixtures/helm-target-contract test`
- `./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=4`
- `./gradlew -p agent-skills/fixtures/helm-target-contract test -PfixtureGroovyVersion=5`
- Local standards and specification reviews: no findings.

Closes #472