### PR TITLE
Adopt KlumCast 0.4.0-rc.2 artifact set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This is a breaking release. See the [Builder-first construction migration](https://github.com/klum-dsl/klum-ast/wiki/Builder-First-Migration) for required client and extension changes.
 
+## Dependency compatibility
+
+- Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0. Existing name-bound custom checks continue through KlumCast's temporary 0.4 migration bridge; #460 owns their durable SPI migration.
+
 ## Builder-first construction
 
 - Added a task-oriented Gradle onboarding preview, portable `start-klum-project`, `author-klum-model`, and `feature-advisor` Agent Skills, plus an executable minimal fixture. `feature-advisor` also assesses whether KlumAST or its skill distribution needs an update ([#470](https://github.com/klum-dsl/klum-ast/issues/470)).

--- a/klum-ast/build.gradle
+++ b/klum-ast/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     api project(':klum-ast-annotations')
     api project(':klum-ast-runtime')
     api libs.annodocimal.global.ast
+    api libs.klum.cast.spi
     api libs.klum.cast.compile
 
     sharedTests libs.annodocimal.gradle.plugin

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
@@ -23,6 +23,7 @@
  */
 package com.blackbuild.klum.ast.util.layer3;
 
+import com.blackbuild.klum.ast.util.layer3.annotations.DefaultValues;
 import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
 import com.blackbuild.klum.cast.checks.impl.ValidationException;
 import org.codehaus.groovy.ast.AnnotatedNode;
@@ -34,8 +35,9 @@ import java.lang.annotation.Annotation;
 public class DefaultValuesCheck extends KlumCastCheck<Annotation> {
     @Override
     protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) throws ValidationException {
-        boolean controlAnnotationHasValuesMapping = annotationToCheck.getMembers().containsKey("valueTarget");
-        ClassNode targetAnnotation = (ClassNode) target;
+        boolean controlAnnotationHasValuesMapping = controlAnnotation instanceof DefaultValues
+                && !((DefaultValues) controlAnnotation).valueTarget().isEmpty();
+        ClassNode targetAnnotation = annotationToCheck.getClassNode();
         boolean targetAnnotationHasValueMember = !targetAnnotation.getMethods("value").isEmpty();
 
         if (controlAnnotationHasValuesMapping && !targetAnnotationHasValueMember)

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesSpec.groovy
@@ -684,9 +684,9 @@ import java.lang.annotation.Target
         bar.name == "defaultName"
     }
 
-    @Issue("370")
+    @Issue(["370", "459"])
     def "if default-values annotation has a 'value' member, valueTarget must be set"() {
-        when: "value member is present, but valuesTarget is not set"
+        when: "a value member is present without a value target"
         createSecondaryClass '''
             package pk
 
@@ -701,11 +701,19 @@ import java.lang.annotation.*
                 String value()
             }
 '''
+        createClass '''
+            package pk
+
+            @NoValuesMappingSet
+            @DSL
+            class Foo {
+            }
+'''
 
         then:
         thrown(MultipleCompilationErrorsException)
 
-        when: "valuesTarget is set, but value member is not present"
+        when: "a value target is set without a value member"
         createSecondaryClass '''
             package pk
 
@@ -718,6 +726,14 @@ import java.lang.annotation.*
             @DefaultValues(valueTarget = "name")
             @interface MappingSetButNoValueInAnnotation {
                 String name()
+            }
+'''
+        createClass '''
+            package pk
+
+            @MappingSetButNoValueInAnnotation
+            @DSL
+            class Bar {
             }
 '''
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastRcIntegrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastRcIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import com.blackbuild.klum.cast.KlumCastValidated
+import com.blackbuild.klum.cast.checks.impl.KlumCastCheck
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.lang.module.ModuleFinder
+import java.nio.file.Path
+import java.util.jar.JarFile
+
+@Issue("459")
+class KlumCastRcIntegrationTest extends Specification {
+
+    private static final String RC_VERSION = "0.4.0-rc.2"
+    private static final String AST_TRANSFORMATION_SERVICE = "META-INF/services/org.codehaus.groovy.transform.ASTTransformation"
+
+    def "uses the published KlumCast RC artifacts with their stable module names"() {
+        expect:
+        moduleName(jar) == expectedModuleName
+        moduleVersion(jar) == RC_VERSION
+
+        where:
+        jar                       | expectedModuleName
+        jarOf(KlumCastValidated)  | "com.blackbuild.klum.cast.annotations"
+        jarOf(KlumCastCheck)      | "com.blackbuild.klum.cast.spi"
+        compilerJar()             | "com.blackbuild.klum.cast.compiler"
+    }
+
+    def "KlumCast RC artifacts have exclusive package ownership"() {
+        given:
+        def packageSets = [jarOf(KlumCastValidated), jarOf(KlumCastCheck), compilerJar()]
+                .collect { packagesIn(it) }
+
+        expect:
+        packageSets[0].disjoint(packageSets[1])
+        packageSets[0].disjoint(packageSets[2])
+        packageSets[1].disjoint(packageSets[2])
+    }
+
+    private static Path jarOf(Class<?> type) {
+        Path.of(type.protectionDomain.codeSource.location.toURI())
+    }
+
+    private static Path compilerJar() {
+        def service = KlumCastRcIntegrationTest.classLoader.getResources(AST_TRANSFORMATION_SERVICE)
+                .toList()
+                .find { it.toExternalForm().contains("klum-cast-compile") }
+
+        assert service != null: "KlumCast compiler AST transformation is not service-loaded"
+
+        Path.of(URI.create(service.toExternalForm().split("!")[0].substring("jar:".length())))
+    }
+
+    private static String moduleName(Path jar) {
+        ModuleFinder.of(jar).findAll().first().descriptor().name()
+    }
+
+    private static String moduleVersion(Path jar) {
+        ModuleFinder.of(jar).findAll().first().descriptor().rawVersion().orElse(null)
+    }
+
+    private static Set<String> packagesIn(Path jar) {
+        new JarFile(jar.toFile()).withCloseable { archive ->
+            archive.entries()
+                    .findAll { !it.directory && it.name.endsWith(".class") && it.name != "module-info.class" }
+                    .collect { it.name.substring(0, it.name.lastIndexOf('/')).replace('/', '.') }
+                    .toSet()
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,9 +35,10 @@ dependencyResolutionManagement {
 
             library("jb-anno", "org.jetbrains:annotations:16.0.2")
 
-            version("klum-cast", "0.3.1")
+            version("klum-cast", "0.4.0-rc.2")
             library("klum-cast-compile", "com.blackbuild.klum.cast", "klum-cast-compile").versionRef("klum-cast")
             library("klum-cast-annotations", "com.blackbuild.klum.cast", "klum-cast-annotations").versionRef("klum-cast")
+            library("klum-cast-spi", "com.blackbuild.klum.cast", "klum-cast-spi").versionRef("klum-cast")
 
             version("spock-g3", "2.4-groovy-3.0")
             version("spock-g4", "2.4-groovy-4.0")
@@ -84,4 +85,3 @@ include 'code-coverage-report'
 
 
 // includeBuild "../anno-docimal"
-

--- a/wiki/Migration.md
+++ b/wiki/Migration.md
@@ -14,6 +14,16 @@ and treat the completed-model export as a separately owned external projection. 
 use repeated imports as a Jackson-specific merge/layering mechanism; [#304](https://github.com/klum-dsl/klum-ast/issues/304)
 owns source-neutral composition.
 
+## KlumCast 0.4 RC dependencies
+
+KlumAST 4.0 uses the immutable KlumCast `0.4.0-rc.2` artifact set: `klum-cast-annotations`, `klum-cast-spi`, and
+`klum-cast-compile`. Its stable automatic module names are `com.blackbuild.klum.cast.annotations`,
+`com.blackbuild.klum.cast.spi`, and `com.blackbuild.klum.cast.compiler`; do not substitute filename-derived names or use
+local module-path flags to compensate for an invalid dependency graph.
+
+Recompile schemas and custom checks when moving to KlumAST 4.0. Existing name-bound custom checks remain supported by
+KlumCast's temporary 0.4 migration bridge. Their migration to the durable check SPI is tracked by [#460](https://github.com/klum-dsl/klum-ast/issues/460), not by this dependency integration.
+
 # to 2.2
 
 `toString()` methods are not automatically generated anymore, to restore the old behavior, add the `@ToString` annotation to the classes.


### PR DESCRIPTION
## Summary

- Adopt the immutable KlumCast 0.4.0-rc.2 annotations, SPI, and compiler artifacts.
- Publish the SPI role from the compiler module and verify the resolved artifacts automatic-module identities, service registration, and exclusive package ownership.
- Preserve DefaultValues diagnostics through the temporary legacy custom-check bridge.
- Document the KlumAST 4.0 recompilation and module-name implications.

## Why

KlumCast 0.3.1 has split packages and unstable automatic module identities, preventing #391 from using a portable upstream dependency graph. RC.2 supplies the accepted three-artifact migration input.

The durable migration from KlumCastCheck to the new Check SPI remains outside this PR and with #460.

## Compatibility

KlumAST 4.0 schemas and custom checks must be recompiled. Existing name-bound custom checks continue through the temporary 0.4 bridge.

## Validation

- ./gradlew :klum-ast:test
- ./gradlew :klum-ast:groovy4Tests
- ./gradlew :klum-ast:groovy5Tests
- Generated Maven POM inspection for annotations, SPI, and compiler dependency roles.
- Direct resolved-JAR module, package-ownership, and AST-service checks.

Closes #459

Follow-up coordinated external-consumer validation: #512.