### PR TITLE
Harden KlumAST release and publication process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: "The independently authorized release stage"
+        required: true
+        type: choice
+        options:
+          - candidate
+          - final
+      version:
+        description: "Exact immutable version to publish, for example 4.0.0-rc.1"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.stage }} ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Reject an already used version or tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.stage }}:${{ inputs.version }}" in
+            candidate:*-rc.[0-9]*) ;;
+            final:[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "The selected stage does not match the exact immutable version." >&2; exit 1 ;;
+          esac
+          git show-ref --verify --quiet "refs/tags/v${{ inputs.version }}" && {
+            echo "The release tag already exists; published versions are never retried in place." >&2
+            exit 1
+          }
+          gh release view "v${{ inputs.version }}" >/dev/null 2>&1 && {
+            echo "The GitHub release already exists; published versions are never retried in place." >&2
+            exit 1
+          }
+      - name: Require every protected credential before publication
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for credential in \
+            ORG_GRADLE_PROJECT_sonatypeUsername \
+            ORG_GRADLE_PROJECT_sonatypePassword \
+            ORG_GRADLE_PROJECT_signingKey \
+            ORG_GRADLE_PROJECT_signingPassword \
+            GRADLE_PUBLISH_KEY \
+            GRADLE_PUBLISH_SECRET
+          do
+            test -n "${!credential}" || {
+              echo "The protected release environment is missing $credential." >&2
+              exit 1
+            }
+          done
+      - name: Publish the complete product
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: >-
+          ./gradlew ${{ inputs.stage }} publishToSonatype closeAndReleaseSonatypeStagingRepository
+          :klum-ast-gradle-plugin:publishPlugins
+          -PreleaseExpectedVersion=${{ inputs.version }}
+      - name: Create immutable GitHub release record
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.stage }}" = candidate ]; then
+            gh release create "v${{ inputs.version }}" --prerelease --target "$GITHUB_SHA" --generate-notes
+          else
+            gh release create "v${{ inputs.version }}" --target "$GITHUB_SHA" --generate-notes
+          fi
+
+  resolve-back:
+    name: Resolve public product from clean repositories
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GRADLE_USER_HOME: ${{ runner.temp }}/gradle-user-home
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Resolve Maven modules and Gradle plugin markers
+        run: >-
+          ./gradlew --refresh-dependencies -p release/consumer verifyPublicProduct
+          -PreleaseVersion=${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-input:
+    name: Validate release stage and version
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.select-environment.outputs.name }}
+
+    steps:
+      - id: select-environment
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_STAGE" == candidate && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
+            echo 'name=release-candidate' >> "$GITHUB_OUTPUT"
+          elif [[ "$RELEASE_STAGE" == final && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo 'name=final-release' >> "$GITHUB_OUTPUT"
+          else
+            echo 'The selected stage does not match the exact immutable version.' >&2
+            exit 1
+          fi
+
   publish:
     name: Publish ${{ inputs.stage }} ${{ inputs.version }}
+    needs: validate-release-input
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: ${{ inputs.stage == 'candidate' && 'release-candidate' || 'final-release' }}
+    environment:
+      name: ${{ needs.validate-release-input.outputs.environment }}
     env:
       KLUM_AST_RELEASE_AUTHORIZED: ${{ inputs.stage }}
       ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -68,11 +93,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          case "${{ inputs.stage }}:${{ inputs.version }}" in
-            candidate:*-rc.[0-9]*) ;;
-            final:[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "The selected stage does not match the exact immutable version." >&2; exit 1 ;;
-          esac
           git show-ref --verify --quiet "refs/tags/v${{ inputs.version }}" && {
             echo "The release tag already exists; published versions are never retried in place." >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish protected release
 
 on:
   workflow_dispatch:
@@ -14,28 +14,49 @@ on:
         description: "Exact immutable version to publish, for example 4.0.0-rc.1"
         required: true
         type: string
+      commit:
+        description: "Full source commit SHA on master"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ inputs.version }}
+  group: publish-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
   publish:
     name: Publish ${{ inputs.stage }} ${{ inputs.version }}
     runs-on: ubuntu-latest
-    environment:
-      name: release
-    permissions:
-      contents: write
+    timeout-minutes: 60
+    environment: ${{ inputs.stage == 'candidate' && 'release-candidate' || 'final-release' }}
+    env:
+      KLUM_AST_RELEASE_AUTHORIZED: ${{ inputs.stage }}
+      ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+      ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+      - name: Verify the authorized source commit
+        env:
+          EXPECTED_COMMIT: ${{ inputs.commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_commit=$(git rev-parse HEAD)
+          test "$actual_commit" = "$EXPECTED_COMMIT"
+          git merge-base --is-ancestor "$actual_commit" origin/master
+          test -z "$(git status --porcelain=v1)"
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -61,13 +82,6 @@ jobs:
             exit 1
           }
       - name: Require every protected credential before publication
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         shell: bash
         run: |
           set -euo pipefail
@@ -84,45 +98,8 @@ jobs:
               exit 1
             }
           done
-      - name: Publish the complete product
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+      - name: Verify, sign, stage, and publish the complete product
         run: >-
-          ./gradlew ${{ inputs.stage }} publishToSonatype closeAndReleaseSonatypeStagingRepository
-          :klum-ast-gradle-plugin:publishPlugins
+          ./gradlew ${{ inputs.stage }} publishCompleteKlumAstProduct
           -PreleaseExpectedVersion=${{ inputs.version }}
-      - name: Create immutable GitHub release record
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${{ inputs.stage }}" = candidate ]; then
-            gh release create "v${{ inputs.version }}" --prerelease --target "$GITHUB_SHA" --generate-notes
-          else
-            gh release create "v${{ inputs.version }}" --target "$GITHUB_SHA" --generate-notes
-          fi
-
-  resolve-back:
-    name: Resolve public product from clean repositories
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-      - name: Resolve Maven modules and Gradle plugin markers
-        env:
-          GRADLE_USER_HOME: ${{ runner.temp }}/gradle-user-home
-        run: >-
-          ./gradlew --refresh-dependencies -p release/consumer verifyPublicProduct
-          -PreleaseVersion=${{ inputs.version }}
+          -PreleaseStage=${{ inputs.stage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      GRADLE_USER_HOME: ${{ runner.temp }}/gradle-user-home
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
@@ -123,6 +121,8 @@ jobs:
           distribution: temurin
           java-version: "17"
       - name: Resolve Maven modules and Gradle plugin markers
+        env:
+          GRADLE_USER_HOME: ${{ runner.temp }}/gradle-user-home
         run: >-
           ./gradlew --refresh-dependencies -p release/consumer verifyPublicProduct
           -PreleaseVersion=${{ inputs.version }}

--- a/.github/workflows/verify-public-release.yml
+++ b/.github/workflows/verify-public-release.yml
@@ -1,0 +1,43 @@
+name: Verify public release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact public X.Y.Z-rc.N or X.Y.Z version"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve Maven modules and Gradle plugin markers
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Resolve the complete public product with clean caches
+        env:
+          GRADLE_USER_HOME: ${{ runner.temp }}/gradle-user-home
+        run: >-
+          ./gradlew --refresh-dependencies -p release/consumer verifyPublicProduct
+          -PreleaseVersion=${{ inputs.version }}
+          --no-build-cache
+          --no-daemon
+      - name: Retain public consumer evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-consumer-${{ inputs.version }}
+          path: release/consumer/build/verification/**
+          if-no-files-found: error

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,121 @@
+# Releasing KlumAST
+
+This is the KlumAST-local procedure for release candidates (RCs) and finals. It implements
+[ADR 0012](docs/adr/0012-shared-prerelease-channel-policy.md); that ADR is the authority for
+the shared channel vocabulary and immutability rules. This file does not authorize a release.
+Only an explicitly authorized maintainer may approve the protected `release` environment and
+dispatch [Release](.github/workflows/release.yml).
+
+## Product and trust map
+
+The release is one product at one exact version. Its public Maven coordinates are:
+
+- `klum-ast-annotations`, `klum-ast`, `klum-ast-runtime`, `klum-ast-jackson`,
+  `klum-ast-bean-validation`, `klum-ast-bom`, and `klum-ast-gradle-plugin`, all in
+  `com.blackbuild.klum.ast`.
+
+The Gradle Plugin Portal exposes three declared public plugin IDs:
+
+- `com.blackbuild.klum-ast-schema`
+- `com.blackbuild.klum-ast-model`
+- `com.blackbuild.convention.groovy`
+
+The `release` GitHub environment is the sole credential boundary. It must contain only
+maintainer-managed `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `SIGNING_KEY`,
+`SIGNING_PASSWORD`, `GRADLE_PUBLISH_KEY`, and `GRADLE_PUBLISH_SECRET` secrets. The workflow
+maps them to Gradle only in the protected job; ordinary CI, pull requests, forks, and
+resolve-back receive none of them. The normal `GITHUB_TOKEN` is scoped to `contents: read`;
+the protected job alone receives `contents: write` for Nebula's tag and the immutable GitHub
+release record.
+
+Maven publications are signed and staged through the configured Sonatype endpoint. Plugin
+markers and plugin publication use the Gradle Plugin Portal. A GitHub release records the
+tag and notes after those artifact publications. These systems cannot provide one
+cross-registry transaction: a failure after any remote operation burns the version rather
+than permitting a retry in place.
+
+The mutable `gitPublishPush` wiki path is deliberately not part of the protected artifact
+workflow. [#456](https://github.com/klum-dsl/klum-ast/issues/456) owns the required decision
+on versioned documentation/Javadoc source, hosting, URLs, preview lifecycle, and retention.
+Until that decision and its dedicated protected publication path exist, the current wiki is
+not a release destination.
+
+The repository currently uses major action tags in its workflows. Maintainers must review
+the resolved action revisions and their update policy before authorizing the first use of the
+new release workflow; this is a release gate, not permission to substitute an arbitrary
+action revision during an incident.
+
+## Before approving an RC or final
+
+1. Confirm an explicit human authorization for this exact stage, version, and commit. RC and
+   final approvals are separate.
+2. Start from a clean, non-composite checkout of the intended commit. The build rejects
+   composite builds, and the protected workflow rejects an existing `v<version>` tag or
+   GitHub release.
+3. Verify the expected version: an RC is `X.Y.Z-rc.N` with a new increasing `N`; a final is
+   exactly `X.Y.Z`. Alpha, beta, milestone, and snapshot names are not release channels.
+4. Confirm `CHANGES.md` remains under the projected final `(unreleased)` heading while RCs
+   are evaluated. After accepting the last RC, only the ADR 0012 documentation-only exception
+   may date the exact final heading; any substantive source, dependency, signing, publication,
+   or workflow change requires the next RC.
+5. Ensure all 4.0 blockers, documentation/Javadocs, and the normal Java 17 Groovy 3/4/5
+   `check` gate are ready. The workflow runs `check` and requires the computed Nebula version
+   to equal the approved input before any publication task starts.
+6. Confirm #456 has delivered the accepted versioned documentation/Javadoc destination and
+   that its protected publication path has produced the exact stable or RC documentation
+   snapshot required for this version. Do not substitute the mutable wiki while this gate is
+   open.
+
+## Protected publication path
+
+Dispatch **Release** from the exact accepted commit, select `candidate` or `final`, and enter
+the exact version. The environment approval is the irreversible-operation checkpoint. The
+workflow executes, in its protected job:
+
+```text
+./gradlew <candidate|final> publishToSonatype closeAndReleaseSonatypeStagingRepository \
+  :klum-ast-gradle-plugin:publishPlugins \
+  -PreleaseExpectedVersion=<exact version>
+```
+
+Nebula selects the candidate/final version during configuration; `verifyReleaseVersion`
+rejects a mismatch before the lifecycle task or any publication task executes. The command
+therefore publishes the Maven product, closes/releases its staging repository, and publishes
+the Plugin Portal product from one Gradle configuration. Documentation/Javadoc publication
+is intentionally excluded pending #456's versioned-destination decision. It does not make
+cross-registry publication reversible or claim that a final is byte-identical to its RC.
+
+After a successful RC, record the exact tag, GitHub prerelease, workflow run, resolved
+coordinates, and consumer evidence. The RC validates that source commit. Do not relabel,
+replace, or promote it. A final is a new `X.Y.Z` publication from the exact commit accepted
+for the final RC, followed by its own remote verification.
+
+## Public resolve-back evidence
+
+The `resolve-back` job uses a fresh GitHub-hosted runner and an empty `GRADLE_USER_HOME`. It
+executes [release/consumer](release/consumer), which has no composite build, `mavenLocal`,
+or local repository and resolves all Maven coordinates through Maven Central plus all three
+declared plugin markers through the Plugin Portal. A release is incomplete until this job
+passes and an authorized maintainer records equivalent clean external-consumer evidence from
+a different machine or network as required by ADR 0012.
+
+`com.blackbuild.convention.groovy` is an intentional third public marker. The fixture proves
+it alongside the Schema and Model plugin IDs; this is one complete product validation, not a
+new release channel.
+
+## Failure and recovery
+
+| Failure point | Safe action | Retry rule |
+| --- | --- | --- |
+| Input, clean-checkout, version, tests, or environment approval fails | Fix before publication and obtain authorization again. | The unused version may be reused only if no tag or public artifact exists. |
+| Signing or Sonatype staging fails before release | Abort/drop the staging repository using the registry's protected operation; retain the incident evidence. | Use the next RC number if a tag or any artifact was created. |
+| Maven Central succeeds but Plugin Portal or GitHub release fails | Stop. Do not delete, overwrite, or republish Maven coordinates. Record the partial RC as failed/superseded. | Correct the cause and issue `rc.N+1`; do not repair a different registry under the old version. |
+| Plugin Portal succeeds but GitHub release metadata fails | Stop and record the partial immutable RC. | Use `rc.N+1`; do not repair the old version in place. |
+| Versioned documentation/Javadoc destination is unavailable | Do not authorize an RC or final. #456 must supply the accepted destination and protected publication path. | No artifact publication begins, so no version is consumed. |
+| RC consumer resolve-back fails | Mark that RC rejected/superseded and preserve the evidence. | Any substantive change requires `rc.N+1`. |
+| Final remote verification fails | Treat the final as an incident; it is not an RC retry. | Do not remove published artifacts. A tag may be deleted only by explicit human decision when no artifact was ever published. |
+
+Never print, copy, or diagnose secret values. Do not run publication tasks locally, use
+`publishToMavenLocal` as consumer evidence, or trigger this workflow merely to rehearse it.
+The first real RC is the authorized public validation event; its evidence and recovery record
+are retained with the GitHub prerelease and release workflow run.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,8 @@
 This is the KlumAST-local procedure for release candidates (RCs) and finals. It implements
 [ADR 0012](docs/adr/0012-shared-prerelease-channel-policy.md); that ADR is the authority for
 the shared channel vocabulary and immutability rules. This file does not authorize a release.
-Only an explicitly authorized maintainer may approve the protected `release` environment and
-dispatch [Release](.github/workflows/release.yml).
+Only an explicitly authorized maintainer may approve the protected `release-candidate` or
+`final-release` environment and dispatch [Publish protected release](.github/workflows/release.yml).
 
 ## Product and trust map
 
@@ -20,19 +20,18 @@ The Gradle Plugin Portal exposes three declared public plugin IDs:
 - `com.blackbuild.klum-ast-model`
 - `com.blackbuild.convention.groovy`
 
-The `release` GitHub environment is the sole credential boundary. It must contain only
-maintainer-managed `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `SIGNING_KEY`,
-`SIGNING_PASSWORD`, `GRADLE_PUBLISH_KEY`, and `GRADLE_PUBLISH_SECRET` secrets. The workflow
-maps them to Gradle only in the protected job; ordinary CI, pull requests, forks, and
-resolve-back receive none of them. The normal `GITHUB_TOKEN` is scoped to `contents: read`;
-the protected job alone receives `contents: write` for Nebula's tag and the immutable GitHub
-release record.
+The `release-candidate` and `final-release` GitHub environments are separate credential
+boundaries. Each contains only maintainer-managed `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`,
+`SIGNING_KEY`, `SIGNING_PASSWORD`, `GRADLE_PUBLISH_KEY`, and `GRADLE_PUBLISH_SECRET` secrets.
+The workflow maps them to Gradle only in the protected job; ordinary CI, pull requests, forks,
+and resolve-back receive none of them. The publication workflow retains `contents: read` and no
+persisted checkout credential; it cannot push tags or create a GitHub release record.
 
 Maven publications are signed and staged through the configured Sonatype endpoint. Plugin
-markers and plugin publication use the Gradle Plugin Portal. A GitHub release records the
-tag and notes after those artifact publications. These systems cannot provide one
-cross-registry transaction: a failure after any remote operation burns the version rather
-than permitting a retry in place.
+markers and plugin publication use the Gradle Plugin Portal. A maintainer creates the immutable
+tag and GitHub release record only after the credential-free public proof succeeds. These systems
+cannot provide one cross-registry transaction: a failure after any remote operation burns the
+version rather than permitting a retry in place.
 
 The mutable `gitPublishPush` wiki path is deliberately not part of the protected artifact
 workflow. [#456](https://github.com/klum-dsl/klum-ast/issues/456) owns the required decision
@@ -47,11 +46,11 @@ action revision during an incident.
 
 ## Before approving an RC or final
 
-1. Confirm an explicit human authorization for this exact stage, version, and commit. RC and
-   final approvals are separate.
-2. Start from a clean, non-composite checkout of the intended commit. The build rejects
-   composite builds, and the protected workflow rejects an existing `v<version>` tag or
-   GitHub release.
+1. Confirm an explicit human authorization for this exact stage, version, and full commit SHA
+   on `master`. RC and final approvals are separate.
+2. Start from a clean, non-composite checkout of the intended `master` commit. The build rejects
+   composite builds, and the protected workflow checks that the selected SHA is on `origin/master`
+   and rejects an existing `v<version>` tag or GitHub release.
 3. Verify the expected version: an RC is `X.Y.Z-rc.N` with a new increasing `N`; a final is
    exactly `X.Y.Z`. Alpha, beta, milestone, and snapshot names are not release channels.
 4. Confirm `CHANGES.md` remains under the projected final `(unreleased)` heading while RCs
@@ -68,36 +67,58 @@ action revision during an incident.
 
 ## Protected publication path
 
-Dispatch **Release** from the exact accepted commit, select `candidate` or `final`, and enter
-the exact version. The environment approval is the irreversible-operation checkpoint. The
-workflow executes, in its protected job:
+Dispatch **Publish protected release**, select `candidate` or `final`, and enter the exact
+version and full `master` commit SHA. The matching environment approval is the irreversible-
+operation checkpoint. The workflow checks out that SHA with no persisted GitHub credential,
+proves it is on `master`, and executes in its protected job:
 
 ```text
-./gradlew <candidate|final> publishToSonatype closeAndReleaseSonatypeStagingRepository \
-  :klum-ast-gradle-plugin:publishPlugins \
-  -PreleaseExpectedVersion=<exact version>
+./gradlew <candidate|final> publishCompleteKlumAstProduct \
+  -PreleaseExpectedVersion=<exact version> \
+  -PreleaseStage=<candidate|final>
 ```
 
-Nebula selects the candidate/final version during configuration; `verifyReleaseVersion`
-rejects a mismatch before the lifecycle task or any publication task executes. The command
-therefore publishes the Maven product, closes/releases its staging repository, and publishes
-the Plugin Portal product from one Gradle configuration. Documentation/Javadoc publication
-is intentionally excluded pending #456's versioned-destination decision. It does not make
-cross-registry publication reversible or claim that a final is byte-identical to its RC.
+Nebula selects the candidate/final version during configuration. `verifyReleaseVersion` rejects
+a version/stage mismatch or an absent matching protected authorization before any publication
+task executes. `publishCompleteKlumAstProduct` is the sole permitted public publication entry:
+it publishes every Maven coordinate to one Sonatype staging repository, closes/releases it, and
+then publishes every Plugin Portal marker. Documentation/Javadoc publication intentionally
+remains excluded pending #456's versioned-destination decision. This does not make cross-registry
+publication reversible or claim that a final is byte-identical to its RC.
 
-After a successful RC, record the exact tag, GitHub prerelease, workflow run, resolved
-coordinates, and consumer evidence. The RC validates that source commit. Do not relabel,
-replace, or promote it. A final is a new `X.Y.Z` publication from the exact commit accepted
-for the final RC, followed by its own remote verification.
+After publication, wait for every Maven coordinate and every Plugin Portal marker to be
+publicly resolvable. Then dispatch [Verify public release](.github/workflows/verify-public-release.yml)
+with the exact version. Only after that workflow and the independent external-consumer check pass,
+create and push annotated tag `v<version>` from the accepted SHA and create the matching GitHub
+release (`--prerelease` for an RC). Record the exact tag, GitHub release, publication workflow,
+verification workflow, resolved coordinates, and consumer evidence. The RC validates that source
+commit. Do not relabel, replace, or promote it. A final is a new `X.Y.Z` publication from the
+exact commit accepted for the final RC, followed by its own remote verification.
+
+The maintainer's post-proof record step is deliberately manual and uses no publication
+credentials. From a clean checkout of the accepted commit, run:
+
+```text
+git fetch origin --tags
+git checkout --detach <accepted commit>
+git tag -a v<version> -m "Release <version>"
+git push origin v<version>
+gh release create v<version> --verify-tag --target <accepted commit> [--prerelease] --generate-notes
+```
+
+Use `--prerelease` only for an RC. Confirm the remote tag targets the accepted commit before
+creating the GitHub release; never use this step to repair a partial publication.
 
 ## Public resolve-back evidence
 
-The `resolve-back` job uses a fresh GitHub-hosted runner and an empty `GRADLE_USER_HOME`. It
-executes [release/consumer](release/consumer), which has no composite build, `mavenLocal`,
-or local repository and resolves all Maven coordinates through Maven Central plus all three
-declared plugin markers through the Plugin Portal. A release is incomplete until this job
-passes and an authorized maintainer records equivalent clean external-consumer evidence from
-a different machine or network as required by ADR 0012.
+The separately dispatched `Verify public release` workflow uses a fresh GitHub-hosted runner,
+an empty `GRADLE_USER_HOME`, and no release credentials. It executes
+[release/consumer](release/consumer), which has no composite build, `mavenLocal`, or local
+repository and resolves all Maven coordinates through Maven Central plus all three declared
+plugin markers through the Plugin Portal. It retains the resolved-coordinate and applied-marker
+evidence as a workflow artifact. A release is incomplete until this proof and an authorized
+maintainer's equivalent clean external-consumer evidence from a different machine or network
+pass as required by ADR 0012.
 
 `com.blackbuild.convention.groovy` is an intentional third public marker. The fixture proves
 it alongside the Schema and Model plugin IDs; this is one complete product validation, not a
@@ -109,8 +130,8 @@ new release channel.
 | --- | --- | --- |
 | Input, clean-checkout, version, tests, or environment approval fails | Fix before publication and obtain authorization again. | The unused version may be reused only if no tag or public artifact exists. |
 | Signing or Sonatype staging fails before release | Abort/drop the staging repository using the registry's protected operation; retain the incident evidence. | Use the next RC number if a tag or any artifact was created. |
-| Maven Central succeeds but Plugin Portal or GitHub release fails | Stop. Do not delete, overwrite, or republish Maven coordinates. Record the partial RC as failed/superseded. | Correct the cause and issue `rc.N+1`; do not repair a different registry under the old version. |
-| Plugin Portal succeeds but GitHub release metadata fails | Stop and record the partial immutable RC. | Use `rc.N+1`; do not repair the old version in place. |
+| Maven Central succeeds but Plugin Portal fails | Stop. Do not delete, overwrite, or republish Maven coordinates. Record the partial RC as failed/superseded. | Correct the cause and issue `rc.N+1`; do not repair a different registry under the old version. |
+| Public proof fails or a tag/GitHub release record cannot be created | Stop and record the immutable RC or final incident. | For an RC, correct the cause and use `rc.N+1`; do not repair the old version in place. |
 | Versioned documentation/Javadoc destination is unavailable | Do not authorize an RC or final. #456 must supply the accepted destination and protected publication path. | No artifact publication begins, so no version is consumed. |
 | RC consumer resolve-back fails | Mark that RC rejected/superseded and preserve the evidence. | Any substantive change requires `rc.N+1`. |
 | Final remote verification fails | Treat the final as an incident; it is not an RC retry. | Do not remove published artifacts. A tag may be deleted only by explicit human decision when no artifact was ever published. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,8 +69,9 @@ action revision during an incident.
 
 Dispatch **Publish protected release**, select `candidate` or `final`, and enter the exact
 version and full `master` commit SHA. The matching environment approval is the irreversible-
-operation checkpoint. The workflow checks out that SHA with no persisted GitHub credential,
-proves it is on `master`, and executes in its protected job:
+operation checkpoint. An unprivileged preflight accepts only valid candidate/final version
+shapes before it selects either protected environment. The workflow then checks out that SHA
+with no persisted GitHub credential, proves it is on `master`, and executes in its protected job:
 
 ```text
 ./gradlew <candidate|final> publishCompleteKlumAstProduct \

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ nexusPublishing {
         sonatype {
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(providers.gradleProperty("sonatypeUsername"))
+            password.set(providers.gradleProperty("sonatypePassword"))
         }
     }
 }
@@ -67,8 +69,34 @@ releaseCheck.doLast {
 
 evaluationDependsOnChildren()
 
-tasks.candidate.finalizedBy tasks.gitPublishPush
-tasks.final.finalizedBy tasks.gitPublishPush
+def releaseExpectedVersion = providers.gradleProperty("releaseExpectedVersion")
+
+tasks.register("verifyReleaseVersion") {
+    group = "verification"
+    description = "Verifies the protected release path received the exact version it is authorized to publish."
+
+    doLast {
+        if (!releaseExpectedVersion.present)
+            throw new GradleException("A release requires -PreleaseExpectedVersion=<exact version>.")
+
+        def expected = releaseExpectedVersion.get()
+        if (version.toString() != expected)
+            throw new GradleException("Release version $version does not match authorized version $expected.")
+    }
+}
+
+["candidate", "final"].each { releaseTask ->
+    tasks.named(releaseTask) {
+        dependsOn tasks.named("check"), tasks.named("verifyReleaseVersion")
+    }
+}
+
+def closeSonatypeStagingRepository = tasks.named("closeAndReleaseSonatypeStagingRepository")
+def publishGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("publishPlugins")
+
+publishGradlePlugins.configure {
+    mustRunAfter closeSonatypeStagingRepository
+}
 
 if (hasProperty('buildScan')) {
     develocity {

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,8 @@ def publishMavenProductToSonatype = tasks.register("publishMavenProductToSonatyp
     dependsOn tasks.named("verifyReleaseVersion")
     dependsOn sonatypePublicationTasks
 }
+def closeSonatypeRepository = tasks.named("closeSonatypeStagingRepository")
+def releaseSonatypeRepository = tasks.named("releaseSonatypeStagingRepository")
 def closeSonatypeStagingRepository = tasks.named("closeAndReleaseSonatypeStagingRepository")
 def publishGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("publishPlugins")
 def publishCompleteKlumAstProduct = tasks.register("publishCompleteKlumAstProduct") {
@@ -134,11 +136,15 @@ sonatypePublicationTasks.each { publicationTask ->
     }
 }
 
-closeSonatypeStagingRepository.configure {
-    dependsOn tasks.named("verifyReleaseVersion"), publishMavenProductToSonatype
-    doFirst {
-        if (!gradle.taskGraph.hasTask(publishCompleteKlumAstProduct.get()))
-            throw new GradleException("Use publishCompleteKlumAstProduct; direct Sonatype staging release is forbidden.")
+[closeSonatypeRepository, releaseSonatypeRepository, closeSonatypeStagingRepository].each { stagingTask ->
+    stagingTask.configure {
+        dependsOn tasks.named("verifyReleaseVersion")
+        if (stagingTask == closeSonatypeRepository)
+            dependsOn publishMavenProductToSonatype
+        doFirst {
+            if (!gradle.taskGraph.hasTask(publishCompleteKlumAstProduct.get()))
+                throw new GradleException("Use publishCompleteKlumAstProduct; direct Sonatype staging release is forbidden.")
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,18 +70,31 @@ releaseCheck.doLast {
 evaluationDependsOnChildren()
 
 def releaseExpectedVersion = providers.gradleProperty("releaseExpectedVersion")
+def releaseStage = providers.gradleProperty("releaseStage")
+def releaseAuthorization = providers.environmentVariable("KLUM_AST_RELEASE_AUTHORIZED")
 
 tasks.register("verifyReleaseVersion") {
     group = "verification"
-    description = "Verifies the protected release path received the exact version it is authorized to publish."
+    description = "Verifies the protected release path received the authorized stage and exact version."
 
     doLast {
         if (!releaseExpectedVersion.present)
             throw new GradleException("A release requires -PreleaseExpectedVersion=<exact version>.")
+        if (!releaseStage.present)
+            throw new GradleException("A release requires -PreleaseStage=candidate|final.")
 
         def expected = releaseExpectedVersion.get()
+        def stage = releaseStage.get()
+        if (!(stage in ["candidate", "final"]))
+            throw new GradleException("Release stage must be candidate or final: $stage")
+        if (stage == "candidate" && !(expected ==~ /\d+\.\d+\.\d+-rc\.[1-9]\d*/))
+            throw new GradleException("Candidate versions must match X.Y.Z-rc.N with N greater than zero: $expected")
+        if (stage == "final" && !(expected ==~ /\d+\.\d+\.\d+/))
+            throw new GradleException("Final versions must match X.Y.Z: $expected")
         if (version.toString() != expected)
             throw new GradleException("Release version $version does not match authorized version $expected.")
+        if (releaseAuthorization.orNull != stage)
+            throw new GradleException("Protected $stage authorization is required.")
     }
 }
 
@@ -91,11 +104,51 @@ tasks.register("verifyReleaseVersion") {
     }
 }
 
+def sonatypePublicationTasks = subprojects.findAll { project ->
+    project.tasks.names.contains("publishToSonatype")
+}.collect { project ->
+    project.tasks.named("publishToSonatype")
+}
+def publishMavenProductToSonatype = tasks.register("publishMavenProductToSonatype") {
+    group = "publishing"
+    description = "Publishes every KlumAST Maven coordinate to one protected Sonatype staging repository."
+    dependsOn tasks.named("verifyReleaseVersion")
+    dependsOn sonatypePublicationTasks
+}
 def closeSonatypeStagingRepository = tasks.named("closeAndReleaseSonatypeStagingRepository")
 def publishGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("publishPlugins")
+def publishCompleteKlumAstProduct = tasks.register("publishCompleteKlumAstProduct") {
+    group = "publishing"
+    description = "Publishes the complete protected KlumAST Maven and Gradle Plugin Portal product."
+    dependsOn closeSonatypeStagingRepository
+    dependsOn publishGradlePlugins
+}
+
+sonatypePublicationTasks.each { publicationTask ->
+    publicationTask.configure {
+        dependsOn tasks.named("verifyReleaseVersion")
+        doFirst {
+            if (!gradle.taskGraph.hasTask(publishMavenProductToSonatype.get()))
+                throw new GradleException("Use publishCompleteKlumAstProduct; individual Maven publication is forbidden.")
+        }
+    }
+}
+
+closeSonatypeStagingRepository.configure {
+    dependsOn tasks.named("verifyReleaseVersion"), publishMavenProductToSonatype
+    doFirst {
+        if (!gradle.taskGraph.hasTask(publishCompleteKlumAstProduct.get()))
+            throw new GradleException("Use publishCompleteKlumAstProduct; direct Sonatype staging release is forbidden.")
+    }
+}
 
 publishGradlePlugins.configure {
+    dependsOn tasks.named("verifyReleaseVersion")
     mustRunAfter closeSonatypeStagingRepository
+    doFirst {
+        if (!gradle.taskGraph.hasTask(publishCompleteKlumAstProduct.get()))
+            throw new GradleException("Use publishCompleteKlumAstProduct; direct Gradle Plugin Portal publication is forbidden.")
+    }
 }
 
 if (hasProperty('buildScan')) {

--- a/docs/adr/0012-shared-prerelease-channel-policy.md
+++ b/docs/adr/0012-shared-prerelease-channel-policy.md
@@ -58,7 +58,7 @@ is separate from RC authorization.
 External consumers pin the exact published version, use clean caches and no composite build, `mavenLocal`, local
 repository, or unpublished included build, and resolve each repository's complete public product from its real consumer
 repositories. KlumCast additionally proves its Groovy 3/4/5, classpath, and JPMS consumer contracts; AnnoDocimal proves
-its six artifacts and two plugin markers; KlumAST proves all Maven artifacts and both plugin IDs.
+its six artifacts and two plugin markers; KlumAST proves all Maven artifacts and its three declared plugin markers.
 
 ## Ownership
 

--- a/release/consumer/build.gradle
+++ b/release/consumer/build.gradle
@@ -22,8 +22,15 @@ dependencies {
 tasks.register("verifyPublicProduct") {
     group = "verification"
     description = "Resolves every published Maven module and all declared Gradle plugin markers from public repositories."
+    def evidenceFile = layout.buildDirectory.file("verification/public-product-$releaseVersion.txt")
+    dependsOn subprojects.collect { it.tasks.named("verifyPluginMarker") }
+    outputs.file(evidenceFile)
 
     doLast {
-        configurations.publicProduct.resolve()
+        def artifacts = configurations.publicProduct.resolvedConfiguration.resolvedArtifacts
+                .collect { "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}" }
+                .sort()
+        evidenceFile.get().asFile.parentFile.mkdirs()
+        evidenceFile.get().asFile.text = artifacts.join("\n") + "\n"
     }
 }

--- a/release/consumer/build.gradle
+++ b/release/consumer/build.gradle
@@ -1,0 +1,29 @@
+def releaseVersion = providers.gradleProperty("releaseVersion").orNull
+if (releaseVersion == null)
+    throw new GradleException("Pass -PreleaseVersion=<published version> to resolve the public product.")
+
+configurations {
+    publicProduct {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
+dependencies {
+    publicProduct platform("com.blackbuild.klum.ast:klum-ast-bom:$releaseVersion")
+    publicProduct "com.blackbuild.klum.ast:klum-ast-annotations:$releaseVersion"
+    publicProduct "com.blackbuild.klum.ast:klum-ast:$releaseVersion"
+    publicProduct "com.blackbuild.klum.ast:klum-ast-runtime:$releaseVersion"
+    publicProduct "com.blackbuild.klum.ast:klum-ast-jackson:$releaseVersion"
+    publicProduct "com.blackbuild.klum.ast:klum-ast-bean-validation:$releaseVersion"
+    publicProduct "com.blackbuild.klum.ast:klum-ast-gradle-plugin:$releaseVersion"
+}
+
+tasks.register("verifyPublicProduct") {
+    group = "verification"
+    description = "Resolves every published Maven module and all declared Gradle plugin markers from public repositories."
+
+    doLast {
+        configurations.publicProduct.resolve()
+    }
+}

--- a/release/consumer/groovy-convention-consumer/build.gradle
+++ b/release/consumer/groovy-convention-consumer/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.blackbuild.convention.groovy"
+}

--- a/release/consumer/groovy-convention-consumer/build.gradle
+++ b/release/consumer/groovy-convention-consumer/build.gradle
@@ -1,3 +1,15 @@
 plugins {
     id "com.blackbuild.convention.groovy"
 }
+
+tasks.register("verifyPluginMarker") {
+    def evidenceFile = layout.buildDirectory.file("verification/plugin-marker.txt")
+    outputs.file(evidenceFile)
+
+    doLast {
+        if (!pluginManager.hasPlugin("com.blackbuild.convention.groovy"))
+            throw new GradleException("Groovy convention plugin marker was not resolved and applied.")
+        evidenceFile.get().asFile.parentFile.mkdirs()
+        evidenceFile.get().asFile.text = "com.blackbuild.convention.groovy\n"
+    }
+}

--- a/release/consumer/model-plugin-consumer/build.gradle
+++ b/release/consumer/model-plugin-consumer/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.blackbuild.klum-ast-model"
+}

--- a/release/consumer/model-plugin-consumer/build.gradle
+++ b/release/consumer/model-plugin-consumer/build.gradle
@@ -1,3 +1,15 @@
 plugins {
     id "com.blackbuild.klum-ast-model"
 }
+
+tasks.register("verifyPluginMarker") {
+    def evidenceFile = layout.buildDirectory.file("verification/plugin-marker.txt")
+    outputs.file(evidenceFile)
+
+    doLast {
+        if (!pluginManager.hasPlugin("com.blackbuild.klum-ast-model"))
+            throw new GradleException("Model plugin marker was not resolved and applied.")
+        evidenceFile.get().asFile.parentFile.mkdirs()
+        evidenceFile.get().asFile.text = "com.blackbuild.klum-ast-model\n"
+    }
+}

--- a/release/consumer/schema-plugin-consumer/build.gradle
+++ b/release/consumer/schema-plugin-consumer/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.blackbuild.klum-ast-schema"
+}

--- a/release/consumer/schema-plugin-consumer/build.gradle
+++ b/release/consumer/schema-plugin-consumer/build.gradle
@@ -1,3 +1,15 @@
 plugins {
     id "com.blackbuild.klum-ast-schema"
 }
+
+tasks.register("verifyPluginMarker") {
+    def evidenceFile = layout.buildDirectory.file("verification/plugin-marker.txt")
+    outputs.file(evidenceFile)
+
+    doLast {
+        if (!pluginManager.hasPlugin("com.blackbuild.klum-ast-schema"))
+            throw new GradleException("Schema plugin marker was not resolved and applied.")
+        evidenceFile.get().asFile.parentFile.mkdirs()
+        evidenceFile.get().asFile.text = "com.blackbuild.klum-ast-schema\n"
+    }
+}

--- a/release/consumer/settings.gradle
+++ b/release/consumer/settings.gradle
@@ -1,0 +1,25 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+
+    def releaseVersion = providers.gradleProperty("releaseVersion").orNull
+    if (releaseVersion == null)
+        throw new GradleException("Pass -PreleaseVersion=<published version> to resolve the public product.")
+
+    plugins {
+        id "com.blackbuild.klum-ast-schema" version releaseVersion
+        id "com.blackbuild.klum-ast-model" version releaseVersion
+        id "com.blackbuild.convention.groovy" version releaseVersion
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "klum-ast-public-consumer"
+include "schema-plugin-consumer", "model-plugin-consumer", "groovy-convention-consumer"


### PR DESCRIPTION
## Summary

- implements a protected hybrid RC/final path: separate environments, exact master SHA checkout, and no write-capable publication checkout
- adds a Gradle-level authorization/version guard and one complete-product entry point that rejects partial Maven, staging, or Plugin Portal publication paths
- separates credential-free public resolve-back from publication; it runs after registry propagation and retains Maven-coordinate and applied-plugin-marker evidence
- records tags and GitHub releases manually only after public proof; documents exact commands, recovery, cross-registry burn rules, and the three public Plugin Portal markers
- keeps mutable wiki publication excluded; #456 must supply the versioned documentation/Javadoc destination before an RC or final is authorized

## Validation

- ./gradlew check (Groovy 3/4/5 lanes)
- clean-commit candidate plus complete-product Gradle task graph dry run; no publication task executed
- workflow YAML parsing and diff checks

Related: #488 remains open. This does not publish artifacts, access credentials, create tags/releases, or implement #456 documentation hosting.