### PR TITLE
Generate isolated module Javadocs for #456

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 ## Documentation infrastructure
 
 - Current 4.x user documentation is authored in `docs/user/` and rendered locally from an explicit Git revision into an immutable exact-version Markdown tree. The renderer captures a deterministic source manifest and versioned Season/logo input, while the former mutable wiki publisher fails closed ([#456](https://github.com/klum-dsl/klum-ast/issues/456)).
+- Exact 4.x documentation renders six isolated module-Javadoc trees below `/&lt;version&gt;/api/` for `klum-ast`, runtime, annotations, Jackson, Bean Validation, and the Gradle plugin. The BOM and IDE-only source mirrors are not public API inputs ([#456](https://github.com/klum-dsl/klum-ast/issues/456)).
 
 ## Dependency compatibility
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,10 +80,10 @@ releaseCheck.doLast {
 
 evaluationDependsOnChildren()
 
-def versionedDocumentationJavadocTasks = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collect { module ->
+def versionedDocumentationJavadocTasks = VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.keySet().collect { module ->
     project(":$module").tasks.named('javadoc', Javadoc)
 }
-def versionedDocumentationJavadocDirectories = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collectEntries { module ->
+def versionedDocumentationJavadocDirectories = VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.keySet().collectEntries { module ->
     [(module): project(":$module").tasks.named('javadoc', Javadoc).get().destinationDir]
 }
 tasks.named('renderVersionedDocumentation', RenderVersionedDocumentationTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import com.blackbuild.klum.ast.docs.RenderVersionedDocumentationTask
 import com.blackbuild.klum.ast.docs.VerifyVersionedDocumentationRendererTask
+import com.blackbuild.klum.ast.docs.VersionedDocumentationRenderer
+import org.gradle.api.tasks.javadoc.Javadoc
 
 buildscript {
     repositories {
@@ -45,15 +47,6 @@ sonar {
 def splitDocumentationProperty = { String name ->
     providers.gradleProperty(name).map { value -> value.split(',').collect { it.trim() }.findAll { it } }.orElse([])
 }
-def documentationJavadocChecksums = providers.gradleProperty('documentationJavadocChecksums').map { value ->
-    value.split(',').collect { entry ->
-        def parts = entry.split('=', 2)*.trim()
-        if (parts.size() != 2 || !parts[0] || !parts[1])
-            throw new GradleException('documentationJavadocChecksums must use module=sha256 entries.')
-        [(parts[0]): parts[1]]
-    }.collectEntries { it }
-}.orElse([:])
-
 tasks.register('renderVersionedDocumentation', RenderVersionedDocumentationTask) {
     group = 'documentation'
     description = 'Renders one immutable, exact-version documentation tree from explicit Git object inputs.'
@@ -63,7 +56,6 @@ tasks.register('renderVersionedDocumentation', RenderVersionedDocumentationTask)
     status.set(providers.gradleProperty('documentationStatus'))
     brandingManifestPath.set(providers.gradleProperty('documentationBrandingManifest'))
     archivedVersions.set(splitDocumentationProperty('documentationArchivedVersions'))
-    javadocInputChecksums.set(documentationJavadocChecksums)
     objectDirectory.set(layout.dir(providers.gradleProperty('documentationObjectDirectory').map { file(it) }))
     outputDirectory.set(layout.dir(providers.gradleProperty('documentationOutputDirectory').map { file(it) }))
 }
@@ -87,6 +79,21 @@ releaseCheck.doLast {
 }
 
 evaluationDependsOnChildren()
+
+def versionedDocumentationJavadocTasks = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collect { module ->
+    project(":$module").tasks.named('javadoc', Javadoc)
+}
+def versionedDocumentationJavadocDirectories = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collectEntries { module ->
+    [(module): project(":$module").tasks.named('javadoc', Javadoc).get().destinationDir]
+}
+tasks.named('renderVersionedDocumentation', RenderVersionedDocumentationTask) {
+    dependsOn(versionedDocumentationJavadocTasks)
+    moduleJavadocs.from(versionedDocumentationJavadocTasks)
+    moduleJavadocDirectories.set(versionedDocumentationJavadocDirectories)
+}
+tasks.named('verifyVersionedDocumentationRenderer', VerifyVersionedDocumentationRendererTask) {
+    dependsOn(versionedDocumentationJavadocTasks)
+}
 
 def releaseExpectedVersion = providers.gradleProperty("releaseExpectedVersion")
 def releaseStage = providers.gradleProperty("releaseStage")

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/RenderVersionedDocumentationTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/RenderVersionedDocumentationTask.groovy
@@ -24,13 +24,18 @@
 package com.blackbuild.klum.ast.docs
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 abstract class RenderVersionedDocumentationTask extends DefaultTask {
@@ -41,8 +46,11 @@ abstract class RenderVersionedDocumentationTask extends DefaultTask {
     @Input abstract Property<String> getStatus()
     @Input abstract Property<String> getBrandingManifestPath()
     @Input abstract ListProperty<String> getArchivedVersions()
-    @Input abstract MapProperty<String, String> getJavadocInputChecksums()
     @InputDirectory abstract DirectoryProperty getObjectDirectory()
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract ConfigurableFileCollection getModuleJavadocs()
+    @Internal abstract MapProperty<String, File> getModuleJavadocDirectories()
     @OutputDirectory abstract DirectoryProperty getOutputDirectory()
 
     @TaskAction
@@ -56,6 +64,6 @@ abstract class RenderVersionedDocumentationTask extends DefaultTask {
                 status               : status.get(),
                 brandingManifestPath : brandingManifestPath.get(),
                 archivedVersions     : archivedVersions.get(),
-                javadocInputChecksums: javadocInputChecksums.get())
+                moduleJavadocs       : moduleJavadocDirectories.get())
     }
 }

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -55,10 +55,13 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertTrue(!new File(currentOne, '4.0.0-rc.1/Legacy.md').exists(), '4.x render must not select wiki/')
         assertContains(new File(currentOne, '4.0.0-rc.1/source-manifest.json').text, 'Season 4: The Makeover', 'branding manifest capture')
         assertTrue(new File(currentOne, '4.0.0-rc.1/assets/branding/klumlogo.png').file, 'logo must be local to the exact tree')
+        String apiLanding = new File(currentOne, '4.0.0-rc.1/api/index.md').text
+        assertContains(apiLanding, 'distinct Javadoc base', 'API landing policy')
         VersionedDocumentationRenderer.MODULE_JAVADOCS.each { String module, String representativeType ->
             File moduleOutput = new File(currentOne, "4.0.0-rc.1/api/$module")
             VerifyVersionedDocumentationRendererTask.assertTrue(new File(moduleOutput, representativeType).file, "representative public type must be reachable for $module")
             VerifyVersionedDocumentationRendererTask.assertContains(new File(moduleOutput, 'index.html').text, module, "isolated API base must retain $module")
+            VerifyVersionedDocumentationRendererTask.assertContains(apiLanding, "/4.0.0-rc.1/api/$module/", "API landing must link to $module")
         }
         assertTrue(!new File(currentOne, '4.0.0-rc.1/api/klum-ast-bom').exists(), 'BOM must not have an API output')
 

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -42,38 +42,45 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         project.delete(outputs)
         outputs.mkdirs()
         initializeFixture(fixture)
+        Map<String, File> moduleJavadocs = initializeModuleJavadocs(fixture)
         String revision = git(fixture, ['rev-parse', 'HEAD']).trim()
 
         File currentOne = new File(outputs, 'output-one')
         File currentTwo = new File(outputs, 'output-two')
-        render(fixture, currentOne, revision, '4.0.0-rc.1', 'public-rc')
-        render(fixture, currentTwo, revision, '4.0.0-rc.1', 'public-rc')
+        render(fixture, currentOne, revision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
+        render(fixture, currentTwo, revision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
         assertEqual(treeDigest(currentOne), treeDigest(currentTwo), 'Repeated exact-revision rendering must be deterministic')
         assertContains(new File(currentOne, '4.0.0-rc.1/Home.md').text, 'Prerelease warning', 'RC chrome')
         assertContains(new File(currentOne, '4.0.0-rc.1/Home.md').text, '/4.0.0-rc.1/status.md', 'RC status link')
         assertTrue(!new File(currentOne, '4.0.0-rc.1/Legacy.md').exists(), '4.x render must not select wiki/')
         assertContains(new File(currentOne, '4.0.0-rc.1/source-manifest.json').text, 'Season 4: The Makeover', 'branding manifest capture')
         assertTrue(new File(currentOne, '4.0.0-rc.1/assets/branding/klumlogo.png').file, 'logo must be local to the exact tree')
+        VersionedDocumentationRenderer.MODULE_JAVADOCS.each { String module, String representativeType ->
+            File moduleOutput = new File(currentOne, "4.0.0-rc.1/api/$module")
+            VerifyVersionedDocumentationRendererTask.assertTrue(new File(moduleOutput, representativeType).file, "representative public type must be reachable for $module")
+            VerifyVersionedDocumentationRendererTask.assertContains(new File(moduleOutput, 'index.html').text, module, "isolated API base must retain $module")
+        }
+        assertTrue(!new File(currentOne, '4.0.0-rc.1/api/klum-ast-bom').exists(), 'BOM must not have an API output')
 
         File historical = new File(outputs, 'historical')
-        render(fixture, historical, revision, '3.0.1', 'archived')
+        render(fixture, historical, revision, '3.0.1', 'archived', moduleJavadocs)
         assertContains(new File(historical, '3.0.1/Legacy.md').text, 'Archived (legacy)', 'archived chrome')
         assertContains(new File(historical, '3.0.1/Legacy.md').text, '/archive/', 'archive link')
         assertTrue(!new File(historical, '3.0.1/Home.md').exists(), 'historical render must select wiki/')
 
         expectFailure('dirty input') {
             new File(fixture, 'dirty.txt').text = 'dirty'
-            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'dirty-output'), revision, '4.0.0-rc.1', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'dirty-output'), revision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
         }
         new File(fixture, 'dirty.txt').delete()
         expectFailure('unresolved revision') {
-            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'missing-revision'), '0' * 40, '4.0.0-rc.1', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'missing-revision'), '0' * 40, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
         }
         expectFailure('public-rc must be an RC') {
-            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'not-an-rc'), revision, '4.0.0', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'not-an-rc'), revision, '4.0.0', 'public-rc', moduleJavadocs)
         }
         expectFailure('development aliases are forbidden') {
-            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'development'), revision, '4.0.0-rc.1', 'development')
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'development'), revision, '4.0.0-rc.1', 'development', moduleJavadocs)
         }
 
         new File(fixture, 'docs/user/status.md').text = '# collision\n'
@@ -81,7 +88,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         git(fixture, ['commit', '-m', 'fixture duplicate path'])
         String duplicateRevision = git(fixture, ['rev-parse', 'HEAD']).trim()
         expectFailure('renderer-owned path collision') {
-            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'duplicate'), duplicateRevision, '4.0.0-rc.1', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'duplicate'), duplicateRevision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
         }
 
         File missingRoot = Files.createTempDirectory(temporaryDir.toPath(), 'documentation-missing-root-').toFile()
@@ -94,7 +101,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         git(missingRoot, ['commit', '-m', 'fixture missing current root'])
         String missingRootRevision = git(missingRoot, ['rev-parse', 'HEAD']).trim()
         expectFailure('missing current source root') {
-            VerifyVersionedDocumentationRendererTask.render(missingRoot, new File(outputs, 'missing-root'), missingRootRevision, '4.0.0-rc.1', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(missingRoot, new File(outputs, 'missing-root'), missingRootRevision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
         }
 
         File malformedBranding = Files.createTempDirectory(temporaryDir.toPath(), 'documentation-malformed-branding-').toFile()
@@ -104,7 +111,49 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         git(malformedBranding, ['commit', '-m', 'fixture malformed branding'])
         String malformedRevision = git(malformedBranding, ['rev-parse', 'HEAD']).trim()
         expectFailure('malformed branding manifest') {
-            VerifyVersionedDocumentationRendererTask.render(malformedBranding, new File(outputs, 'malformed-branding'), malformedRevision, '4.0.0-rc.1', 'public-rc')
+            VerifyVersionedDocumentationRendererTask.render(malformedBranding, new File(outputs, 'malformed-branding'), malformedRevision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
+        }
+
+        Map<String, File> missingModule = new LinkedHashMap<>(moduleJavadocs)
+        missingModule.remove('klum-ast-runtime')
+        File failedOutput = new File(outputs, 'missing-module-javadoc')
+        expectFailure('missing module Javadoc output') {
+            VerifyVersionedDocumentationRendererTask.render(fixture, failedOutput, revision, '4.0.0-rc.1', 'public-rc', missingModule)
+        }
+        assertTrue(!failedOutput.exists(), 'A failed Javadoc input must not produce a partial exact-version render')
+
+        File mirror = new File(moduleJavadocs['klum-ast'], 'com/example/Example_DSL.html')
+        mirror.parentFile.mkdirs()
+        mirror.text = 'mirror'
+        expectFailure('IDE source mirror exclusion') {
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'mirror'), revision, '4.0.0-rc.1', 'public-rc', moduleJavadocs)
+        }
+        mirror.delete()
+
+        Map<String, File> bom = new LinkedHashMap<>(moduleJavadocs)
+        bom['klum-ast-bom'] = new File(temporaryDir, 'bom-javadocs')
+        bom['klum-ast-bom'].mkdirs()
+        expectFailure('BOM exclusion') {
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'bom'), revision, '4.0.0-rc.1', 'public-rc', bom)
+        }
+
+        Map<String, File> merged = new LinkedHashMap<>(moduleJavadocs)
+        merged['klum-ast-runtime'] = merged['klum-ast']
+        expectFailure('isolated module outputs') {
+            VerifyVersionedDocumentationRendererTask.render(fixture, new File(outputs, 'merged'), revision, '4.0.0-rc.1', 'public-rc', merged)
+        }
+
+        def renderTask = project.tasks.named('renderVersionedDocumentation').get()
+        Set<String> directDependencies = renderTask.taskDependencies.getDependencies(renderTask)*.path as Set
+        Set<String> expectedDependencies = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collect { ":$it:javadoc".toString() } as Set
+        if (!directDependencies.containsAll(expectedDependencies))
+            throw new GradleException("Exact-version rendering must depend on every allowed module Javadoc task; actual direct dependencies: $directDependencies")
+        assertTrue(!directDependencies.contains(':klum-ast-bom:javadoc'), 'BOM must not be wired into exact-version API rendering')
+        def rootProject = project
+        VersionedDocumentationRenderer.MODULE_JAVADOCS.each { String module, String representativeType ->
+            def javadocTask = rootProject.project(":$module").tasks.named('javadoc').get()
+            VerifyVersionedDocumentationRendererTask.assertTrue(new File(javadocTask.destinationDir, representativeType).file, "standard $module Javadocs must expose a representative public type")
+            VerifyVersionedDocumentationRendererTask.assertTrue(javadocTask.source.files.every { !it.name.endsWith('_DSL.java') }, "standard $module Javadocs must exclude IDE source mirrors")
         }
 
         assertTrue(project.tasks.findByName('gitPublishPush')?.description?.contains('fails closed'),
@@ -118,6 +167,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         new File(repository, 'docs/user/img').mkdirs()
         new File(repository, 'docs/branding').mkdirs()
         new File(repository, 'wiki').mkdirs()
+        new File(repository, '.gitignore').text = '*/build/\n'
         new File(repository, 'docs/user/Home.md').text = '# Current documentation\n\nCurrent content.\n'
         byte[] logo = 'fixture-logo'.getBytes(StandardCharsets.UTF_8)
         new File(repository, 'docs/user/img/klumlogo.png').bytes = logo
@@ -133,7 +183,22 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         git(repository, ['commit', '-m', 'fixture documentation input'])
     }
 
-    static void render(File repository, File output, String revision, String version, String status) {
+    private static Map<String, File> initializeModuleJavadocs(File repository) {
+        VersionedDocumentationRenderer.MODULE_JAVADOCS.collectEntries { String module, String representativeType ->
+            File moduleRoot = new File(repository, "$module/build/docs/javadoc")
+            new File(moduleRoot, 'index.html').with {
+                parentFile.mkdirs()
+                text = "<html>$module</html>"
+            }
+            new File(moduleRoot, representativeType).with {
+                parentFile.mkdirs()
+                text = "<html>$module representative public type</html>"
+            }
+            [(module): moduleRoot]
+        }
+    }
+
+    static void render(File repository, File output, String revision, String version, String status, Map<String, File> moduleJavadocs) {
         VersionedDocumentationRenderer.render(
                 objectDirectory      : repository,
                 outputDirectory      : output,
@@ -143,7 +208,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 status               : status,
                 brandingManifestPath : 'docs/branding/season-4-klumast.json',
                 archivedVersions     : ['2.2.0'],
-                javadocInputChecksums: ['klum-ast': 'a' * 64])
+                moduleJavadocs       : moduleJavadocs)
     }
 
     private static void expectFailure(String description, Closure action) {

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -57,7 +57,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertTrue(new File(currentOne, '4.0.0-rc.1/assets/branding/klumlogo.png').file, 'logo must be local to the exact tree')
         String apiLanding = new File(currentOne, '4.0.0-rc.1/api/index.md').text
         assertContains(apiLanding, 'distinct Javadoc base', 'API landing policy')
-        VersionedDocumentationRenderer.MODULE_JAVADOCS.each { String module, String representativeType ->
+        VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.each { String module, String representativeType ->
             File moduleOutput = new File(currentOne, "4.0.0-rc.1/api/$module")
             VerifyVersionedDocumentationRendererTask.assertTrue(new File(moduleOutput, representativeType).file, "representative public type must be reachable for $module")
             VerifyVersionedDocumentationRendererTask.assertContains(new File(moduleOutput, 'index.html').text, module, "isolated API base must retain $module")
@@ -148,12 +148,12 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
 
         def renderTask = project.tasks.named('renderVersionedDocumentation').get()
         Set<String> directDependencies = renderTask.taskDependencies.getDependencies(renderTask)*.path as Set
-        Set<String> expectedDependencies = VersionedDocumentationRenderer.MODULE_JAVADOCS.keySet().collect { ":$it:javadoc".toString() } as Set
+        Set<String> expectedDependencies = VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.keySet().collect { ":$it:javadoc".toString() } as Set
         if (!directDependencies.containsAll(expectedDependencies))
             throw new GradleException("Exact-version rendering must depend on every allowed module Javadoc task; actual direct dependencies: $directDependencies")
         assertTrue(!directDependencies.contains(':klum-ast-bom:javadoc'), 'BOM must not be wired into exact-version API rendering')
         def rootProject = project
-        VersionedDocumentationRenderer.MODULE_JAVADOCS.each { String module, String representativeType ->
+        VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.each { String module, String representativeType ->
             def javadocTask = rootProject.project(":$module").tasks.named('javadoc').get()
             VerifyVersionedDocumentationRendererTask.assertTrue(new File(javadocTask.destinationDir, representativeType).file, "standard $module Javadocs must expose a representative public type")
             VerifyVersionedDocumentationRendererTask.assertTrue(javadocTask.source.files.every { !it.name.endsWith('_DSL.java') }, "standard $module Javadocs must exclude IDE source mirrors")
@@ -187,7 +187,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
     }
 
     private static Map<String, File> initializeModuleJavadocs(File repository) {
-        VersionedDocumentationRenderer.MODULE_JAVADOCS.collectEntries { String module, String representativeType ->
+        VersionedDocumentationRenderer.MODULE_REPRESENTATIVE_JAVADOCS.collectEntries { String module, String representativeType ->
             File moduleRoot = new File(repository, "$module/build/docs/javadoc")
             new File(moduleRoot, 'index.html').with {
                 parentFile.mkdirs()

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
@@ -39,6 +39,14 @@ import java.security.MessageDigest
 class VersionedDocumentationRenderer {
 
     static final String RENDERER_ID = 'klum-ast-buildsrc-vd-1'
+    static final Map<String, String> MODULE_JAVADOCS = [
+            'klum-ast'                : 'com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.html',
+            'klum-ast-runtime'        : 'com/blackbuild/klum/ast/KlumModelObject.html',
+            'klum-ast-annotations'    : 'com/blackbuild/groovy/configdsl/transform/DSL.html',
+            'klum-ast-jackson'        : 'com/blackbuild/klum/ast/jackson/KlumAstModule.html',
+            'klum-ast-bean-validation': 'com/blackbuild/klum/ast/validation/bean/JSR380Validator.html',
+            'klum-ast-gradle-plugin'  : 'com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.html'
+    ].asImmutable()
     private static final Set<String> STATUSES = ['current', 'archived', 'public-rc'] as Set
     private static final Set<String> RESERVED_PATHS = ['status.md', 'source-manifest.json'] as Set
     private static final String VERSION_PATTERN = /\d+\.\d+\.\d+(?:-rc\.[1-9]\d*)?/
@@ -51,7 +59,7 @@ class VersionedDocumentationRenderer {
         String version = requiredString(inputs, 'version')
         String status = requiredString(inputs, 'status')
         String brandingManifestPath = requiredRelativePath(requiredString(inputs, 'brandingManifestPath'), 'brandingManifestPath')
-        Map<String, String> javadocInputChecksums = normalizedChecksums(inputs.javadocInputChecksums ?: [:])
+        Map<String, File> moduleJavadocs = version.startsWith('4.') ? requiredModuleJavadocs(inputs.moduleJavadocs, objectDirectory) : [:]
         List<String> archivedVersions = ((inputs.archivedVersions ?: []) as List<String>).collect { it.toString() }.sort()
 
         requireFullSha(revision, 'revision')
@@ -71,6 +79,8 @@ class VersionedDocumentationRenderer {
         if (resolvedRevision != revision)
             fail("Revision must resolve to the supplied full SHA: $revision")
         git(objectDirectory, ['cat-file', '-e', "${revision}^{commit}"])
+        if (version.startsWith('4.') && git(objectDirectory, ['rev-parse', 'HEAD']).trim() != revision)
+            fail('4.x module Javadocs must be generated from the selected checked-out revision.')
 
         String sourceRoot = version.startsWith('4.') ? 'docs/user' : 'wiki'
         List<String> sourcePaths = git(objectDirectory, ['ls-tree', '-r', '--name-only', revision, '--', sourceRoot])
@@ -90,6 +100,8 @@ class VersionedDocumentationRenderer {
             requireRelativePath(outputPath, 'source path')
             if (RESERVED_PATHS.contains(outputPath))
                 fail("Source path collides with renderer-owned output: $outputPath")
+            if (outputPath == 'api' || outputPath.startsWith('api/'))
+                fail("Source path collides with renderer-owned API output: $outputPath")
             if (!outputPaths.add(outputPath))
                 fail("Duplicate output path: $outputPath")
             byte[] content = gitBytes(objectDirectory, ['show', "${revision}:${sourcePath}"])
@@ -108,6 +120,8 @@ class VersionedDocumentationRenderer {
         if (logoDigest != branding.sha256)
             fail("Branding manifest digest does not match $logoPath")
         write(exactDirectory, logoTarget, logo)
+
+        Map<String, String> javadocInputChecksums = copyModuleJavadocs(exactDirectory, moduleJavadocs)
 
         outputPaths.add('status.md')
         write(exactDirectory, 'status.md', statusRecord(version, status).getBytes(StandardCharsets.UTF_8))
@@ -153,16 +167,56 @@ class VersionedDocumentationRenderer {
         branding
     }
 
-    private static Map<String, String> normalizedChecksums(Object values) {
+    private static Map<String, File> requiredModuleJavadocs(Object values, File objectDirectory) {
         if (!(values instanceof Map))
-            fail('Javadoc input checksums must be a module-to-sha256 map')
-        Map<String, String> normalized = [:]
+            fail('Module Javadocs must be a module-to-directory map')
+        Map<String, File> normalized = [:]
         (values as Map).each { key, value ->
-            if (!(key instanceof String) || !key || !(value instanceof String) || !(value ==~ /[0-9a-f]{64}/))
-                fail('Javadoc input checksums must use non-empty module names and SHA-256 values')
-            normalized[key] = value
+            if (!(key instanceof String) || !MODULE_JAVADOCS.containsKey(key))
+                fail("Module Javadocs must use the explicit API allowlist: ${MODULE_JAVADOCS.keySet()}")
+            File directory = value instanceof File ? value : new File(value.toString())
+            File expectedDirectory = new File(objectDirectory, "$key/build/docs/javadoc").canonicalFile
+            if (directory.canonicalFile != expectedDirectory)
+                fail("Module Javadocs for $key must come from its selected-revision Javadoc task: $expectedDirectory")
+            if (!directory.directory)
+                fail("Module Javadoc output is missing for $key: $directory")
+            if (!new File(directory, 'index.html').file)
+                fail("Module Javadoc output is incomplete for $key: $directory")
+            if (!new File(directory, MODULE_JAVADOCS[key]).file)
+                fail("Representative public type is absent from $key Javadocs: ${MODULE_JAVADOCS[key]}")
+            if (containsMirrorJavadoc(directory))
+                fail("IDE source mirrors must not appear in $key Javadocs")
+            normalized[key] = directory.canonicalFile
         }
+        if (normalized.keySet() != MODULE_JAVADOCS.keySet())
+            fail("Module Javadocs must contain exactly the explicit API allowlist: ${MODULE_JAVADOCS.keySet()}")
+        if (normalized.values().toSet().size() != normalized.size())
+            fail('Module Javadocs must use distinct isolated module outputs')
         normalized
+    }
+
+    private static Map<String, String> copyModuleJavadocs(File exactDirectory, Map<String, File> moduleJavadocs) {
+        Map<String, String> checksums = new TreeMap<>()
+        moduleJavadocs.each { String module, File source ->
+            File target = new File(exactDirectory, "api/$module")
+            source.eachFileRecurse { File file ->
+                if (file.file) {
+                    String path = source.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char)
+                    write(target, path, file.bytes)
+                }
+            }
+            checksums[module] = treeDigest(source)
+        }
+        checksums
+    }
+
+    private static boolean containsMirrorJavadoc(File directory) {
+        boolean found = false
+        directory.eachFileRecurse { File file ->
+            if (file.file && file.name.endsWith('_DSL.html'))
+                found = true
+        }
+        found
     }
 
     private static String chrome(String version, String status) {
@@ -198,6 +252,19 @@ class VersionedDocumentationRenderer {
                 hashes[root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char)] = sha256(file.bytes)
         }
         hashes
+    }
+
+    private static String treeDigest(File root) {
+        MessageDigest digest = MessageDigest.getInstance('SHA-256')
+        List<File> files = []
+        root.eachFileRecurse { File file -> if (file.file) files << file }
+        files.sort { File left, File right ->
+            root.toPath().relativize(left.toPath()).toString() <=> root.toPath().relativize(right.toPath()).toString()
+        }.each { File file ->
+            digest.update(root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char).getBytes(StandardCharsets.UTF_8))
+            digest.update(file.bytes)
+        }
+        digest.digest().encodeHex().toString()
     }
 
     private static String canonicalJson(Map<String, ?> value) {

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
@@ -39,7 +39,7 @@ import java.security.MessageDigest
 class VersionedDocumentationRenderer {
 
     static final String RENDERER_ID = 'klum-ast-buildsrc-vd-1'
-    static final Map<String, String> MODULE_JAVADOCS = [
+    static final Map<String, String> MODULE_REPRESENTATIVE_JAVADOCS = [
             'klum-ast'                : 'com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.html',
             'klum-ast-runtime'        : 'com/blackbuild/klum/ast/KlumModelObject.html',
             'klum-ast-annotations'    : 'com/blackbuild/groovy/configdsl/transform/DSL.html',
@@ -174,8 +174,8 @@ class VersionedDocumentationRenderer {
             fail('Module Javadocs must be a module-to-directory map')
         Map<String, File> normalized = [:]
         (values as Map).each { key, value ->
-            if (!(key instanceof String) || !MODULE_JAVADOCS.containsKey(key))
-                fail("Module Javadocs must use the explicit API allowlist: ${MODULE_JAVADOCS.keySet()}")
+            if (!(key instanceof String) || !MODULE_REPRESENTATIVE_JAVADOCS.containsKey(key))
+                fail("Module Javadocs must use the explicit API allowlist: ${MODULE_REPRESENTATIVE_JAVADOCS.keySet()}")
             File directory = value instanceof File ? value : new File(value.toString())
             File expectedDirectory = new File(objectDirectory, "$key/build/docs/javadoc").canonicalFile
             if (directory.canonicalFile != expectedDirectory)
@@ -184,14 +184,14 @@ class VersionedDocumentationRenderer {
                 fail("Module Javadoc output is missing for $key: $directory")
             if (!new File(directory, 'index.html').file)
                 fail("Module Javadoc output is incomplete for $key: $directory")
-            if (!new File(directory, MODULE_JAVADOCS[key]).file)
-                fail("Representative public type is absent from $key Javadocs: ${MODULE_JAVADOCS[key]}")
+            if (!new File(directory, MODULE_REPRESENTATIVE_JAVADOCS[key]).file)
+                fail("Representative public type is absent from $key Javadocs: ${MODULE_REPRESENTATIVE_JAVADOCS[key]}")
             if (containsMirrorJavadoc(directory))
                 fail("IDE source mirrors must not appear in $key Javadocs")
             normalized[key] = directory.canonicalFile
         }
-        if (normalized.keySet() != MODULE_JAVADOCS.keySet())
-            fail("Module Javadocs must contain exactly the explicit API allowlist: ${MODULE_JAVADOCS.keySet()}")
+        if (normalized.keySet() != MODULE_REPRESENTATIVE_JAVADOCS.keySet())
+            fail("Module Javadocs must contain exactly the explicit API allowlist: ${MODULE_REPRESENTATIVE_JAVADOCS.keySet()}")
         if (normalized.values().toSet().size() != normalized.size())
             fail('Module Javadocs must use distinct isolated module outputs')
         normalized
@@ -250,7 +250,7 @@ class VersionedDocumentationRenderer {
     private static String apiIndex(String version) {
         "# KlumAST $version API reference\n\n" +
                 'Each published module has a distinct Javadoc base. The BOM and IDE-only source mirrors are not API inputs.\n\n' +
-                MODULE_JAVADOCS.keySet().collect { module -> "- [$module](/$version/api/$module/)" }.join('\n') + '\n'
+                MODULE_REPRESENTATIVE_JAVADOCS.keySet().collect { module -> "- [$module](/$version/api/$module/)" }.join('\n') + '\n'
     }
 
     private static Map<String, String> outputHashes(File root) {

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VersionedDocumentationRenderer.groovy
@@ -122,6 +122,8 @@ class VersionedDocumentationRenderer {
         write(exactDirectory, logoTarget, logo)
 
         Map<String, String> javadocInputChecksums = copyModuleJavadocs(exactDirectory, moduleJavadocs)
+        if (!moduleJavadocs.isEmpty())
+            write(exactDirectory, 'api/index.md', apiIndex(version).getBytes(StandardCharsets.UTF_8))
 
         outputPaths.add('status.md')
         write(exactDirectory, 'status.md', statusRecord(version, status).getBytes(StandardCharsets.UTF_8))
@@ -241,7 +243,14 @@ class VersionedDocumentationRenderer {
     }
 
     private static String rootIndex(String version, String status) {
-        "# KlumAST documentation snapshot\n\nThis local render contains the immutable [$version](/$version/) documentation tree with status **$status**.\n"
+        "# KlumAST documentation snapshot\n\nThis local render contains the immutable [$version](/$version/) documentation tree with status **$status**.\n\n" +
+                "Its [isolated module API reference](/$version/api/) belongs to the same exact version.\n"
+    }
+
+    private static String apiIndex(String version) {
+        "# KlumAST $version API reference\n\n" +
+                'Each published module has a distinct Javadoc base. The BOM and IDE-only source mirrors are not API inputs.\n\n' +
+                MODULE_JAVADOCS.keySet().collect { module -> "- [$module](/$version/api/$module/)" }.join('\n') + '\n'
     }
 
     private static Map<String, String> outputHashes(File root) {

--- a/docs/implementation/evidence/issue-456-vd3-module-javadocs.md
+++ b/docs/implementation/evidence/issue-456-vd3-module-javadocs.md
@@ -1,0 +1,32 @@
+# #456 VD-3 isolated module-Javadoc evidence
+
+This is a sanitized, durable local record for the VD-3 implementation slice. It records
+only the external facts and local validation needed to review the slice; it excludes prompts,
+credentials, raw command output, host details, and inferred telemetry.
+
+## External contract evidence
+
+- [Issue #456](https://github.com/klum-dsl/klum-ast/issues/456) requires durable,
+  version-specific Javadocs for the 4.x multi-module product.
+- [ADR 0013](../../adr/0013-versioned-documentation-and-javadocs.md) fixes the six-module
+  set, `/&lt;version&gt;/api/&lt;module&gt;/` bases, and the BOM/mirror exclusions.
+- [PR #537](https://github.com/klum-dsl/klum-ast/pull/537) delivered the VD-1 renderer
+  contract that this slice extends without changing the release or Pages boundary.
+
+## VD-3 evidence boundary
+
+- The exact-version renderer invokes only the ordinary `javadoc` tasks for `klum-ast`,
+  `klum-ast-runtime`, `klum-ast-annotations`, `klum-ast-jackson`,
+  `klum-ast-bean-validation`, and `klum-ast-gradle-plugin`.
+- Each output is copied to its own `/&lt;version&gt;/api/&lt;module&gt;/` base and is linked from
+  the exact version's `/api/` landing. The BOM has no API base.
+- The renderer rejects a missing module output, a non-allowlisted input, a duplicate module
+  output, or an IDE-mirror page before creating an exact-version render. A failed module
+  `javadoc` task is a task dependency failure, so the renderer action cannot claim a
+  partially generated labelled result.
+
+## Local verification
+
+`verifyVersionedDocumentationRenderer` exercises the renderer fixture and all six standard
+module-Javadoc tasks. It checks representative public types, separate bases, module-task
+wiring, BOM/mirror exclusion, failure containment, and API navigation.

--- a/docs/user/Javadoc.md
+++ b/docs/user/Javadoc.md
@@ -6,6 +6,14 @@ factories and generated Builders. Their base documentation comes from the corres
 
 For schema-defined methods, the Javadoc is taken from the method itself.
 
+## Versioned API reference
+
+Every exact 4.x documentation render includes an `/&lt;version&gt;/api/` landing page with separate Javadoc bases for
+`klum-ast`, `klum-ast-runtime`, `klum-ast-annotations`, `klum-ast-jackson`,
+`klum-ast-bean-validation`, and `klum-ast-gradle-plugin`. Use the module base that owns the type rather than expecting a
+merged API namespace. The dependency-management BOM has no API reference, and AnnoDocimal IDE source mirrors are not
+compiled, packaged, or presented as published API.
+
 ## Templating
 
 The Javadocs of Builder base methods use templates to reduce boilerplate and customize the generated overloads.

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/LifecycleHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/LifecycleHelper.java
@@ -48,7 +48,7 @@ public class LifecycleHelper {
     /**
      * Executes all methods annotated with the given annotation on the rw instance of the proxy.
      * Also executes all closures annotated with the given annotation.
-     * @param proxy the proxy for which the lifecycle methods should be executed
+     * @param builder the Builder for which the lifecycle methods should be executed
      * @param annotation the annotation that marks the lifecycle methods and closures
      */
     public static void executeLifecycleMethods(InternalKlumBuilder<?> builder, Class<? extends Annotation> annotation) {
@@ -78,7 +78,7 @@ public class LifecycleHelper {
 
     /**
      * Executes all closures annotated with the given annotation on the DSL instance of the proxy.
-     * @param proxy The proxy for which the lifecycle closures should be executed
+     * @param builder The Builder for which the lifecycle closures should be executed
      * @param annotation the annotation that marks the lifecycle closures
      */
     public static void executeLifecycleClosures(InternalKlumBuilder<?> builder, Class<? extends Annotation> annotation) {


### PR DESCRIPTION
Related: #456

## What changed
- Generate isolated exact-version Javadocs for six published modules and link them from /<version>/api/.
- Enforce the fixed module allowlist and reject BOM, IDE mirrors, missing or merged module outputs, and revision mismatches.
- Record Javadoc checksums in the source manifest and repair stale runtime Javadoc parameter tags.
- Document the API layout and retain sanitized implementation evidence.

## Why
ADR 0013 VD-3 requires API references tied to the selected 4.x revision without merged namespaces or IDE-only inputs.

## Impact
Exact-version renders now fail before a partial labelled output if module Javadocs cannot be produced. No deployment, aliases, historical ingestion, publishing credentials, or release workflow is included.

## Validation
- ./gradlew test
- ./gradlew groovy4Tests groovy5Tests
- ./gradlew verifyVersionedDocumentationRenderer
- ./gradlew check
- Exact-SHA renderVersionedDocumentation with six API bases and manifest verification