### PR TITLE
Verify staged Pages manifest after push

### DIFF
--- a/.github/workflows/publish-pending-documentation.yml
+++ b/.github/workflows/publish-pending-documentation.yml
@@ -220,7 +220,9 @@ jobs:
       - name: Write and read back the immutable gh-pages commit
         env:
           DEPLOYMENT_COMMIT: ${{ steps.pages.outputs.deployment_commit }}
+          EXACT_PATH: ${{ steps.handoff.outputs.exact_path }}
           PAGES_WRITER_TOKEN: ${{ steps.pages-writer-token.outputs.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -229,6 +231,11 @@ jobs:
           git -C pages fetch --no-tags origin gh-pages
           test "$(git -C pages rev-parse FETCH_HEAD)" = "$DEPLOYMENT_COMMIT"
           git -C pages diff --quiet "$DEPLOYMENT_COMMIT" FETCH_HEAD
+          staged_manifest="build/pending-documentation/$RELEASE_VERSION/site-manifest.json"
+          written_manifest="$(mktemp)"
+          trap 'rm -f "$written_manifest"' EXIT
+          git -C pages show "FETCH_HEAD:${EXACT_PATH}site-manifest.json" > "$written_manifest"
+          cmp -- "$staged_manifest" "$written_manifest"
       - name: Upload the read-back-verified gh-pages ledger
         uses: actions/upload-pages-artifact@v4
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -122,12 +122,13 @@ state that this is unlisted release-gate evidence, never a public RC, stable pag
 
 The Pages job writes the rendered static HTML, local assets, exact Javadocs, `site-manifest.json`,
 and a small handoff below the protected `gh-pages` branch. It refuses an existing pending path,
-commits the new tree, and reads the pushed commit back before uploading that exact ledger with
-`actions/upload-pages-artifact` and deploying it with `actions/deploy-pages`. Its only outputs to
-the artifact workflow are `stage`, `version`, `sha`, exact path, site-manifest SHA-256, immutable
-`gh-pages` commit, Pages run/attempt identity, and reported page URL. The artifact job rechecks every
-value before it can invoke `publishCompleteKlumAstProduct`. The Pages jobs have no artifact
-credentials; the artifact job has no permission to alter the Pages tree.
+commits the new tree, and reads the pushed commit back. The staged render remains available until its
+`site-manifest.json` is byte-identical to the manifest read from that fetched ledger commit. Only then
+does it upload that exact ledger with `actions/upload-pages-artifact` and deploy it with
+`actions/deploy-pages`. Its only outputs to the artifact workflow are `stage`, `version`, `sha`, exact
+path, site-manifest SHA-256, immutable `gh-pages` commit, Pages run/attempt identity, and reported
+page URL. The artifact job rechecks every value before it can invoke `publishCompleteKlumAstProduct`.
+The Pages jobs have no artifact credentials; the artifact job has no permission to alter the Pages tree.
 
 For a final, the selected source revision must include
 `docs/branding/final-approval.json`. That approval is bound to the exact branding-manifest path

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -337,6 +337,22 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(pagesWorkflow, 'actions/create-github-app-token@v1', 'gh-pages writes must use the dedicated Pages writer App')
         assertContains(pagesWorkflow, 'PAGES_WRITER_TOKEN', 'the dedicated App token must be used only for gh-pages writes')
         assertTrue(!pagesWorkflow.contains('git push origin HEAD:gh-pages'), 'the workflow token must not write the Pages ledger directly')
+        String stagedCopy = 'cp -a "build/pending-documentation/$RELEASE_VERSION/." "pages/$EXACT_PATH"'
+        String stagedManifest = 'staged_manifest="build/pending-documentation/$RELEASE_VERSION/site-manifest.json"'
+        String fetchedManifest = 'git -C pages show "FETCH_HEAD:${EXACT_PATH}site-manifest.json" > "$written_manifest"'
+        String manifestComparison = 'cmp -- "$staged_manifest" "$written_manifest"'
+        assertContains(pagesWorkflow, stagedCopy, 'the rendered pending snapshot must be copied into the ledger')
+        assertContains(pagesWorkflow, fetchedManifest, 'the manifest comparison must read the fetched ledger commit')
+        assertTrue(!pagesWorkflow.contains('mv "build/pending-documentation/$RELEASE_VERSION/."'),
+                'the staged pending snapshot must remain available for read-back verification')
+        assertTrue(pagesWorkflow.indexOf(stagedCopy) < pagesWorkflow.indexOf(stagedManifest),
+                'the staged snapshot must be copied before its manifest is retained for read-back')
+        assertTrue(pagesWorkflow.indexOf('test "$(git -C pages rev-parse FETCH_HEAD)" = "$DEPLOYMENT_COMMIT"') < pagesWorkflow.indexOf(manifestComparison),
+                'the fetched ledger identity must be verified before its manifest is compared')
+        assertTrue(pagesWorkflow.indexOf(fetchedManifest) < pagesWorkflow.indexOf(manifestComparison),
+                'the manifest comparison must use bytes read from the fetched ledger')
+        assertTrue(pagesWorkflow.indexOf(stagedManifest) < pagesWorkflow.indexOf(manifestComparison),
+                'the staged manifest must remain available until post-push byte comparison completes')
         assertTrue(!pagesWorkflow.contains('publishCompleteKlumAstProduct'), 'Pages workflow must not publish artifacts')
         String releaseWorkflow = new File(project.rootDir, '.github/workflows/release.yml').text
         assertContains(releaseWorkflow, 'stage-pending-documentation', 'artifact workflow must require the pending Pages stage')


### PR DESCRIPTION
## Summary

- Retain the staged pending render until its manifest is compared with bytes read from fetched `gh-pages`.
- Lock the copy/no-move/fetched-manifest/read-back ordering in the static workflow contract.
- Document the post-push manifest identity check.

## Scope

Related: #456.

This pull request does not configure GitHub Pages, environments, Apps, credentials, branch rules, aliases, releases, or tags.

## Validation

- `./gradlew verifyVersionedDocumentationRenderer groovy4Tests groovy5Tests`
- `git diff --check`
