### PR TITLE
Persist AFK policy and evidence contract

### DIFF
--- a/.agents/skills/work-orchestrator/SKILL.md
+++ b/.agents/skills/work-orchestrator/SKILL.md
@@ -30,6 +30,12 @@ Run each agent assignment in its own isolated worktree. Its branch, base revisio
 known before editing. Do not treat an agent worktree as an IDE-main replacement, and do not mix assignments in one
 worktree. Report the worktree path, branch, and final commit when handing an implementation or policy change back.
 
+Treat a proposed handoff as speculative until the Hive admits it. A handoff is reviewable only when it names the
+accepted contract or issue reference, the exact base revision, the bounded local-commit outcome, and the validation
+that will establish it. The completion record then names the worktree, branch, final commit, validation, and rebase
+status against that base. If the base moved, rebase and revalidate before handoff, or record the safe stop; never
+silently substitute a moving branch name for commit-addressable evidence.
+
 Prepare pull-request review in a separate detached worktree named `review-<PR>` (or an unambiguous equivalent), at
 the precise PR head commit being reviewed. Keep the review checkout detached so it cannot accidentally advance or
 replace a local branch. A review report must identify the PR, the detached worktree path, the reviewed head commit,
@@ -64,6 +70,11 @@ For every item, distinguish:
 
 An item is `ready` only when it is actionable, has no substantive open prerequisite, and no user-visible task is already doing that work. A `not ready` item names every material open prerequisite. Never mark an issue or release delivered solely because a task reported completion.
 
+Keep bounded research questions visible in the horizon as `research` candidates, separate from ready delivery work.
+Each names its question, authoritative evidence sources, and the decision owner. Evidence-only research is not an
+implementation admission unless its expected result is a safe, non-decisional local report or commit; research that
+could decide product, compatibility, architecture, classification, scope, or publication remains in the human queue.
+
 ### 3. Render dependencies for decisions
 
 Use a compact Mermaid dependency graph when several labeled relationships make the horizon easier to understand; use a table alone for one independent item or when a graph would be decorative. Edges always run from prerequisite to dependent. Each graph node and table row carries a stable short label, issue or other owning reference, concise title, and written execution state.
@@ -83,6 +94,13 @@ Give the new task the stable short label, callback ID, a bounded outcome, local 
 
 If a task fails to report, inspect its thread before inferring status. Reconcile every report against live evidence and explain only material changes.
 
+The Hive is the sole dispatcher and authoritative worker record for this horizon. It alone records admissions,
+capacity, and completion handoffs. A worker may retain permanent authority only for the explicitly scoped local
+operations in its assignment; it cannot dispatch ordinary work. The only permitted child work is explicitly declared
+two-axis local review: before it starts, the Hive names the child, the two review axes, its scope, and its capacity
+count; its start, result, validation, and stop condition are audited in the callback/evidence record. Undeclared,
+non-review, remote, or cross-repository children are prohibited.
+
 When a worker reaches `(ready:PR)`, its final callback must also contain a concise **review/change brief**. This is a review aid, not a file-by-file changelog. Include two to five outcome bullets; key files grouped as implementation, tests, and user-facing documentation (state `none` for an absent category); grouped minor or auxiliary changes; meaningful validation; and the review focus or compatibility risk (or explicit `none`). For simple work, the brief may be copied into the draft pull-request body. For complex work, it is the executive summary while the pull request retains the fuller rationale and evidence.
 
 ### 5. Triage cross-orchestrator impact
@@ -95,15 +113,15 @@ This is automatic triage, not authorization or work dispatch: never auto-start a
 
 ### 6. Run an explicitly bounded AFK window
 
-AFK mode is an exception to the normal no-auto-start rule, not a second orchestrator. Enter it only when the user explicitly supplies all of the following: a fixed duration or deadline, a capacity mode, and a maximum model/reasoning level. Render the active window and its ceiling visibly. A request that omits capacity is **passive reconciliation-only**, not permission to launch work.
+AFK mode is an exception to the normal no-auto-start rule, not a second orchestrator. Enter it only when the user explicitly supplies all of the following: a fixed duration or deadline, a capacity mode, and a maximum model/reasoning level. Render the active window and its ceiling visibly. An AFK window is one-shot and non-renewing: a later window requires a new explicit authorization. A request that omits capacity is **passive reconciliation-only**, not permission to launch work.
 
 Capacity is a ceiling on concurrently active implementation tasks: `passive` = 0, `low` = 1, `normal` = 2, and `high` = 3. A repository overlay may lower that number for its own risk, but may never raise it. Use the least costly model and reasoning level that fits each admitted task, never exceeding the declared ceiling.
 
-Before every launch, refresh the candidate's declared evidence sources and admit it only when the evidence is fresh, the work is already fully specified, and it belongs to the allowed task class: a bounded implementation or validation/documentation follow-up whose safe delivery boundary is a local commit. A candidate requiring a product, compatibility, architecture, classification, scope, or publication decision stays in the human queue. An empty admissible queue is valid and must remain idle.
+Before every launch, refresh the candidate's declared evidence sources and admit it only when the evidence is fresh, the work is already fully specified, and it belongs to the allowed task class: a bounded implementation or validation/documentation follow-up whose safe delivery boundary is a local commit. Evidence-only research is admissible only under the conditions stated in the horizon protocol. A candidate requiring a product, compatibility, architecture, classification, scope, or publication decision stays in the human queue. An empty admissible queue is valid and must remain idle. If quota/capacity data is not exposed, record it as `unavailable`; do not estimate it or admit additional work from an inference.
 
 Every admitted task is a fresh, user-visible worktree task with a stable short label, callback ID, bounded outcome, and the normal report protocol. It may create a local branch, edit, validate, review its local history, and commit. It must not use credentials or make any remote mutation: no push; PR or issue creation; comment, closure, label, milestone, or dependency change; merge, release, workflow dispatch; or equivalent remote action. Do not treat local commits as publication authorization.
 
-An unexpected decision, exception, ambiguous evidence, failed admission check, or policy conflict is a safe stop: launch no replacement work and return the candidate with its evidence and question to the human queue. At the deadline, on an early return from AFK, or when capacity is reduced, stop new launches, let already admitted work reach its safe local boundary, and then provide the complete handoff: task reports, local branch/commit state, validation, unresolved human queue, and every external condition.
+An unexpected decision, exception, ambiguous evidence, failed admission check, or policy conflict is a safe stop: launch no replacement work and return the candidate with its evidence and question to the human queue. At the deadline, on an early return from AFK, or when capacity is reduced, stop new launches, let already admitted work reach its safe local boundary, and then provide the complete handoff: task reports, local branch/commit state, validation, unresolved human queue, and every external condition. The Hive returns the full refreshed overview and reconciled decision matrix before it presents or considers further dispatch.
 
 Use the existing orchestrator and, when the platform supports it, exactly one one-shot deadline heartbeat for the AFK window. Do not create another orchestrator, a recurring automation, or a self-renewing heartbeat. On exit, the normal no-auto-start rule immediately resumes. Cross-orchestrator impact triage remains required, but during AFK it may only route non-blocking information; it cannot dispatch remote, cross-repository, or additional work.
 
@@ -129,7 +147,7 @@ When the report ends the last substantive worker, perform a mandatory **full ref
 
 For a release or other bounded run, require every created worker to write an append-only, machine-readable evidence event stream and to include the local evidence-stream location in its callback report. This applies to both active and finished user-visible workers; the orchestrator backfills no inferred history. Use the exact schema and minimal valid examples for a [worker finish](references/post-release-evidence.example.json) and [completion handoff](references/post-release-evidence.completion-handoff.example.json).
 
-Record only events observed by the worker or orchestrator. Assign stable opaque IDs to the release, run, worker, task, event, artifact, decision, and operation; use safe summaries, links, or artifact categories instead of copied content. Never auto-collect or store raw prompts, secrets, credentials, full command output, or inferred telemetry, including inferred token/quota pressure, active/wait time, cognition, or mental state. Record only observed safe summaries or references; use `unavailable` or an `audit_gap` event when the platform does not expose the data. Apply this boundary equally to completion-handoff refresh events.
+Record only events observed by the worker or orchestrator. Assign stable opaque IDs to the release, run, worker, task, event, artifact, decision, and operation; use safe summaries, links, or artifact categories instead of copied content. The schema's optional policy context records only safe mode, window, deadline, capacity, admission-stop, and contract/rebase/validation references. Never auto-collect or store raw prompts, secrets, credentials, full command output, or inferred telemetry, including inferred token/quota pressure, active/wait time, cognition, or mental state. Record only observed safe summaries or references; use `unavailable` or an `audit_gap` event when the platform does not expose the data. Apply this boundary equally to completion-handoff refresh events.
 
 Use append-only semantics: add a new event; never edit or delete an already-recorded one. Correct factual errors with a `correction` event that identifies the superseded event and replacement values. Redact unsafe detail with a `redaction` event that identifies the event/field and reason, preserves the audit trail, and replaces the detail with a safe category or stable reference. A correction or redaction must not silently rewrite timing, authorization, or outcome history.
 
@@ -175,6 +193,8 @@ Before handing off an overview or an orchestrator task, verify:
 - [ ] Cross-cutting candidates were routed once with the required evidence and ownership fields, then deduplicated by receivers without triggering work, GitHub writes, repository changes, or feedback loops.
 - [ ] Refreshing and rendering made no repository, tracker, project, PR, release, or task-state mutation beyond a user-authorized task lifecycle action.
 - [ ] An AFK window, when active, records an explicit deadline, capacity mode, and model/reasoning ceiling; admission evidence is fresh; every launched task is a local-only worktree task within the capacity cap; and no recurring automation or remote mutation was used.
+- [ ] Every speculative handoff is commit-addressable and records contract, base, worktree/branch, validation, and rebase status; the Hive returned a full overview before any further dispatch.
+- [ ] Every local-review child was declared by name with two review axes, counted against capacity, and audited; all other child dispatch is absent.
 - [ ] A release/run evidence stream exists outside the product repository for each created worker, has valid start/finish events or an explicit audit gap, and contains no prohibited sensitive content.
 - [ ] The release-close aggregation produces only a sanitized report and machine-readable summary for the proposed engineering-baseline/release-governance location; its measurements preserve unavailable/unknown states.
 

--- a/.agents/skills/work-orchestrator/SKILL.md
+++ b/.agents/skills/work-orchestrator/SKILL.md
@@ -133,6 +133,13 @@ On a user report or orchestrator refresh, verify relevant issue, PR, and merge s
 
 Where the repository has an archive-safe terminal state, workers must request Hive reconciliation; they must not self-archive or set that terminal state as part of normal completion. The Hive makes an explicit final reconciliation before applying it: assigned execution and delivery are complete; the audit/evidence record is complete or explicitly has no unfilled required fields; no local commit, tracker or PR update, external delivery, decision, human action, or task-scope condition remains. A completed or merged-delivery title alone is not sufficient. Retain the useful completed/delivery state in the final callback and, where practical, in the archive title or evidence record.
 
+When a worker stops at a safe boundary under the applicable `re` policy, it is neither completed nor blocked: use the
+repository's `(paused)` title state and say explicitly that it is **waiting for an explicit resume**. Its callback records
+the safe boundary, branch/commit, validation, unresolved condition, and the resume precondition. Do not clean up,
+reassign, or infer resumption from the passage of time. On entry to a later authorized AFK window, the Hive refreshes the
+paused worker's evidence and considers eligible paused workers before new candidates. A resume still requires fresh
+admission, capacity, and the explicit authorization required by the local overlay.
+
 ### 8. Present next work after worker completion
 
 Treat a **completed worker** as a worker that reports `COMPLETED` after finishing its assigned bounded execution scope. It is not an issue, pull request, or release delivery claim: an open PR, review, merge, credential, or release condition remains an external delivery condition. A `NOT READY` report, an unstarted task, and a worker whose bounded scope is still active are not completed workers.
@@ -195,6 +202,7 @@ Before handing off an overview or an orchestrator task, verify:
 - [ ] An AFK window, when active, records an explicit deadline, capacity mode, and model/reasoning ceiling; admission evidence is fresh; every launched task is a local-only worktree task within the capacity cap; and no recurring automation or remote mutation was used.
 - [ ] Every speculative handoff is commit-addressable and records contract, base, worktree/branch, validation, and rebase status; the Hive returned a full overview before any further dispatch.
 - [ ] Every local-review child was declared by name with two review axes, counted against capacity, and audited; all other child dispatch is absent.
+- [ ] A safe `re`-policy stop uses the repository's `(paused)` title, says it is waiting for explicit resume, and is considered before new AFK candidates after a fresh admission check.
 - [ ] A release/run evidence stream exists outside the product repository for each created worker, has valid start/finish events or an explicit audit gap, and contains no prohibited sensitive content.
 - [ ] The release-close aggregation produces only a sanitized report and machine-readable summary for the proposed engineering-baseline/release-governance location; its measurements preserve unavailable/unknown states.
 

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.completion-handoff.example.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.completion-handoff.example.json
@@ -5,6 +5,12 @@
   "release": {"release_id": "klum-ast-4.0", "reference": "release governance run"},
   "run": {"run_id": "run-4.0-next-policy", "callback_thread_id": "019f7046-f4fb-7e01-b527-33f2938da753"},
   "worker": {"worker_id": "worker-next-pol-orchestrator", "task_id": "task-next-pol"},
+  "policy_context": {
+    "mode": "afk",
+    "window_id": "afk-window-example-001",
+    "deadline": "2026-07-20T11:30:00Z",
+    "admission_stop": {"outcome": "stopped", "reason": "Window deadline reached; no further admission.", "candidate_reference": "next-work horizon"}
+  },
   "event_type": "orchestrator",
   "event": {
     "occurred_at": "2026-07-20T10:16:00Z",

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
@@ -5,6 +5,14 @@
   "release": {"release_id": "klum-ast-4.0", "reference": "release governance run"},
   "run": {"run_id": "run-4.0-evidence-policy", "callback_thread_id": "019f7046-f4fb-7e01-b527-33f2938da753"},
   "worker": {"worker_id": "worker-evid-pol", "task_id": "task-evid-pol"},
+  "policy_context": {
+    "mode": "afk",
+    "window_id": "afk-window-example-001",
+    "deadline": "2026-07-20T11:30:00Z",
+    "capacity": {"mode": "high", "model_reasoning_ceiling": "GPT-5.6 Terra/high", "active_task_limit": 3, "repository_task_limit": 2, "heavy_process_limit": 1, "quota_visibility": "unavailable"},
+    "admission_stop": {"outcome": "admitted", "candidate_reference": "AFK-PERSIST local policy candidate"},
+    "contract_rebase_validation": {"contract_reference": "accepted AFK policy", "base_revision": "c68d2757", "worktree_reference": "isolated local worktree", "branch": "codex/afk-persist-policy", "rebase_status": "not_needed", "validation_references": ["schema validation", "documentation diff check"]}
+  },
   "event_type": "worker_finished",
   "event": {
     "occurred_at": "2026-07-20T10:15:00Z",

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.example.json
@@ -11,6 +11,7 @@
     "deadline": "2026-07-20T11:30:00Z",
     "capacity": {"mode": "high", "model_reasoning_ceiling": "GPT-5.6 Terra/high", "active_task_limit": 3, "repository_task_limit": 2, "heavy_process_limit": 1, "quota_visibility": "unavailable"},
     "admission_stop": {"outcome": "admitted", "candidate_reference": "AFK-PERSIST local policy candidate"},
+    "pause": {"state": "resumed", "reason": "A prior safe re-policy pause was explicitly resumed.", "safe_boundary": "Commit-addressable local policy branch was revalidated.", "resume_authorization": "explicit_required"},
     "contract_rebase_validation": {"contract_reference": "accepted AFK policy", "base_revision": "c68d2757", "worktree_reference": "isolated local worktree", "branch": "codex/afk-persist-policy", "rebase_status": "not_needed", "validation_references": ["schema validation", "documentation diff check"]}
   },
   "event_type": "worker_finished",

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
@@ -78,6 +78,7 @@
         "deadline": {"$ref": "#/$defs/utcTimestamp"},
         "capacity": {"$ref": "#/$defs/capacity"},
         "admission_stop": {"$ref": "#/$defs/admissionStop"},
+        "pause": {"$ref": "#/$defs/pause"},
         "contract_rebase_validation": {"$ref": "#/$defs/contractRebaseValidation"}
       }
     },
@@ -109,6 +110,18 @@
           "then": {"required": ["reason"]}
         }
       ]
+    },
+    "pause": {
+      "description": "Safe record for a worker paused at a local stopping boundary; never records prompts or inferred state.",
+      "type": "object",
+      "required": ["state", "safe_boundary", "resume_authorization"],
+      "additionalProperties": false,
+      "properties": {
+        "state": {"enum": ["paused", "resumed"]},
+        "reason": {"$ref": "#/$defs/safeText"},
+        "safe_boundary": {"$ref": "#/$defs/safeText"},
+        "resume_authorization": {"const": "explicit_required"}
+      }
     },
     "contractRebaseValidation": {
       "type": "object",

--- a/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
+++ b/.agents/skills/work-orchestrator/references/post-release-evidence.schema.json
@@ -13,6 +13,7 @@
     "release": {"$ref": "#/$defs/release"},
     "run": {"$ref": "#/$defs/run"},
     "worker": {"$ref": "#/$defs/worker"},
+    "policy_context": {"$ref": "#/$defs/policyContext"},
     "event_type": {"enum": ["worker_started", "worker_finished", "orchestrator", "correction", "redaction"]},
     "event": {"type": "object"}
   },
@@ -64,6 +65,63 @@
         "worker_id": {"$ref": "#/$defs/stableId"},
         "task_id": {"$ref": "#/$defs/stableId"},
         "parent_worker_id": {"$ref": "#/$defs/stableId"}
+      }
+    },
+    "policyContext": {
+      "description": "Optional append-only, sanitized context for an admission or handoff; no prompts, secrets, raw command output, or inferred telemetry.",
+      "type": "object",
+      "required": ["mode"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"enum": ["ordinary", "afk", "evidence_only_research"]},
+        "window_id": {"$ref": "#/$defs/stableId"},
+        "deadline": {"$ref": "#/$defs/utcTimestamp"},
+        "capacity": {"$ref": "#/$defs/capacity"},
+        "admission_stop": {"$ref": "#/$defs/admissionStop"},
+        "contract_rebase_validation": {"$ref": "#/$defs/contractRebaseValidation"}
+      }
+    },
+    "capacity": {
+      "type": "object",
+      "required": ["mode", "model_reasoning_ceiling"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"$ref": "#/$defs/safeText"},
+        "model_reasoning_ceiling": {"$ref": "#/$defs/safeText"},
+        "active_task_limit": {"type": "integer", "minimum": 0},
+        "repository_task_limit": {"type": "integer", "minimum": 0},
+        "heavy_process_limit": {"type": "integer", "minimum": 0},
+        "quota_visibility": {"enum": ["observable", "unavailable"]}
+      }
+    },
+    "admissionStop": {
+      "type": "object",
+      "required": ["outcome"],
+      "additionalProperties": false,
+      "properties": {
+        "outcome": {"enum": ["admitted", "stopped", "not_applicable"]},
+        "reason": {"$ref": "#/$defs/safeText"},
+        "candidate_reference": {"$ref": "#/$defs/safeText"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"outcome": {"const": "stopped"}}},
+          "then": {"required": ["reason"]}
+        }
+      ]
+    },
+    "contractRebaseValidation": {
+      "type": "object",
+      "required": ["contract_reference", "base_revision", "rebase_status", "validation_references"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_reference": {"$ref": "#/$defs/safeText"},
+        "base_revision": {"$ref": "#/$defs/stableId"},
+        "worktree_reference": {"$ref": "#/$defs/safeText"},
+        "branch": {"$ref": "#/$defs/safeText"},
+        "final_revision": {"$ref": "#/$defs/stableId"},
+        "rebase_status": {"enum": ["not_needed", "validated", "stopped", "unavailable"]},
+        "validation_references": {"$ref": "#/$defs/safeTextList"}
       }
     },
     "model": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Non-archive-safe states:
 - `(ready:PR)` — committed work still needs pushing and/or pull-request creation.
 - `(PR:open)` — a pull request exists but is not verified merged, even if assigned implementation work is finished.
 - `(needs:changes)` — substantive adjustments remain, including pull-request stabilization or review fixes.
+- `(paused)` — the worker stopped at a safe boundary under the applicable `re` policy and is waiting for an explicit resume.
 - `(blocked)` — external input or state is required.
 
 Completed and delivery states:

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -53,9 +53,9 @@ upstream in
 [`blackbuild/engineering-baseline#2`](https://github.com/blackbuild/engineering-baseline/issues/2). The KlumAST-specific
 issue-tracker and authorization wording above remains local.
 
-The reusable AFK-window protocol is also a candidate for that same baseline issue. Its KlumAST overlay remains local:
-resource-sensitive concurrency reduction, license-policy hard stops, and human ownership of uncertain classification and
-all GitHub changes.
+The reusable AFK-window protocol, commit-addressable handoff, and safe evidence-context contract are also proposals for
+that same baseline issue. Its KlumAST overlay remains local: the exact burst/capacity limits, resource-sensitive
+concurrency reduction, license-policy hard stops, and human ownership of uncertain classification and all GitHub changes.
 
 When a KlumAST worker completes, apply the generic `work-orchestrator` completion-handoff protocol; this overlay does not
 authorize automatic follow-up work or change the root `AGENTS.md` delivery/archive states. In particular, a worker that
@@ -71,6 +71,32 @@ reviewed head commit, and the comparison base or range; implementation handoffs 
 branch, and final commit. Apply the generic skill's explicit, non-forced cleanup rules, while retaining worktrees when
 their delivery condition or investigation value remains active.
 
+## AFK-ADV-DEC local overlay
+
+The Hive is KlumAST's only dispatcher and authoritative record during an AFK burst. It may admit one non-renewing,
+90-minute window with at most three active tasks overall, at most two in this repository, and at most one
+heavy local process (for example, a full build or compatibility lane) at a time. The ceiling is GPT-5.6 Terra at
+`high` reasoning; a lower-cost model may be selected when it fits. A new window needs new explicit authorization;
+neither a heartbeat nor an early completion renews the burst.
+
+Admission is fresh and candidate-specific: the Hive must have a fully specified contract, evidence source, base revision,
+bounded local-commit output, and validation/rebase plan. It stops admission on the deadline, a capacity limit, unavailable
+quota/capacity visibility, an unexpected decision or exception, ambiguous or stale evidence, a failed check, a license
+policy conflict, or any request for remote state. It records the stop as `unavailable` or a safe evidence reference rather
+than estimating hidden quota or process state.
+
+The accepted permanent authority is local only: within its declared scope a worker may use an isolated worktree and branch,
+edit, validate, review local history, and create a local commit. It never authorizes credentials, push, GitHub changes,
+merge, release, workflow dispatch, or external evidence storage. The only children are declared two-axis local-review
+children. Before each child starts, the Hive records its name, both review axes, capacity count, local scope, and audit
+return; all other delegation is prohibited.
+
+Keep research candidates visible in the horizon with their evidence sources and human decision owner. AFK research is
+evidence-only only when the question and sources are fully specified, the result cannot decide product/compatibility/
+architecture/classification/scope/publication, and its stopping boundary is a safe local report or commit. Otherwise it
+waits in the human queue. At every AFK return, the Hive first produces the full refreshed overview and reconciled matrix;
+it does not use the return as authority to dispatch another task.
+
 ## Post-release orchestration evidence overlay
 
 For KlumAST 4.0, every cross-orchestrator evidence stream must carry stable `release_id` `klum-ast-4.0` and a distinct
@@ -83,4 +109,6 @@ Keep runtime records outside the KlumAST checkout, organized by release/run. A r
 sanitized human-reviewable report plus machine-readable summary for the engineering-baseline/release-governance location.
 This policy does not authorize creating that store, automating collection, or mutating this product repository, its
 tracker, or its remotes to gather evidence. Preserve KlumAST's normal human ownership of classification, GitHub changes,
-and publication authority.
+and publication authority. When a per-run store is explicitly authorized, use the reusable schema's safe append-only
+policy context for mode, window, deadline, capacity, admission stop, and contract/base/rebase/validation references; do
+not add prompts, secrets, credentials, raw command output, inferred quota, or inferred cognition.

--- a/docs/agents/short-term-backlog.md
+++ b/docs/agents/short-term-backlog.md
@@ -97,6 +97,12 @@ architecture/classification/scope/publication, and its stopping boundary is a sa
 waits in the human queue. At every AFK return, the Hive first produces the full refreshed overview and reconciled matrix;
 it does not use the return as authority to dispatch another task.
 
+If a KlumAST worker stops at a safe boundary under the applicable `re` policy, title it `(paused)` and state that it is
+waiting for an explicit resume. Its callback preserves the safe branch/commit/validation boundary and the precise resume
+precondition; a pause is not completion, cancellation, or cleanup authorization. When entering another authorized AFK
+window, the Hive refreshes and considers eligible paused workers before new candidates. It may resume one only after the
+normal fresh-admission and capacity checks still pass.
+
 ## Post-release orchestration evidence overlay
 
 For KlumAST 4.0, every cross-orchestrator evidence stream must carry stable `release_id` `klum-ast-4.0` and a distinct


### PR DESCRIPTION
## Summary

- Make speculative orchestration handoffs commit-addressable, with contract/base/worktree/branch/validation/rebase evidence.
- Persist the KlumAST AFK-ADV-DEC overlay: one 90-minute non-renewing burst, 3 total / 2 repository / 1 heavy-process limits, and a Terra/high ceiling.
- Add privacy-preserving append-only policy context to the orchestration evidence schema and examples.
- Define the `(paused)` safe-stop lifecycle and require explicit resume; later AFK windows consider eligible paused workers before new candidates.

## Why

The accepted AFK policy needs a local, reviewable source of truth without granting remote operations or creating a runtime evidence store.

## Impact

The reusable orchestration protocol gains safe, optional policy-context references. KlumAST-specific burst limits, local-only authority, license stops, and GitHub ownership remain repository-local. No runtime behavior or product API changes.

## Validation

- `git diff --check`
- JSON parsing for the schema and both examples
- Focused `jq` assertions for the policy context, 3/2/1 capacity limits, handoff/rebase references, stopped admission, and explicit paused/resumed state.

## Review focus

Confirm that the reusable protocol remains generic while the exact KlumAST limits stay in the local overlay. The optional schema context is additive; any downstream consumer that needs it mandatory should use a deliberate versioned migration.
Also confirm that resumption is considered before new AFK candidates, but remains conditional on fresh admission, capacity, and explicit authorization.
