### PR TITLE
Migrate KlumAST custom checks to the KlumCast Check SPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ This is a breaking release. See the [Builder-first construction migration](docs/
   own documentation ([#461](https://github.com/klum-dsl/klum-ast/issues/461)). Final AnnoDocimal 1.0 remains a KlumAST
   final-release prerequisite; this change validates the immutable RC train only.
 - Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0.
-- Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
+- Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes. Invalid `@Overwrite.Single(MERGE)` strategies on non-DSL fields are rejected during compilation ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
 
 ## Builder-first construction
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@ This is a breaking release. See the [Builder-first construction migration](docs/
   property documentation is projected verbatim to generated Model and Builder accessors unless an accessor supplies its
   own documentation ([#461](https://github.com/klum-dsl/klum-ast/issues/461)). Final AnnoDocimal 1.0 remains a KlumAST
   final-release prerequisite; this change validates the immutable RC train only.
-- Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0. Existing name-bound custom checks continue through KlumCast's temporary 0.4 migration bridge; #460 owns their durable SPI migration.
+- Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0.
+- Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
 
 ## Builder-first construction
 

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -20,8 +20,9 @@ KlumAST 4.0 uses the immutable KlumCast `0.4.0-rc.2` artifact set: `klum-cast-an
 `com.blackbuild.klum.cast.spi`, and `com.blackbuild.klum.cast.compiler`; do not substitute filename-derived names or use
 local module-path flags to compensate for an invalid dependency graph.
 
-Recompile schemas and custom checks when moving to KlumAST 4.0. Existing name-bound custom checks remain supported by
-KlumCast's temporary 0.4 migration bridge. Their migration to the durable check SPI is tracked by [#460](https://github.com/klum-dsl/klum-ast/issues/460), not by this dependency integration.
+Recompile schemas and custom checks when moving to KlumAST 4.0. KlumAST's built-in name-bound checks use KlumCast's
+durable stateless `Check` SPI and report structured, source-positioned diagnostics. Custom checks must implement that SPI;
+the deprecated compatibility adapter is only a temporary migration aid for external consumers ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
 
 ## To 2.2
 

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
@@ -64,6 +64,8 @@ public class FieldAstValidator implements Check {
     }
 
     protected Diagnostic extraValidateMethod(AnnotationNode annotationToCheck, MethodNode target) {
+        if (target == null)
+            return null;
         if (getFieldType(target) == FieldType.LINK && annotationToCheck.getMember(DEFAULT_IMPL_MEMBER) != null)
             return violation(annotationToCheck, "Default Implementation is not allowed on LINK fields");
         if (target.getParameters().length == 0)

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
@@ -24,96 +24,109 @@
 package com.blackbuild.groovy.configdsl.transform.ast;
 
 import com.blackbuild.groovy.configdsl.transform.FieldType;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import com.blackbuild.klum.common.CommonAstHelper;
 import org.codehaus.groovy.ast.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
 import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.*;
 import static com.blackbuild.klum.common.CommonAstHelper.*;
 import static java.lang.reflect.Modifier.isFinal;
 
 @SuppressWarnings("unused") // see Field
-public class FieldAstValidator extends KlumCastCheck<Annotation> {
+public class FieldAstValidator implements Check {
 
     private static final String DEFAULT_IMPL_MEMBER = "defaultImpl";
 
-    private AnnotationNode annotationToCheck;
-
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
-        this.annotationToCheck = annotationToCheck;
+    public List<Diagnostic> check(CheckContext context) {
+        AnnotationNode annotationToCheck = context.getValidatedAnnotation();
+        AnnotatedNode target = context.getTarget();
+        Diagnostic diagnostic = null;
         if (target instanceof FieldNode)
-            extraValidateField((FieldNode) target);
+            diagnostic = extraValidateField(annotationToCheck, (FieldNode) target);
         else if (target instanceof MethodNode)
-            extraValidateMethod((MethodNode) target);
+            diagnostic = extraValidateMethod(annotationToCheck, (MethodNode) target);
+        return diagnostic == null ? List.of() : List.of(diagnostic);
     }
 
-    protected void extraValidateField(FieldNode fieldNode) {
+    protected Diagnostic extraValidateField(AnnotationNode annotationToCheck, FieldNode fieldNode) {
+        Diagnostic diagnostic;
         if (isCollectionOrMap(fieldNode.getType()))
-            validateFieldAnnotationOnCollection();
+            diagnostic = validateFieldAnnotationOnCollection(annotationToCheck);
         else
-            validateFieldAnnotationOnSingleField(fieldNode);
-        validateDefaultImpl(CommonAstHelper.getElementType(fieldNode));
+            diagnostic = validateFieldAnnotationOnSingleField(annotationToCheck, fieldNode);
+        return diagnostic == null ? validateDefaultImpl(annotationToCheck, CommonAstHelper.getElementType(fieldNode)) : diagnostic;
     }
 
-    protected void extraValidateMethod(MethodNode target) {
+    protected Diagnostic extraValidateMethod(AnnotationNode annotationToCheck, MethodNode target) {
         if (getFieldType(target) == FieldType.LINK && annotationToCheck.getMember(DEFAULT_IMPL_MEMBER) != null)
-            throw new IllegalStateException("Default Implementation is not allowed on LINK fields");
-        validateDefaultImpl(target.getParameters()[0].getType());
+            return violation(annotationToCheck, "Default Implementation is not allowed on LINK fields");
+        return validateDefaultImpl(annotationToCheck, target.getParameters()[0].getType());
     }
 
-    private void validateDefaultImpl(ClassNode fieldType) {
-        if (annotationToCheck.getMember(DEFAULT_IMPL_MEMBER) == null) return;
+    private Diagnostic validateDefaultImpl(AnnotationNode annotationToCheck, ClassNode fieldType) {
+        if (annotationToCheck.getMember(DEFAULT_IMPL_MEMBER) == null) return null;
 
         @NotNull ClassNode defaultImpl = getNullSafeClassMember(annotationToCheck, DEFAULT_IMPL_MEMBER, null);
 
         if (isFinal(fieldType.getModifiers()))
-            throw new IllegalStateException(String.format(
-                   "annotated field %s is final and cannot be overridden.",
+            return violation(annotationToCheck, String.format(
+                    "annotated field %s is final and cannot be overridden.",
                     fieldType.getName())
             );
 
         if (!isDSLObject(defaultImpl))
-            throw new IllegalStateException(
+            return violation(annotationToCheck,
                     "Default Implementation must be an DSL-Object"
-            ) ;
+            );
 
         if (!isAssignableTo(defaultImpl, fieldType))
-            throw new IllegalStateException(String.format(
+            return violation(annotationToCheck, String.format(
                 "Annotated Default Implementation %s of %s is not a valid subtype of it.", defaultImpl.getName(), fieldType.getName()
             ));
 
         if (getFieldType(fieldType) == FieldType.LINK)
-            throw new IllegalStateException("Default Implementation is not allowed on LINK fields");
+            return violation(annotationToCheck, "Default Implementation is not allowed on LINK fields");
 
         if (isDSLObject(fieldType) && isKeyed(defaultImpl) && !isKeyed(fieldType))
-            throw new IllegalStateException(
+            return violation(annotationToCheck,
                     String.format("Default Implementation %s is keyed, but field %s is not.",
                             defaultImpl.getName(), fieldType.getName()));
 
         if (!isInstantiable(defaultImpl))
-            throw new IllegalStateException(
+            return violation(annotationToCheck,
                     String.format("Default Implementation %s is not instantiable.", defaultImpl.getName())
             );
+
+        return null;
     }
 
-    private void validateFieldAnnotationOnSingleField(FieldNode fieldNode) {
+    private Diagnostic validateFieldAnnotationOnSingleField(AnnotationNode annotationToCheck, FieldNode fieldNode) {
         if (annotationToCheck.getMembers().containsKey("members"))
-            throw new IllegalStateException(String.format("@Field.members is only valid for List or Map fields, but field %s is of type %s", fieldNode.getName(), fieldNode.getType().getName()));
+            return violation(annotationToCheck, String.format("@Field.members is only valid for List or Map fields, but field %s is of type %s", fieldNode.getName(), fieldNode.getType().getName()));
 
         if (annotationToCheck.getMembers().containsKey("key") && !isKeyed(fieldNode.getType()))
-            throw new IllegalStateException("@Field.key is only valid for keyed dsl fields");
+            return violation(annotationToCheck, "@Field.key is only valid for keyed dsl fields");
 
         if (annotationToCheck.getMembers().containsKey("keyMapping") && !isMap(fieldNode.getType()))
-            throw new IllegalStateException("@Field.keyMapping is only valid for Map fields");
+            return violation(annotationToCheck, "@Field.keyMapping is only valid for Map fields");
+
+        return null;
     }
 
-    private void validateFieldAnnotationOnCollection() {
+    private Diagnostic validateFieldAnnotationOnCollection(AnnotationNode annotationToCheck) {
         if (annotationToCheck.getMembers().containsKey("key"))
-            throw new IllegalStateException("@Field.key is only allowed for non collection fields.");
+            return violation(annotationToCheck, "@Field.key is only allowed for non collection fields.");
+        return null;
+    }
+
+    private Diagnostic violation(AnnotationNode annotationToCheck, String message) {
+        return new Diagnostic(getClass().getName(), message, annotationToCheck);
     }
 
 }

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/FieldAstValidator.java
@@ -66,6 +66,8 @@ public class FieldAstValidator implements Check {
     protected Diagnostic extraValidateMethod(AnnotationNode annotationToCheck, MethodNode target) {
         if (getFieldType(target) == FieldType.LINK && annotationToCheck.getMember(DEFAULT_IMPL_MEMBER) != null)
             return violation(annotationToCheck, "Default Implementation is not allowed on LINK fields");
+        if (target.getParameters().length == 0)
+            return null;
         return validateDefaultImpl(annotationToCheck, target.getParameters()[0].getType());
     }
 

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
@@ -41,7 +41,9 @@ public class WriteAccessMethodCheck implements Check {
         if (method.isPrivate())
             return List.of(new Diagnostic(getClass().getName(), "Lifecycle methods must not be private!", context.getValidatedAnnotation()));
 
-        if (context.getControlAnnotation(WriteAccess.class).map(WriteAccess::value).orElse(null) == WriteAccess.Type.LIFECYCLE && method.getParameters().length > 0)
+        if (context.getControlAnnotation(WriteAccess.class)
+                .orElseThrow(() -> new IllegalStateException("WriteAccessMethodCheck requires a WriteAccess control annotation"))
+                .value() == WriteAccess.Type.LIFECYCLE && method.getParameters().length > 0)
             return List.of(new Diagnostic(getClass().getName(), String.format(
                 "Method %s.%s is annotated with @WriteAccess(LIFECYCLE) but has parameters",
                 method.getDeclaringClass().getName(),

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
@@ -27,8 +27,6 @@ import com.blackbuild.groovy.configdsl.transform.WriteAccess;
 import com.blackbuild.klum.cast.spi.Check;
 import com.blackbuild.klum.cast.spi.CheckContext;
 import com.blackbuild.klum.cast.spi.Diagnostic;
-import org.codehaus.groovy.ast.AnnotatedNode;
-import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.MethodNode;
 
 import java.util.List;

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/mutators/WriteAccessMethodCheck.java
@@ -24,26 +24,30 @@
 package com.blackbuild.groovy.configdsl.transform.ast.mutators;
 
 import com.blackbuild.groovy.configdsl.transform.WriteAccess;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.MethodNode;
 
-import static java.util.Objects.requireNonNull;
+import java.util.List;
 
-public class WriteAccessMethodCheck extends KlumCastCheck<WriteAccess> {
+public class WriteAccessMethodCheck implements Check {
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
-        MethodNode method = (MethodNode) target;
+    public List<Diagnostic> check(CheckContext context) {
+        MethodNode method = (MethodNode) context.getTarget();
 
         if (method.isPrivate())
-            throw new IllegalStateException("Lifecycle methods must not be private!");
+            return List.of(new Diagnostic(getClass().getName(), "Lifecycle methods must not be private!", context.getValidatedAnnotation()));
 
-        if (requireNonNull(controlAnnotation).value() == WriteAccess.Type.LIFECYCLE && method.getParameters().length > 0)
-            throw new IllegalStateException(String.format(
-                    "Method %s.%s is annotated with @WriteAccess(LIFECYCLE) but has parameters",
-                    method.getDeclaringClass().getName(),
-                    method.getName()
-            ));
+        if (context.getControlAnnotation(WriteAccess.class).map(WriteAccess::value).orElse(null) == WriteAccess.Type.LIFECYCLE && method.getParameters().length > 0)
+            return List.of(new Diagnostic(getClass().getName(), String.format(
+                "Method %s.%s is annotated with @WriteAccess(LIFECYCLE) but has parameters",
+                method.getDeclaringClass().getName(),
+                method.getName()
+            ), context.getValidatedAnnotation()));
+
+        return List.of();
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
@@ -27,7 +27,6 @@ import com.blackbuild.klum.ast.util.layer3.annotations.DefaultValues;
 import com.blackbuild.klum.cast.spi.Check;
 import com.blackbuild.klum.cast.spi.CheckContext;
 import com.blackbuild.klum.cast.spi.Diagnostic;
-import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/util/layer3/DefaultValuesCheck.java
@@ -24,29 +24,34 @@
 package com.blackbuild.klum.ast.util.layer3;
 
 import com.blackbuild.klum.ast.util.layer3.annotations.DefaultValues;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
-import com.blackbuild.klum.cast.checks.impl.ValidationException;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
-public class DefaultValuesCheck extends KlumCastCheck<Annotation> {
+public class DefaultValuesCheck implements Check {
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) throws ValidationException {
-        boolean controlAnnotationHasValuesMapping = controlAnnotation instanceof DefaultValues
-                && !((DefaultValues) controlAnnotation).valueTarget().isEmpty();
+    public List<Diagnostic> check(CheckContext context) {
+        boolean controlAnnotationHasValuesMapping = context.getControlAnnotation(DefaultValues.class)
+                .map(DefaultValues::valueTarget)
+                .filter(valueTarget -> !valueTarget.isEmpty())
+                .isPresent();
+        AnnotationNode annotationToCheck = context.getValidatedAnnotation();
         ClassNode targetAnnotation = annotationToCheck.getClassNode();
         boolean targetAnnotationHasValueMember = !targetAnnotation.getMethods("value").isEmpty();
 
         if (controlAnnotationHasValuesMapping && !targetAnnotationHasValueMember)
-            throw new ValidationException(
-                String.format("DefaultValues has a 'valueTarget' member, but the target annotation %s does not have a 'value' member", targetAnnotation.getName()), target);
+            return List.of(new Diagnostic(getClass().getName(),
+                String.format("DefaultValues has a 'valueTarget' member, but the target annotation %s does not have a 'value' member", targetAnnotation.getName()), context.getTarget()));
 
         if (!controlAnnotationHasValuesMapping && targetAnnotationHasValueMember)
-            throw new ValidationException(
-                String.format("Target annotation %s does have a 'value' member, but DefaultValues does not have a 'valueTarget' member", targetAnnotation.getName()), target);
+            return List.of(new Diagnostic(getClass().getName(),
+                String.format("Target annotation %s does have a 'value' member, but DefaultValues does not have a 'valueTarget' member", targetAnnotation.getName()), context.getTarget()));
 
+        return List.of();
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckDslAnnotation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckDslAnnotation.java
@@ -24,27 +24,35 @@
 package com.blackbuild.klum.ast.validation;
 
 import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
 import static com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper.isDSLObject;
 import static com.blackbuild.klum.common.CommonAstHelper.getNullSafeClassMember;
 import static com.blackbuild.klum.common.CommonAstHelper.isAssignableTo;
 
-public class CheckDslAnnotation extends KlumCastCheck<Annotation> {
+public class CheckDslAnnotation implements Check {
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
+    public List<Diagnostic> check(CheckContext context) {
+        AnnotationNode annotationToCheck = context.getValidatedAnnotation();
         ClassNode defaultImpl = getNullSafeClassMember(annotationToCheck, "defaultImpl", null);
-        if (defaultImpl == null) return;
-        if (!isAssignableTo(defaultImpl, (ClassNode) target))
-            throw new IllegalStateException("defaultImpl must be a subtype of the annotated class!");
+        if (defaultImpl == null) return List.of();
+        if (!isAssignableTo(defaultImpl, (ClassNode) context.getTarget()))
+            return violation(context, "defaultImpl must be a subtype of the annotated class!");
         if (!isDSLObject(defaultImpl))
-            throw new IllegalStateException("defaultImpl must be a DSLObject!");
+            return violation(context, "defaultImpl must be a DSLObject!");
         if (!DslAstHelper.isInstantiable(defaultImpl))
-            throw new IllegalStateException("defaultImpl must be instantiable!");
+            return violation(context, "defaultImpl must be instantiable!");
+        return List.of();
+    }
+
+    private List<Diagnostic> violation(CheckContext context, String message) {
+        return List.of(new Diagnostic(getClass().getName(), message, context.getValidatedAnnotation()));
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckDslAnnotation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckDslAnnotation.java
@@ -27,7 +27,6 @@ import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
 import com.blackbuild.klum.cast.spi.Check;
 import com.blackbuild.klum.cast.spi.CheckContext;
 import com.blackbuild.klum.cast.spi.Diagnostic;
-import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckForPrimitiveBoolean.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/CheckForPrimitiveBoolean.java
@@ -23,23 +23,22 @@
  */
 package com.blackbuild.klum.ast.validation;
 
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
-import org.codehaus.groovy.ast.AnnotatedNode;
-import org.codehaus.groovy.ast.AnnotationNode;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.FieldNode;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
-public class CheckForPrimitiveBoolean extends KlumCastCheck<Annotation> {
+public class CheckForPrimitiveBoolean implements Check {
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
-        if (((FieldNode) target).getType().equals(ClassHelper.boolean_TYPE))
-            throw new IllegalStateException("Validation is not valid on 'boolean' fields, use 'Boolean' instead.");
-    }
-
-    @Override
-    protected boolean isValidFor(AnnotatedNode target) {
-        return target instanceof FieldNode;
+    public List<Diagnostic> check(CheckContext context) {
+        if (!(context.getTarget() instanceof FieldNode))
+            return List.of();
+        FieldNode target = (FieldNode) context.getTarget();
+        if (target.getType().equals(ClassHelper.boolean_TYPE))
+            return List.of(new Diagnostic(getClass().getName(), "Validation is not valid on 'boolean' fields, use 'Boolean' instead.", context.getValidatedAnnotation()));
+        return List.of();
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteMapCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteMapCheck.java
@@ -25,25 +25,27 @@ package com.blackbuild.klum.ast.validation;
 
 import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
 import com.blackbuild.klum.ast.util.copy.OverwriteStrategy;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
-import org.codehaus.groovy.ast.AnnotatedNode;
-import org.codehaus.groovy.ast.AnnotationNode;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
 import static com.blackbuild.klum.common.CommonAstHelper.*;
 
-public class OverwriteMapCheck extends KlumCastCheck<Annotation> {
+public class OverwriteMapCheck implements Check {
 
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
-        FieldNode field = (FieldNode) target;
+    public List<Diagnostic> check(CheckContext context) {
+        FieldNode field = (FieldNode) context.getTarget();
+        var annotationToCheck = context.getValidatedAnnotation();
         OverwriteStrategy.Map strategy = getNullSafeEnumMemberValue(annotationToCheck, "value", OverwriteStrategy.Map.INHERIT);
         ClassNode elementType = getElementType(field);
 
         if (strategy == OverwriteStrategy.Map.MERGE_VALUES && !DslAstHelper.isDSLObject(elementType))
-            throw new IllegalArgumentException("MERGE_VALUES is only allowed for DSL objects");
+            return List.of(new Diagnostic(getClass().getName(), "MERGE_VALUES is only allowed for DSL objects", annotationToCheck));
+        return List.of();
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteSingleCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteSingleCheck.java
@@ -25,27 +25,29 @@ package com.blackbuild.klum.ast.validation;
 
 import com.blackbuild.groovy.configdsl.transform.ast.DslAstHelper;
 import com.blackbuild.klum.ast.util.copy.OverwriteStrategy;
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
-import org.codehaus.groovy.ast.AnnotatedNode;
-import org.codehaus.groovy.ast.AnnotationNode;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import org.codehaus.groovy.ast.FieldNode;
 
-import java.lang.annotation.Annotation;
+import java.util.List;
 
 import static com.blackbuild.klum.common.CommonAstHelper.getNullSafeEnumMemberValue;
 import static com.blackbuild.klum.common.CommonAstHelper.isCollectionOrMap;
 
-public class OverwriteSingleCheck extends KlumCastCheck<Annotation> {
+public class OverwriteSingleCheck implements Check {
 
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) {
-        FieldNode field = (FieldNode) target;
+    public List<Diagnostic> check(CheckContext context) {
+        FieldNode field = (FieldNode) context.getTarget();
+        var annotationToCheck = context.getValidatedAnnotation();
         OverwriteStrategy.Single strategy = getNullSafeEnumMemberValue(annotationToCheck, "single", OverwriteStrategy.Single.INHERIT);
 
         if (isCollectionOrMap(field.getType()))
-            throw new IllegalArgumentException("Single overwrite strategy is not allowed for collections or maps");
+            return List.of(new Diagnostic(getClass().getName(), "Single overwrite strategy is not allowed for collections or maps", annotationToCheck));
 
         if (strategy == OverwriteStrategy.Single.MERGE && !DslAstHelper.isDSLObject(field.getType()))
-            throw new IllegalArgumentException("MERGE is only allowed for DSL objects");
+            return List.of(new Diagnostic(getClass().getName(), "MERGE is only allowed for DSL objects", annotationToCheck));
+        return List.of();
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteSingleCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/OverwriteSingleCheck.java
@@ -41,7 +41,7 @@ public class OverwriteSingleCheck implements Check {
     public List<Diagnostic> check(CheckContext context) {
         FieldNode field = (FieldNode) context.getTarget();
         var annotationToCheck = context.getValidatedAnnotation();
-        OverwriteStrategy.Single strategy = getNullSafeEnumMemberValue(annotationToCheck, "single", OverwriteStrategy.Single.INHERIT);
+        OverwriteStrategy.Single strategy = getNullSafeEnumMemberValue(annotationToCheck, "value", OverwriteStrategy.Single.INHERIT);
 
         if (isCollectionOrMap(field.getType()))
             return List.of(new Diagnostic(getClass().getName(), "Single overwrite strategy is not allowed for collections or maps", annotationToCheck));

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/ValidateAnnotationCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/ValidateAnnotationCheck.java
@@ -23,56 +23,66 @@
  */
 package com.blackbuild.klum.ast.validation;
 
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck;
-import com.blackbuild.klum.cast.checks.impl.ValidationException;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
 import groovyjarjarasm.asm.Opcodes;
 import org.codehaus.groovy.ast.*;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
-public class ValidateAnnotationCheck extends KlumCastCheck<Annotation> {
+public class ValidateAnnotationCheck implements Check {
     @Override
-    protected void doCheck(AnnotationNode annotationToCheck, AnnotatedNode target) throws ValidationException {
+    public List<Diagnostic> check(CheckContext context) {
+        AnnotationNode annotationToCheck = context.getValidatedAnnotation();
+        AnnotatedNode target = context.getTarget();
         if (target instanceof ClassNode) {
-            if (target instanceof InnerClassNode) checkOnInnerClass((InnerClassNode) target);
-            else checkOnOuterClass(annotationToCheck);
+            if (target instanceof InnerClassNode) return checkOnInnerClass((InnerClassNode) target, annotationToCheck);
+            return checkOnOuterClass(annotationToCheck);
         } else if (target instanceof MethodNode) {
-            checkOnMethod((MethodNode) target);
+            return checkOnMethod((MethodNode) target, annotationToCheck);
         } else if (target instanceof FieldNode) {
-            checkOnField((FieldNode) target);
+            return checkOnField((FieldNode) target, annotationToCheck);
         } else {
-            throw new ValidationException("@Validate can only be used on (inner) classes, methods or fields!");
+            return violation("@Validate can only be used on (inner) classes, methods or fields!", annotationToCheck);
         }
     }
 
-    private void checkOnField(FieldNode target) throws ValidationException {
+    private List<Diagnostic> checkOnField(FieldNode target, AnnotationNode annotationToCheck) {
         if (target.isStatic())
-            throw new ValidationException("@Validate can only be used on non-static fields!");
+            return violation("@Validate can only be used on non-static fields!", annotationToCheck);
+        return List.of();
     }
 
-    private void checkOnMethod(MethodNode target) throws ValidationException {
+    private List<Diagnostic> checkOnMethod(MethodNode target, AnnotationNode annotationToCheck) {
         if (target.isStatic())
-            throw new ValidationException("@Validate can only be used on non-static methods!");
+            return violation("@Validate can only be used on non-static methods!", annotationToCheck);
+        return List.of();
     }
 
-    private void checkOnOuterClass(AnnotationNode annotationToCheck) throws ValidationException {
+    private List<Diagnostic> checkOnOuterClass(AnnotationNode annotationToCheck) {
         if (annotationToCheck.getMember("level") != null)
-            throw new ValidationException("@Validate.level is not allowed on top level classes!");
+            return violation("@Validate.level is not allowed on top level classes!", annotationToCheck);
+        return List.of();
     }
 
-    private void checkOnInnerClass(InnerClassNode target) throws ValidationException {
+    private List<Diagnostic> checkOnInnerClass(InnerClassNode target, AnnotationNode annotationToCheck) {
         if ((target.getModifiers() & Opcodes.ACC_STATIC) != 0)
-            throw new ValidationException("@Validate can only be used on non-static inner classes!");
+            return violation("@Validate can only be used on non-static inner classes!", annotationToCheck);
         List<ConstructorNode> constructors = target.getDeclaredConstructors();
 
         if (!Modifier.isAbstract(target.getModifiers())) {
             if (constructors.size() > 1)
-                throw new ValidationException("@Validate can only be used on inner classes with a maximum of one constructor!", constructors.get(1));
+                return violation("@Validate can only be used on inner classes with a maximum of one constructor!", constructors.get(1));
 
             if (constructors.size() == 1 && constructors.get(0).getParameters().length > 0)
-                throw new ValidationException("@Validate can only be used on inner classes with a no-argument constructor!", constructors.get(0));
+                return violation("@Validate can only be used on inner classes with a no-argument constructor!", constructors.get(0));
         }
+        return List.of();
+    }
+
+    private List<Diagnostic> violation(String message, ASTNode node) {
+        return List.of(new Diagnostic(getClass().getName(), message, node));
     }
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/ValidateAnnotationCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/validation/ValidateAnnotationCheck.java
@@ -38,7 +38,7 @@ public class ValidateAnnotationCheck implements Check {
         AnnotationNode annotationToCheck = context.getValidatedAnnotation();
         AnnotatedNode target = context.getTarget();
         if (target instanceof ClassNode) {
-            if (target instanceof InnerClassNode) return checkOnInnerClass((InnerClassNode) target, annotationToCheck);
+            if (target instanceof InnerClassNode innerClass) return checkOnInnerClass(innerClass, annotationToCheck);
             return checkOnOuterClass(annotationToCheck);
         } else if (target instanceof MethodNode) {
             return checkOnMethod((MethodNode) target, annotationToCheck);

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
@@ -222,6 +222,22 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
         '''
     }
 
+    def "zero-argument virtual field keeps its parameter-contract diagnostic"() {
+        expect:
+        def error = compilationError '''
+            @DSL
+            class DefaultImplementation { }
+
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = DefaultImplementation)
+                void value() { }
+            }
+        '''
+        error.message.contains("must have 1 parameters")
+        !error.message.contains("Technical failure")
+    }
+
     private static Check newInstance(Class<? extends Check> checkType) {
         checkType.getDeclaredConstructor().newInstance()
     }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform
+
+import com.blackbuild.groovy.configdsl.transform.ast.FieldAstValidator
+import com.blackbuild.groovy.configdsl.transform.ast.mutators.WriteAccessMethodCheck
+import com.blackbuild.klum.ast.util.copy.Overwrite
+import com.blackbuild.klum.ast.util.layer3.annotations.DefaultValues
+import com.blackbuild.klum.ast.util.layer3.DefaultValuesCheck
+import com.blackbuild.klum.ast.validation.CheckDslAnnotation
+import com.blackbuild.klum.ast.validation.CheckForPrimitiveBoolean
+import com.blackbuild.klum.ast.validation.OverwriteMapCheck
+import com.blackbuild.klum.ast.validation.OverwriteSingleCheck
+import com.blackbuild.klum.ast.validation.ValidateAnnotationCheck
+import com.blackbuild.klum.cast.checks.impl.KlumCastCheck
+import com.blackbuild.klum.cast.KlumCastValidator
+import com.blackbuild.klum.cast.spi.Check
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import spock.lang.Issue
+
+@Issue("460")
+class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
+
+    def "all name-bound KlumAST checks implement the durable SPI directly"() {
+        expect:
+        Check.isAssignableFrom(checkType)
+        !KlumCastCheck.isAssignableFrom(checkType)
+        checkType.getDeclaredConstructor()
+        newInstance(checkType).diagnosticDefinitions*.code == [checkType.name]
+
+        where:
+        checkType << [
+                FieldAstValidator,
+                WriteAccessMethodCheck,
+                DefaultValuesCheck,
+                CheckDslAnnotation,
+                CheckForPrimitiveBoolean,
+                OverwriteMapCheck,
+                OverwriteSingleCheck,
+                ValidateAnnotationCheck,
+        ]
+    }
+
+    def "annotation artifact retains the eight supported name bindings"() {
+        expect:
+        annotationTypes
+                .collect { it.getAnnotationsByType(KlumCastValidator).toList() }
+                .flatten()
+                .collect { it.value() }
+                .toSet() == checkTypes*.name.toSet()
+
+        where:
+        annotationTypes = [Field, DSL, WriteAccess, Validate, Overwrite.Single, Overwrite.Map, DefaultValues]
+        checkTypes = [
+                FieldAstValidator,
+                WriteAccessMethodCheck,
+                DefaultValuesCheck,
+                CheckDslAnnotation,
+                CheckForPrimitiveBoolean,
+                OverwriteMapCheck,
+                OverwriteSingleCheck,
+                ValidateAnnotationCheck,
+        ]
+    }
+
+    def "name-bound validation check emits a positioned structured diagnostic"() {
+        when:
+        createClass '''
+            @DSL
+            class BrokenModel {
+                @Validate boolean enabled
+            }
+        '''
+
+        then:
+        def error = thrown(MultipleCompilationErrorsException)
+        error.message.contains(CheckForPrimitiveBoolean.name)
+        error.message.contains("Validation is not valid on 'boolean' fields")
+    }
+
+    private static Check newInstance(Class<? extends Check> checkType) {
+        checkType.getDeclaredConstructor().newInstance()
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
@@ -162,6 +162,66 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
         error.message.contains("@ line")
     }
 
+    @Unroll
+    def "Field defaultImpl #description is rejected with a structured diagnostic"() {
+        expect:
+        def error = compilationError(source)
+        error.message.contains(FieldAstValidator.name)
+        error.message.contains(message)
+        error.message.contains("@ line")
+
+        where:
+        description       | message                                                | source
+        "targets final type" | "is final and cannot be overridden"                | '''
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = String) String value
+            }
+        '''
+        "is not assignable" | "is not a valid subtype"                           | '''
+            @DSL
+            class DefaultImplementation { }
+
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = DefaultImplementation) Runnable value
+            }
+        '''
+        "is used on a LINK method" | "Default Implementation is not allowed on LINK fields" | '''
+            @DSL
+            class DefaultImplementation { }
+
+            @DSL
+            class BrokenModel {
+                @Field(value = FieldType.LINK, defaultImpl = DefaultImplementation)
+                void linked(DefaultImplementation value) { }
+            }
+        '''
+        "changes keyedness" | "is keyed, but field"                              | '''
+            @DSL
+            abstract class Base { }
+
+            @DSL
+            class KeyedImplementation extends Base {
+                @Key String id
+            }
+
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = KeyedImplementation) Base value
+            }
+        '''
+        "is not instantiable" | "is not instantiable"                              | '''
+            @DSL
+            abstract class AbstractImplementation { }
+
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = AbstractImplementation) AbstractImplementation value
+            }
+        '''
+    }
+
     private static Check newInstance(Class<? extends Check> checkType) {
         checkType.getDeclaredConstructor().newInstance()
     }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
@@ -33,33 +33,35 @@ import com.blackbuild.klum.ast.validation.CheckForPrimitiveBoolean
 import com.blackbuild.klum.ast.validation.OverwriteMapCheck
 import com.blackbuild.klum.ast.validation.OverwriteSingleCheck
 import com.blackbuild.klum.ast.validation.ValidateAnnotationCheck
-import com.blackbuild.klum.cast.checks.impl.KlumCastCheck
 import com.blackbuild.klum.cast.KlumCastValidator
 import com.blackbuild.klum.cast.spi.Check
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import spock.lang.Issue
+import spock.lang.Unroll
 
 @Issue("460")
 class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
 
+    private static final CHECK_TYPES = [
+            FieldAstValidator,
+            WriteAccessMethodCheck,
+            DefaultValuesCheck,
+            CheckDslAnnotation,
+            CheckForPrimitiveBoolean,
+            OverwriteMapCheck,
+            OverwriteSingleCheck,
+            ValidateAnnotationCheck,
+    ]
+
     def "all name-bound KlumAST checks implement the durable SPI directly"() {
         expect:
         Check.isAssignableFrom(checkType)
-        !KlumCastCheck.isAssignableFrom(checkType)
+        checkType.superclass == Object
         checkType.getDeclaredConstructor()
         newInstance(checkType).diagnosticDefinitions*.code == [checkType.name]
 
         where:
-        checkType << [
-                FieldAstValidator,
-                WriteAccessMethodCheck,
-                DefaultValuesCheck,
-                CheckDslAnnotation,
-                CheckForPrimitiveBoolean,
-                OverwriteMapCheck,
-                OverwriteSingleCheck,
-                ValidateAnnotationCheck,
-        ]
+        checkType << CHECK_TYPES
     }
 
     def "annotation artifact retains the eight supported name bindings"() {
@@ -68,38 +70,108 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
                 .collect { it.getAnnotationsByType(KlumCastValidator).toList() }
                 .flatten()
                 .collect { it.value() }
-                .toSet() == checkTypes*.name.toSet()
+                .toSet() == CHECK_TYPES*.name.toSet()
 
         where:
         annotationTypes = [Field, DSL, WriteAccess, Validate, Overwrite.Single, Overwrite.Map, DefaultValues]
-        checkTypes = [
-                FieldAstValidator,
-                WriteAccessMethodCheck,
-                DefaultValuesCheck,
-                CheckDslAnnotation,
-                CheckForPrimitiveBoolean,
-                OverwriteMapCheck,
-                OverwriteSingleCheck,
-                ValidateAnnotationCheck,
-        ]
     }
 
-    def "name-bound validation check emits a positioned structured diagnostic"() {
-        when:
-        createClass '''
+    @Unroll
+    def "name-bound #checkType.simpleName check emits a positioned structured diagnostic"() {
+        expect:
+        def error = compilationError(source)
+        error.message.contains(checkType.name)
+        error.message.contains(message)
+        error.message.contains("@ line")
+
+        where:
+        checkType                 | message                                         | source
+        CheckDslAnnotation        | "defaultImpl must be a subtype"                | '''
+            @DSL(defaultImpl = String)
+            interface BrokenModel { }
+        '''
+        FieldAstValidator          | "Default Implementation must be an DSL-Object" | '''
+            @DSL
+            class BrokenModel {
+                @Field(defaultImpl = String) CharSequence value
+            }
+        '''
+        WriteAccessMethodCheck     | "Lifecycle methods must not be private"        | '''
+            @DSL
+            class BrokenModel {
+                @PostCreate private void initialize() { }
+            }
+        '''
+        CheckForPrimitiveBoolean   | "Validation is not valid on 'boolean' fields"  | '''
             @DSL
             class BrokenModel {
                 @Validate boolean enabled
             }
         '''
+        ValidateAnnotationCheck    | "@Validate can only be used on non-static fields" | '''
+            @DSL
+            class BrokenModel {
+                @Validate static String enabled
+            }
+        '''
+        OverwriteSingleCheck       | "MERGE is only allowed for DSL objects"        | '''
+            import com.blackbuild.klum.ast.util.copy.Overwrite
+            import com.blackbuild.klum.ast.util.copy.OverwriteStrategy
+
+            @DSL
+            class BrokenModel {
+                @Overwrite.Single(OverwriteStrategy.Single.MERGE) String title
+            }
+        '''
+        OverwriteMapCheck          | "MERGE_VALUES is only allowed for DSL objects" | '''
+            import com.blackbuild.klum.ast.util.copy.Overwrite
+            import com.blackbuild.klum.ast.util.copy.OverwriteStrategy
+
+            @DSL
+            class BrokenModel {
+                @Overwrite.Map(OverwriteStrategy.Map.MERGE_VALUES) Map<String, String> values
+            }
+        '''
+    }
+
+    def "name-bound DefaultValues check emits a positioned structured diagnostic"() {
+        given:
+        createSecondaryClass '''
+            import com.blackbuild.klum.ast.util.layer3.annotations.DefaultValues
+            import java.lang.annotation.*
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target([ElementType.TYPE])
+            @DefaultValues
+            @interface BrokenDefaults {
+                String value()
+            }
+        '''
+
+        when:
+        createClass '''
+            @BrokenDefaults
+            @DSL
+            class BrokenModel { }
+        '''
 
         then:
         def error = thrown(MultipleCompilationErrorsException)
-        error.message.contains(CheckForPrimitiveBoolean.name)
-        error.message.contains("Validation is not valid on 'boolean' fields")
+        error.message.contains(DefaultValuesCheck.name)
+        error.message.contains("does have a 'value' member")
+        error.message.contains("@ line")
     }
 
     private static Check newInstance(Class<? extends Check> checkType) {
         checkType.getDeclaredConstructor().newInstance()
+    }
+
+    private MultipleCompilationErrorsException compilationError(String source) {
+        try {
+            createClass(source)
+        } catch (MultipleCompilationErrorsException error) {
+            return error
+        }
+        throw new AssertionError("Expected compilation to fail")
     }
 }


### PR DESCRIPTION
## Summary

- Migrate all eight KlumAST name-bound compiler checks from KlumCast's deprecated compatibility adapter to the stateless `Check` SPI.
- Return source-positioned structured diagnostics, retain string bindings across the annotations/compiler boundary, and preserve technical failures.
- Add focused negative compiler coverage for every binding and every `Field.defaultImpl` rejection branch; document the migration and the restored `@Overwrite.Single(MERGE)` rejection.

## Validation

- `./gradlew check` (root; Groovy 3, Groovy 4, and Groovy 5 lanes)
- `git diff --check`

Related: #460
