### PR TITLE
Prevent duplicate Bean Validation annotations in Groovy 5

### DIFF
--- a/klum-ast-bean-validation/src/test/groovy/com/blackbuild/klum/ast/validation/bean/TransformedBeanValidationTest.groovy
+++ b/klum-ast-bean-validation/src/test/groovy/com/blackbuild/klum/ast/validation/bean/TransformedBeanValidationTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.validation.bean
+
+import com.blackbuild.groovy.configdsl.transform.AbstractDSLSpec
+import com.blackbuild.klum.ast.util.KlumValidationException
+import spock.lang.Issue
+
+@Issue("391")
+class TransformedBeanValidationTest extends AbstractDSLSpec {
+
+    def "a plain Min constraint does not have duplicate annotation metadata"() {
+        given:
+        Class<?> plainSchema = loader.parseClass('''
+            package fixture.schema
+
+            import jakarta.validation.constraints.Min
+
+            class PlainValidatedStation {
+                @Min(10L)
+                int capacity
+            }
+        ''')
+
+        expect:
+        plainSchema.getDeclaredField("capacity").annotations*.annotationType().name == ["jakarta.validation.constraints.Min"]
+    }
+
+    def "a transformed Min constraint remains reflectively readable before Bean Validation runs"() {
+        given:
+        createClass('''
+            package fixture.schema
+
+            import jakarta.validation.constraints.Min
+
+            @DSL
+            class ValidatedStation {
+                @Min(10L)
+                int capacity
+            }
+        ''')
+
+        when:
+        def annotations = clazz.getDeclaredField("capacity").annotations
+
+        then:
+        annotations*.annotationType().name == ["jakarta.validation.constraints.Min"]
+    }
+
+    def "a transformed Min constraint remains valid in every Groovy test lane"() {
+        given:
+        createClass('''
+            package fixture.schema
+
+            import jakarta.validation.constraints.Min
+
+            @DSL
+            class ValidatedStation {
+                @Min(10L)
+                int capacity
+            }
+        ''')
+
+        when:
+        def station = clazz.Create.With {
+            capacity 12
+        }
+
+        then:
+        station.capacity == 12
+        clazz.getDeclaredField("capacity").annotations*.annotationType().name == ["jakarta.validation.constraints.Min"]
+        clazz.declaredClasses.find { it.name.endsWith("\$Builder") }
+                .getDeclaredField("capacity").annotations.length == 0
+
+        when:
+        clazz.Create.With {
+            capacity 9
+        }
+
+        then:
+        thrown(KlumValidationException)
+    }
+}

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AnnotationCopyExceptions.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/AnnotationCopyExceptions.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.groovy.configdsl.transform.ast;
+
+import org.codehaus.groovy.ast.AnnotationNode;
+
+/**
+ * Keeps annotations whose semantics belong only to the completed model off generated Builder fields.
+ */
+final class AnnotationCopyExceptions {
+
+    private AnnotationCopyExceptions() {
+        // This utility class should not be instantiated.
+    }
+
+    static boolean shouldCopy(AnnotationNode annotation) {
+        String name = annotation.getClassNode().getName();
+        if (name.startsWith("jakarta.validation.") || name.startsWith("javax.validation."))
+            return false;
+        return annotation.getClassNode().getAnnotations().stream()
+                .noneMatch(metaAnnotation -> metaAnnotation.getClassNode().getName().equals("jakarta.validation.Constraint")
+                        || metaAnnotation.getClassNode().getName().equals("javax.validation.Constraint"));
+    }
+}

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -437,7 +437,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         );
         builderField.addAnnotations(modelField.getAnnotations().stream()
                 .filter(AnnotationCopyExceptions::shouldCopy)
-                .collect(toList()));
+                .toList());
         builderField.setSourcePosition(modelField);
         rwClass.addField(builderField);
         builderFields.put(modelField, builderField);

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -435,13 +435,26 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 rwClass,
                 modelField.getInitialExpression()
         );
-        builderField.addAnnotations(modelField.getAnnotations());
+        // Bean Validation inspects the materialized model; mirroring its constraints onto the Builder
+        // makes Groovy 5 emit duplicate metadata.
+        builderField.addAnnotations(modelField.getAnnotations().stream()
+                .filter(annotation -> !isBeanValidationAnnotation(annotation))
+                .collect(toList()));
         builderField.setSourcePosition(modelField);
         rwClass.addField(builderField);
         builderFields.put(modelField, builderField);
 
         // Source code is evaluated exactly once, as part of Builder construction.
         modelField.setInitialValueExpression(null);
+    }
+
+    private static boolean isBeanValidationAnnotation(AnnotationNode annotation) {
+        String name = annotation.getClassNode().getName();
+        if (name.startsWith("jakarta.validation.") || name.startsWith("javax.validation."))
+            return true;
+        return annotation.getClassNode().getAnnotations().stream()
+                .anyMatch(metaAnnotation -> metaAnnotation.getClassNode().getName().equals("jakarta.validation.Constraint")
+                        || metaAnnotation.getClassNode().getName().equals("javax.validation.Constraint"));
     }
 
     private void validateSupportedCollectionDeclaration(FieldNode field) {

--- a/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/groovy/configdsl/transform/ast/DSLASTTransformation.java
@@ -435,10 +435,8 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 rwClass,
                 modelField.getInitialExpression()
         );
-        // Bean Validation inspects the materialized model; mirroring its constraints onto the Builder
-        // makes Groovy 5 emit duplicate metadata.
         builderField.addAnnotations(modelField.getAnnotations().stream()
-                .filter(annotation -> !isBeanValidationAnnotation(annotation))
+                .filter(AnnotationCopyExceptions::shouldCopy)
                 .collect(toList()));
         builderField.setSourcePosition(modelField);
         rwClass.addField(builderField);
@@ -446,15 +444,6 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         // Source code is evaluated exactly once, as part of Builder construction.
         modelField.setInitialValueExpression(null);
-    }
-
-    private static boolean isBeanValidationAnnotation(AnnotationNode annotation) {
-        String name = annotation.getClassNode().getName();
-        if (name.startsWith("jakarta.validation.") || name.startsWith("javax.validation."))
-            return true;
-        return annotation.getClassNode().getAnnotations().stream()
-                .anyMatch(metaAnnotation -> metaAnnotation.getClassNode().getName().equals("jakarta.validation.Constraint")
-                        || metaAnnotation.getClassNode().getName().equals("javax.validation.Constraint"));
     }
 
     private void validateSupportedCollectionDeclaration(FieldNode field) {


### PR DESCRIPTION
## Summary

- Keep Bean Validation annotations on materialized DSL models rather than copying them to generated Builder fields.
- Isolate the decision behind the internal `AnnotationCopyExceptions` module so the transform itself has no Bean Validation-specific rule.
- Add a Groovy 3/4/5 regression that verifies transformed `@Min` constraints both accept valid values and reject invalid ones.

## Root cause

The Builder-first transform copied every field annotation to its generated Builder field. In Groovy 5, Hibernate Validator's metadata walk then encountered duplicate `@Min` metadata for a transformed model.

## Compatibility

Bean Validation constraints, including custom `@Constraint` annotations, remain on the completed model and continue to be enforced. They are no longer reflected on the implementation-only generated Builder field. No public SPI is introduced.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests`
- `./gradlew :klum-ast:groovy5Tests`
- `./gradlew :klum-ast-bean-validation:test :klum-ast-bean-validation:groovy4Tests :klum-ast-bean-validation:groovy5Tests`

## Tracking

Related: #391

Issue #391 remains open: its JPMS package and descriptor prerequisites are outside this localized correction.
