### PR TITLE
Clarify validation subtree results API

### DIFF
--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/util/KlumObjectSupport.java
@@ -135,7 +135,7 @@ public final class KlumObjectSupport<T> {
          * Returns stored validation results for this object and its owned composition subtree.
          * Owner and {@code LINK} fields are not followed.
          */
-        public List<KlumValidationResult> getResults() {
+        public List<KlumValidationResult> getSubtreeResults() {
             List<KlumValidationResult> results = new ArrayList<>();
             KlumObjectSupport.of(object).getStructure().visit((path, element, container, nameOfFieldInContainer) -> {
                 KlumValidationResult result = InternalKlumObjectSupport.getValidationResult(element);
@@ -153,7 +153,7 @@ public final class KlumObjectSupport<T> {
         /** Verifies stored subtree results using {@code failLevel}. */
         public List<KlumValidationResult> verify(Validate.Level failLevel) throws KlumValidationException {
             Objects.requireNonNull(failLevel, "failLevel");
-            List<KlumValidationResult> results = getResults();
+            List<KlumValidationResult> results = getSubtreeResults();
             KlumValidationResult.throwOn(results, failLevel);
             return results;
         }

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/validation/Validator.java
@@ -50,12 +50,12 @@ public class Validator {
      *
      * @param instance the instance to validate the structure of. Must be a DSL object.
      * @return a list of {@link KlumValidationResult} containing validation errors.
-     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().getResults()}
+     * @deprecated use {@code KlumObjectSupport.of(instance).getValidation().getSubtreeResults()}
      */
     @Deprecated(forRemoval = true)
     @SuppressWarnings("java:S1133") // source-compatible OS-2 migration adapter
     public static List<KlumValidationResult> getValidationResultsFromStructure(Object instance) {
-        return KlumObjectSupport.of(instance).getValidation().getResults();
+        return KlumObjectSupport.of(instance).getValidation().getSubtreeResults();
     }
 
     /**

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumObjectSupportSpec.groovy
@@ -33,6 +33,7 @@ import com.blackbuild.klum.ast.util.layer3.StructureUtil
 import com.blackbuild.klum.ast.validation.KlumValidationResult
 import com.blackbuild.klum.ast.validation.Validator
 import org.jetbrains.annotations.NotNull
+import spock.lang.Issue
 
 import javax.tools.ToolProvider
 import java.lang.reflect.Modifier
@@ -60,7 +61,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         support.modelPath
         support.structure.findAll(clazz)
         def storedResult = support.validation.result
-        support.validation.results
+        support.validation.subtreeResults
         def bytes = new ByteArrayOutputStream()
         new ObjectOutputStream(bytes).withCloseable { it.writeObject(instance) }
         def dynamicLoader = loader
@@ -143,7 +144,8 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
         ''', 'cannot find symbol')
     }
 
-    def "validation support includes clean stored results without rerunning validation"() {
+    @Issue("549")
+    def "validation support distinguishes its result from subtree results without rerunning validation"() {
         given:
         createClass '''
             @DSL class Root {
@@ -196,9 +198,9 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
 
         when:
         def result = support.validation.result
-        def results = support.validation.results
+        def subtreeResults = support.validation.subtreeResults
         def deprecatedResults = Validator.getValidationResultsFromStructure(instance)
-        def subtreeResults = childSupport.validation.results
+        def childSubtreeResults = childSupport.validation.subtreeResults
         def verified = support.validation.verify()
         compileJavaConsumer('''
             import com.blackbuild.groovy.configdsl.transform.Validate;
@@ -210,7 +212,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
                 public static void inspect(Root root) {
                     KlumObjectSupport.Validation<Root> validation = KlumObjectSupport.of(root).getValidation();
                     KlumValidationResult result = validation.getResult();
-                    List<KlumValidationResult> results = validation.getResults();
+                    List<KlumValidationResult> subtreeResults = validation.getSubtreeResults();
                     List<KlumValidationResult> verified = validation.verify();
                     validation.verify(Validate.Level.WARNING);
                 }
@@ -219,10 +221,12 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
 
         then:
         result.is(storedRootResult)
-        results == [storedRootResult, storedChildResult, storedCleanResult]
-        deprecatedResults == results
-        subtreeResults == [storedChildResult]
-        verified == results
+        subtreeResults == [storedRootResult, storedChildResult, storedCleanResult]
+        deprecatedResults == subtreeResults
+        childSubtreeResults == [storedChildResult]
+        verified == subtreeResults
+        KlumObjectSupport.Validation.declaredMethods*.name.contains('getSubtreeResults')
+        !KlumObjectSupport.Validation.declaredMethods*.name.contains('getResults')
         Root.validationCalls == 1
         Child.validationCalls == 1
         CleanChild.validationCalls == 1
@@ -235,7 +239,7 @@ class KlumObjectSupportSpec extends AbstractDSLSpec {
 
         then:
         def error = thrown(KlumValidationException)
-        error.validationResults == results
+        error.validationResults == subtreeResults
         Root.validationCalls == 1
         Child.validationCalls == 1
         CleanChild.validationCalls == 1


### PR DESCRIPTION
## Summary

- Rename `KlumObjectSupport.Validation.getResults()` to `getSubtreeResults()`.
- Keep `getResult()` for the support object's own result; update `verify()` and the deprecated `Validator` adapter to use the subtree-result name.
- Exercise the Java and Groovy consumers in the focused validation fixture, including an assertion that no legacy bridge remains.

## Accepted API

The accepted #549 API distinguishes the result for the current object from the results in its owned composition subtree:

```java
validation.getResult();
validation.getSubtreeResults();
```

The clean pre-RC rename intentionally includes no `getResults()` compatibility bridge.

No user-facing documentation, migration content, or release notes were changed in this focused API PR. Coordinate the resulting content updates with #544.

## Compatibility

`KlumObjectSupport.Validation` is absent from v3.0.1, so no released 3.x caller uses this method. The clean rename intentionally breaks developer-snapshot callers of `getResults()`; it establishes the accepted 4.0 public contract.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.groovy.configdsl.transform.KlumObjectSupportSpec`
- `./gradlew :klum-ast:groovy4Tests --tests com.blackbuild.groovy.configdsl.transform.KlumObjectSupportSpec`
- `./gradlew :klum-ast:groovy5Tests --tests com.blackbuild.groovy.configdsl.transform.KlumObjectSupportSpec`
- `./gradlew :klum-ast-runtime:javadoc`
