### PR TITLE
Reconcile live 4.0 issue inventory

### DIFF
--- a/docs/implementation/issue-curation/issue-index.md
+++ b/docs/implementation/issue-curation/issue-index.md
@@ -1,8 +1,28 @@
 # Open issue index for the 4.0 release
 
-Snapshot refreshed 2026-07-17: 109 open issues in `klum-dsl/klum-ast`, inspected from repository base `65f7a99b` and the live issue tracker. The original inventory was read-only; later confirmed normalization actions are recorded below.
+Snapshot refreshed 2026-07-27: 111 open issues in `klum-dsl/klum-ast`, reconciled against live GitHub and `origin/master`
+at `5a5a61b1`. The original inventory was read-only; later confirmed normalization actions are recorded below. The
+2026-07-27 live reconciliation takes precedence over historical rows that describe now-delivered implementation work.
 
 All dispositions are provisional maintainer recommendations. “Relevant” means that the current source still lacks the requested capability or still contains the reported risk; it does not mean that the issue is accepted product policy. The historical 2.x/3.x sections of `docs/user/Roadmap.md` were not used as current policy.
+
+## Live 4.0 reconciliation — 2026-07-27
+
+The following table is the authoritative current release slice. It prevents a historical planning row from making a
+closed issue look active again.
+
+| Issue(s) | Live state | Reconciliation |
+| --- | --- | --- |
+| #394, #428, #435, #450, #459, #460, #461, #468, #488, #559 | closed / delivered | The generated DSL namespace, Jackson parent, completed-object tracer, integration audit, upstream RC integrations, durable Check migration, public inventory, protected release path, and root mirror aggregate are all delivered. #523 and #524 own later final-coordinate promotions. |
+| #391 | open — 4.0 implementation | PR #561 records ADR 0014: Groovy 4/5 have the named-module target; Groovy 3 remains classpath-only. JP-1 through JP-5 remain: inventory, ownership moves/descriptors, named fixtures, and plugin/migration validation. |
+| #456 | open — release operation | Renderer, historical/API evidence, Pages writer/service boundary, protection runbook, and manifest read-back seam are delivered. The first exact pending snapshot and proof-gated aliases remain release-time work. |
+| #491, #544 | open — content acceptance | #545 and #551 delivered the content audit and documentary inventory. #491 retains the selected-documentary queue; #544 needs explicit maintainer acceptance of that queue and the #454/#456 deferrals before the first RC. |
+| #469, #483, #546 | open — bounded post-RC/final evidence | #469's three onboarding tracers are delivered; its field evidence follows an RC. #483 owns the final Season/logo asset and manifest. #546 is non-blocking adopter-exercise evidence after an RC. |
+| #512, #521 | open — initial RC gate | Publish one KlumAST RC, then run clean external-consumer validation and the manual IntelliJ mirror check. Closed #459/#461/#488 are satisfied inputs; #456's exact pending snapshot remains a non-native release prerequisite. |
+| #523, #524, #525 | open — final release gate | Promote upstream final coordinates after the accepted initial train, then validate a final-coordinate KlumAST RC before 4.0.0. |
+
+The remaining open backlog is intentionally unchanged: 95 unmilestoned issues, 3 milestone-2.x issues, and one
+milestone-3.0 issue. No legacy issue was silently promoted into the 4.0 train.
 
 ## Evidence and compatibility keys
 

--- a/docs/implementation/issue-curation/release-4.0.md
+++ b/docs/implementation/issue-curation/release-4.0.md
@@ -1,9 +1,10 @@
-# Provisional 4.0 issue slate
+# 4.0 issue slate
 
 This release view is derived from the complete [open issue index](issue-index.md), not from the outdated version plan in
 `docs/user/Roadmap.md`. The policy baseline is README/CHANGES, the Builder-first migration guide, accepted ADRs 0003–0009, and
 current source/tests. ADR 0007 is superseded by ADR 0009, while ADR 0008 remains a later-4.x target. ADRs 0004–0006 and
-0009 define the remaining accepted 4.0 boundaries.
+0009 define the accepted Builder-first boundaries. The dated live reconciliation below is authoritative where older
+delivery-history prose in this document has not yet been rewritten.
 
 Release-facing identity: **Season 4: The Makeover**, always paired with the semantic version `4.0`.
 
@@ -17,6 +18,21 @@ Release-facing identity: **Season 4: The Makeover**, always paired with the sema
 4. completed-model companion and Jackson interoperability behavior are documented contracts rather than provisional implementation details;
 5. the handwritten package surface and Java module identities are intentional rather than accidental;
 6. Java 17 and Groovy 3/4/5 remain supported.
+
+## Live reconciliation — 2026-07-27
+
+Live GitHub and `origin/master` were reconciled after PRs #545, #551, and #554–#562. This is the release-facing state;
+the detailed sections below preserve the decisions and historical delivery rationale.
+
+| Disposition | Issues | Current release meaning |
+| --- | --- | --- |
+| **Closed, delivered** | #394, #428, #435, #450, #459, #460, #461, #468, #488, #559 | The generated DSL surface, Jackson contract, completed-object facade, integration audit, upstream RC integrations, durable Check migration, public-interface inventory, release path, and root source-mirror aggregate are delivered. Final-coordinate upstream promotions remain #523/#524, not reopened through #459/#461. |
+| **Implementation remains** | #391 | ADR 0014 and PR #561 settle the Groovy boundary: Groovy 4/5 named modules; Groovy 3 classpath support. Execute JP-1 through JP-5: package/import inventory, ownership moves/descriptors, named-schema fixtures, and descriptor/migration validation. |
+| **First-RC gates** | #456, #491, #544, #512, #521 | #456 infrastructure and protected Pages controls are ready; its first exact pending snapshot runs with the RC. #544 needs explicit maintainer content acceptance, accepting #491's documented documentary-test queue/deferrals. #512 then owns clean external-consumer validation and #521 the manual IntelliJ check. |
+| **Post-initial-RC / final gates** | #469, #546, #483, #523–#525 | #469's three onboarding tracers are delivered; field evidence is post-RC. #546 is discovery-only agent-adopter evidence. #483 supplies the approved final Season/logo manifest. #523/#524 promote upstream finals, then #525 validates the final-coordinate KlumAST RC before 4.0.0. |
+
+No unmilestoned issue was promoted into 4.0 in this reconciliation. The post-closure open inventory is 111 issues: 12 in
+milestone 4.0, 3 in 2.x, 1 in 3.0, and 95 unmilestoned legacy/future items.
 
 ## 4.0 must
 


### PR DESCRIPTION
## Summary

- records the 2026-07-27 live GitHub and master reconciliation in the release slate and issue index
- distinguishes delivered/closed work from the remaining JPMS, documentation, content-acceptance, RC, and final-promotion gates
- preserves legacy rows as historical decision evidence while making the dated live state authoritative

## Tracker reconciliation

Issues #428, #435, #450, #460, and #559 were closed separately with their delivery evidence. #394 and #461 were already closed.

## Validation

- git diff --check origin/master...HEAD