### PR TITLE
Add explicit JPMS module descriptors

### DIFF
--- a/buildSrc/src/main/groovy/klum-ast.jpms-descriptor-conventions.gradle
+++ b/buildSrc/src/main/groovy/klum-ast.jpms-descriptor-conventions.gradle
@@ -1,0 +1,48 @@
+import org.gradle.api.tasks.compile.JavaCompile
+
+/**
+ * Compiles explicit module descriptors against Groovy 4 without changing the
+ * Groovy 3 compilation or classpath artifact. The descriptor compiler sees the
+ * normal compiled packages only to validate exports and emits a separate
+ * module-info.class.
+ */
+configurations {
+    jpmsModulePath {
+        canBeConsumed = false
+        canBeResolved = true
+        extendsFrom api, implementation, compileOnly
+        exclude group: 'org.codehaus.groovy'
+        exclude group: 'com.github.adedayo.intellij.sdk'
+    }
+}
+
+dependencies {
+    jpmsModulePath platform(libs.groovy.v4.bom)
+    jpmsModulePath libs.groovy.v4
+}
+
+def compileModuleInfo = tasks.register('compileModuleInfo', JavaCompile) {
+    description = 'Compiles and validates the JPMS descriptor against Groovy 4.'
+    source(fileTree('src/main/module-info'))
+    classpath = sourceSets.main.output
+    destinationDirectory = layout.buildDirectory.dir('classes/java/jpms')
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+    options.release = 17
+    options.compilerArgs.addAll(['--module-path', configurations.jpmsModulePath.asPath])
+    dependsOn(configurations.jpmsModulePath)
+}
+
+tasks.named('jar') {
+    dependsOn(compileModuleInfo)
+    from(compileModuleInfo) {
+        include 'module-info.class'
+    }
+}
+
+tasks.named('sourcesJar') {
+    from('src/main/module-info') {
+        include 'module-info.java'
+    }
+}

--- a/docs/adr/0014-groovy4-jpms-boundary.md
+++ b/docs/adr/0014-groovy4-jpms-boundary.md
@@ -96,9 +96,23 @@ Klum-Wrap is completely separate and is not a qualified-export consumer.
 The runtime descriptor declares `uses` for phase actions and instance
 validators and `provides` its built-in implementations. The Bean Validation
 module provides `InstanceValidator`; the Jackson module provides the Jackson
-`Module`; compiler activation remains a descriptor-owned Groovy transformation
-provider. Fixture evidence, rather than resource discovery by accident,
-establishes each declaration.
+`Module`.
+
+KlumAST compiler transformations are annotation-triggered local transforms,
+not global `META-INF/services` transforms. For Groovy 4/5, the compiler module
+requires `org.apache.groovy` and opens `compiler.internal.ast`,
+`.ast.converters`, `.ast.mutators`, and `.layer3` only to that module, allowing
+Groovy to instantiate the transformations named by the public annotations. It
+also opens `compiler.internal.validation` only to
+`com.blackbuild.klum.cast.compiler`: the established
+`@KlumCastValidator` bindings require Klum Cast to reflectively instantiate
+their internal validation checks. That narrow reflective opening is neither an
+export nor generic reflection access. The compiler exports none of these
+implementation packages and declares no
+`provides org.codehaus.groovy.transform.ASTTransformation` clause. Groovy 3
+has no descriptor alternative and remains classpath-only.
+The named-module fixture proves activation for DSL/mutator, converter, and
+Layer 3 annotations rather than relying on resource discovery by accident.
 
 `module-info.java` belongs to a Schema Developer. A Groovy 4/5 schema requires
 the annotations and runtime modules, `requires static` compiler support, and
@@ -138,3 +152,9 @@ decision outside #391's accepted artifact set.
 **Making Groovy 3 module-path support work with flags.** `--add-reads`,
 `--add-exports`, patched modules, or generated descriptor variants hide the
 unsupported dependency graph and are not portable consumer contracts.
+
+**Publishing compiler transformations as global services or exports.** A
+global transform service would run for every source unit rather than only where
+the public marker annotation applies. Exporting the implementation packages
+would make compiler mechanics a consumer interface. Narrow Groovy-qualified
+opens preserve the existing activation semantics without either leak.

--- a/docs/implementation/adr-0014-groovy4-jpms-boundary.md
+++ b/docs/implementation/adr-0014-groovy4-jpms-boundary.md
@@ -64,16 +64,27 @@ together.
 
 ### JP-3 — Move compiler and adapters; add descriptors
 
-Move compiler implementation into its internal package, create its descriptor
-with `org.apache.groovy`, and declare its transformation provider. Move Jackson
-and Bean Validation implementation linkage to internal packages, retaining only
-their documented public adapters. Add exact descriptors, qualified runtime
-exports to compiler/Jackson only where bytecode proves they are necessary, and
-all `uses`/`provides` declarations.
+Move compiler implementation into its internal package and create its
+Groovy-4/5 descriptor with `org.apache.groovy`. Compiler transformations remain
+annotation-triggered local transforms: open `compiler.internal.ast`,
+`.ast.converters`, `.ast.mutators`, and `.layer3` only to `org.apache.groovy`;
+open `compiler.internal.validation` only to
+`com.blackbuild.klum.cast.compiler` for the established
+`@KlumCastValidator`-based reflective validator binding. The latter is not an
+export or generic reflection opening. Do not declare a global
+`ASTTransformation` provider or export compiler implementation packages. Groovy
+3 retains the common classpath artifact with no descriptor alternative. Move Jackson and Bean Validation implementation
+linkage to internal packages, retaining only their documented public adapters.
+Add exact descriptors, qualified runtime exports to compiler/Jackson only where
+bytecode proves they are necessary, and all runtime/Jackson/Bean
+`uses`/`provides` declarations.
 
 **Acceptance:** `jar --describe-module` reports the five canonical names and
 the intended exports/services; no package is split; no unqualified internal
-export exists.
+export exists. A Groovy 4/5 named-module probe activates DSL/mutator, converter,
+and Layer 3 annotations without `--add-reads`, `--add-exports`,
+`--patch-module`, or equivalent flags; the matching ordinary classpath evidence
+remains green in Groovy 3, 4, and 5.
 
 **Commit boundary:** compiler descriptor/move, then adapter descriptor/service
 work. Each commit retains a buildable descriptor set.

--- a/docs/implementation/evidence/issue-391-jp3-adr-conformance-audit.md
+++ b/docs/implementation/evidence/issue-391-jp3-adr-conformance-audit.md
@@ -1,0 +1,77 @@
+# #391 JP-3 ADR 0014 conformance audit
+
+This fail-closed audit was performed against merged JP-2c-FIX baseline
+`9eeb545a5e99d6e1861805df5167e732ac9fcc59` before any JP-3 module-descriptor
+source was added. It distinguishes a clean relocation boundary from the
+remaining descriptor-design gate.
+
+## Confirmed relocation and classpath boundary
+
+The five freshly built JARs have exclusive final package ownership:
+
+| Artifact | Verified package families |
+| --- | --- |
+| annotations | `com.blackbuild.klum.ast`, `.copy`, `.layer3`, `.internal.cast` |
+| runtime | `com.blackbuild.klum.ast.runtime`, `.runtime.validation`, `.runtime.internal...` |
+| compiler | `com.blackbuild.klum.ast.compiler.internal...` only |
+| Jackson | `com.blackbuild.klum.ast.jackson`, `.jackson.internal` |
+| Bean Validation | `com.blackbuild.klum.ast.validation.bean`, `.bean.internal` |
+
+The source/resource/GDSL scan finds no legacy
+`com.blackbuild.groovy.configdsl`, interim compiler, `util`, `process`, or old
+runtime-validation reference. Annotation transformation and KlumCast-validator
+strings name compiler-internal classes. The runtime and Bean Validation service
+resources use `PhaseAction` and `InstanceValidator`'s relocated public names.
+The generated JAR ownership/service assertions in
+`JpmsPackageBoundaryTest` pass in the Groovy 3, 4, and 5 lanes.
+
+`JpmsGroovyModuleIdentityTest` also passes in every lane: Groovy 3 resolves as
+`org.codehaus.groovy`, while Groovy 4 and 5 resolve as `org.apache.groovy`.
+The audit found no execution use of `--add-reads`, `--add-exports`, or
+`--patch-module`; they occur only in the explicit negative-probe guard and ADR
+text.
+
+The ordinary classpath artifact remains the common production artifact and the
+three lane tests above remain classpath-compatible evidence. It does not yet
+claim a named-schema fixture, which belongs to JP-4.
+
+## Descriptor contract that is already determined
+
+ADR 0014 fixes the five module names, the public export allowlists, the
+non-exported package families, Groovy 4/5's `org.apache.groovy` dependency, and
+Groovy 3's classpath-only boundary. The current bytecode/import graph also
+proves the bounded runtime-internal linkage candidates:
+
+- compiler reads `runtime.internal`, `.internal.process`, and
+  `.internal.layer3`;
+- Jackson reads `runtime.internal` and `.internal.process`;
+- Bean Validation reads only the public runtime-validation contract.
+
+Those observations are inputs to JP-3's qualified exports, not authorization
+to add a broad export or a third-party SPI.
+
+## Blocking descriptor ambiguity
+
+The relocation is clean, but the full ADR conformance check is **not clean**.
+ADR 0014 says that compiler activation remains a descriptor-owned Groovy
+transformation provider. The compiler JAR has no
+`META-INF/services/org.codehaus.groovy.transform.ASTTransformation` provider.
+Instead, annotation classes use `@GroovyASTTransformationClass` strings that
+point to local transformations in four non-exported compiler packages:
+
+- `com.blackbuild.klum.ast.compiler.internal.ast`
+- `com.blackbuild.klum.ast.compiler.internal.ast.converters`
+- `com.blackbuild.klum.ast.compiler.internal.ast.mutators`
+- `com.blackbuild.klum.ast.compiler.internal.layer3`
+
+The accepted material does not specify whether JP-3 must introduce a module
+`provides` activation path, open exactly those packages to `org.apache.groovy`,
+or use another approved named-module activation mechanism. These alternatives
+have different discovery and encapsulation behavior. Choosing one without a
+named-module activation fixture would make an architecture decision rather
+than implement ADR 0014.
+
+JP-3 must remain blocked until the maintainer records the activation/qualified-
+opens contract. The eventual decision needs an executable Groovy 4/5
+named-schema activation assertion; JP-4 owns the full schema fixture, but the
+directive choice must be settled before JP-3 creates the descriptor.

--- a/klum-ast-annotations/build.gradle
+++ b/klum-ast-annotations/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "klum-ast.java-conventions"
+    id "klum-ast.jpms-descriptor-conventions"
     id "klum-ast.jacoco-conventions"
 }
 
@@ -23,4 +24,3 @@ publishing {
 test {
     useJUnitPlatform()
 }
-

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/ModuleMarker.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast;
+
+final class ModuleMarker {
+}

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/copy/ModuleMarker.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/copy/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.copy;
+
+final class ModuleMarker {
+}

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/copy/package-info.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/copy/package-info.java
@@ -1,0 +1,1 @@
+package com.blackbuild.klum.ast.copy;

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/layer3/ModuleMarker.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/layer3/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.layer3;
+
+final class ModuleMarker {
+}

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/layer3/package-info.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/layer3/package-info.java
@@ -1,0 +1,1 @@
+package com.blackbuild.klum.ast.layer3;

--- a/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/package-info.java
+++ b/klum-ast-annotations/src/main/module-info/com/blackbuild/klum/ast/package-info.java
@@ -1,0 +1,1 @@
+package com.blackbuild.klum.ast;

--- a/klum-ast-annotations/src/main/module-info/module-info.java
+++ b/klum-ast-annotations/src/main/module-info/module-info.java
@@ -1,0 +1,8 @@
+module com.blackbuild.klum.ast.annotations {
+    requires static com.blackbuild.annodocimal.annotations;
+    requires static com.blackbuild.klum.cast.annotations;
+    requires static org.apache.groovy;
+    exports com.blackbuild.klum.ast;
+    exports com.blackbuild.klum.ast.copy;
+    exports com.blackbuild.klum.ast.layer3;
+}

--- a/klum-ast-bean-validation/build.gradle
+++ b/klum-ast-bean-validation/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "klum-ast.multigroovy-conventions"
+    id "klum-ast.jpms-descriptor-conventions"
     id "klum-ast.jacoco-conventions"
 }
 

--- a/klum-ast-bean-validation/src/main/module-info/com/blackbuild/klum/ast/validation/bean/ModuleMarker.java
+++ b/klum-ast-bean-validation/src/main/module-info/com/blackbuild/klum/ast/validation/bean/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.validation.bean;
+
+final class ModuleMarker {
+}

--- a/klum-ast-bean-validation/src/main/module-info/com/blackbuild/klum/ast/validation/bean/internal/JSR380Validator.java
+++ b/klum-ast-bean-validation/src/main/module-info/com/blackbuild/klum/ast/validation/bean/internal/JSR380Validator.java
@@ -1,0 +1,10 @@
+package com.blackbuild.klum.ast.validation.bean.internal;
+
+import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+import com.blackbuild.klum.ast.runtime.validation.KlumValidationResult;
+
+public class JSR380Validator implements InstanceValidator {
+    @Override
+    public void validateInstance(Object instance, KlumValidationResult validationResult) {
+    }
+}

--- a/klum-ast-bean-validation/src/main/module-info/module-info.java
+++ b/klum-ast-bean-validation/src/main/module-info/module-info.java
@@ -1,0 +1,9 @@
+module com.blackbuild.klum.ast.validation.bean {
+    requires transitive com.blackbuild.klum.ast.runtime;
+    requires transitive jakarta.validation;
+    requires org.hibernate.validator;
+    exports com.blackbuild.klum.ast.validation.bean;
+
+    provides com.blackbuild.klum.ast.runtime.validation.InstanceValidator with
+            com.blackbuild.klum.ast.validation.bean.internal.JSR380Validator;
+}

--- a/klum-ast-jackson/build.gradle
+++ b/klum-ast-jackson/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "klum-ast.multigroovy-conventions"
+    id "klum-ast.jpms-descriptor-conventions"
     id "klum-ast.jacoco-conventions"
 }
 

--- a/klum-ast-jackson/src/main/module-info/com/blackbuild/klum/ast/jackson/KlumAstModule.java
+++ b/klum-ast-jackson/src/main/module-info/com/blackbuild/klum/ast/jackson/KlumAstModule.java
@@ -1,0 +1,20 @@
+package com.blackbuild.klum.ast.jackson;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+
+public class KlumAstModule extends Module {
+    @Override
+    public String getModuleName() {
+        return "KlumAST";
+    }
+
+    @Override
+    public Version version() {
+        return Version.unknownVersion();
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+    }
+}

--- a/klum-ast-jackson/src/main/module-info/module-info.java
+++ b/klum-ast-jackson/src/main/module-info/module-info.java
@@ -1,0 +1,8 @@
+module com.blackbuild.klum.ast.jackson {
+    requires transitive com.blackbuild.klum.ast.runtime;
+    requires transitive com.fasterxml.jackson.databind;
+    exports com.blackbuild.klum.ast.jackson;
+
+    provides com.fasterxml.jackson.databind.Module with
+            com.blackbuild.klum.ast.jackson.KlumAstModule;
+}

--- a/klum-ast-runtime/build.gradle
+++ b/klum-ast-runtime/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "klum-ast.multigroovy-conventions"
+    id "klum-ast.jpms-descriptor-conventions"
     id "klum-ast.jacoco-conventions"
     id "java-test-fixtures"
 }

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/PhaseAction.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/PhaseAction.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime;
+
+public interface PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/CleanupPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/CleanupPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class CleanupPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/DefaultPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/DefaultPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class DefaultPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/InstantiatePhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/InstantiatePhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class InstantiatePhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/OwnerPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/OwnerPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class OwnerPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/PostTreePhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/PostTreePhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class PostTreePhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/VerifyPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/VerifyPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class VerifyPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/AutoCreationPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/AutoCreationPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.layer3;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class AutoCreationPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/AutoLinkPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/AutoLinkPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.layer3;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class AutoLinkPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/layer3/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.internal.layer3;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/process/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/process/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.internal.process;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/EarlyValidationPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/EarlyValidationPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class EarlyValidationPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumFieldAnnotationsValidator.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumFieldAnnotationsValidator.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+
+public class KlumFieldAnnotationsValidator implements InstanceValidator {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumInnerClassValidator.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumInnerClassValidator.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+
+public class KlumInnerClassValidator implements InstanceValidator {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumMethodAnnotationsValidator.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/KlumMethodAnnotationsValidator.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+
+public class KlumMethodAnnotationsValidator implements InstanceValidator {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/ValidationPhase.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/internal/validation/ValidationPhase.java
@@ -1,0 +1,6 @@
+package com.blackbuild.klum.ast.runtime.internal.validation;
+
+import com.blackbuild.klum.ast.runtime.PhaseAction;
+
+public class ValidationPhase implements PhaseAction {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/validation/InstanceValidator.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/validation/InstanceValidator.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.validation;
+
+public interface InstanceValidator {
+}

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/validation/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/validation/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.runtime.validation;
+
+final class ModuleMarker {
+}

--- a/klum-ast-runtime/src/main/module-info/module-info.java
+++ b/klum-ast-runtime/src/main/module-info/module-info.java
@@ -1,0 +1,34 @@
+module com.blackbuild.klum.ast.runtime {
+    requires transitive com.blackbuild.klum.ast.annotations;
+    requires transitive org.apache.groovy;
+    requires static com.blackbuild.annodocimal.annotations;
+    exports com.blackbuild.klum.ast.runtime;
+    exports com.blackbuild.klum.ast.runtime.validation;
+    exports com.blackbuild.klum.ast.runtime.internal to
+            com.blackbuild.klum.ast.compiler,
+            com.blackbuild.klum.ast.jackson;
+    exports com.blackbuild.klum.ast.runtime.internal.layer3 to
+            com.blackbuild.klum.ast.compiler;
+    exports com.blackbuild.klum.ast.runtime.internal.process to
+            com.blackbuild.klum.ast.compiler,
+            com.blackbuild.klum.ast.jackson;
+
+    uses com.blackbuild.klum.ast.runtime.PhaseAction;
+    uses com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+
+    provides com.blackbuild.klum.ast.runtime.PhaseAction with
+            com.blackbuild.klum.ast.runtime.internal.validation.EarlyValidationPhase,
+            com.blackbuild.klum.ast.runtime.internal.OwnerPhase,
+            com.blackbuild.klum.ast.runtime.internal.DefaultPhase,
+            com.blackbuild.klum.ast.runtime.internal.layer3.AutoCreationPhase,
+            com.blackbuild.klum.ast.runtime.internal.layer3.AutoLinkPhase,
+            com.blackbuild.klum.ast.runtime.internal.PostTreePhase,
+            com.blackbuild.klum.ast.runtime.internal.InstantiatePhase,
+            com.blackbuild.klum.ast.runtime.internal.validation.ValidationPhase,
+            com.blackbuild.klum.ast.runtime.internal.VerifyPhase,
+            com.blackbuild.klum.ast.runtime.internal.CleanupPhase;
+    provides com.blackbuild.klum.ast.runtime.validation.InstanceValidator with
+            com.blackbuild.klum.ast.runtime.internal.validation.KlumFieldAnnotationsValidator,
+            com.blackbuild.klum.ast.runtime.internal.validation.KlumMethodAnnotationsValidator,
+            com.blackbuild.klum.ast.runtime.internal.validation.KlumInnerClassValidator;
+}

--- a/klum-ast/build.gradle
+++ b/klum-ast/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "klum-ast.multigroovy-conventions"
+    id "klum-ast.jpms-descriptor-conventions"
     id "klum-ast.jacoco-conventions"
     id "java-test-fixtures"
 }
@@ -23,6 +24,10 @@ gradle.projectsEvaluated {
         systemProperty('klumRuntimeJar', project(':klum-ast-runtime').tasks.named('jar').flatMap { it.archiveFile }.get().asFile)
         systemProperty('klumJacksonJar', project(':klum-ast-jackson').tasks.named('jar').flatMap { it.archiveFile }.get().asFile)
         systemProperty('klumBeanValidationJar', project(':klum-ast-bean-validation').tasks.named('jar').flatMap { it.archiveFile }.get().asFile)
+        systemProperty('jpmsAdapterModulePath', files(
+                project(':klum-ast-jackson').configurations.runtimeClasspath,
+                project(':klum-ast-bean-validation').configurations.runtimeClasspath
+        ).asPath)
     }
 }
 

--- a/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/ModuleMarker.java
+++ b/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.compiler.internal.ast;
+
+final class ModuleMarker {
+}

--- a/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/converters/ModuleMarker.java
+++ b/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/converters/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.compiler.internal.ast.converters;
+
+final class ModuleMarker {
+}

--- a/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModuleMarker.java
+++ b/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.compiler.internal.ast.mutators;
+
+final class ModuleMarker {
+}

--- a/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/layer3/ModuleMarker.java
+++ b/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/layer3/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.compiler.internal.layer3;
+
+final class ModuleMarker {
+}

--- a/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/validation/ModuleMarker.java
+++ b/klum-ast/src/main/module-info/com/blackbuild/klum/ast/compiler/internal/validation/ModuleMarker.java
@@ -1,0 +1,4 @@
+package com.blackbuild.klum.ast.compiler.internal.validation;
+
+final class ModuleMarker {
+}

--- a/klum-ast/src/main/module-info/module-info.java
+++ b/klum-ast/src/main/module-info/module-info.java
@@ -1,0 +1,15 @@
+module com.blackbuild.klum.ast.compiler {
+    requires java.desktop;
+    requires com.blackbuild.annodocimal.global.ast;
+    requires com.blackbuild.klum.ast.annotations;
+    requires com.blackbuild.klum.ast.runtime;
+    requires com.blackbuild.klum.cast.annotations;
+    requires com.blackbuild.klum.cast.compiler;
+    requires com.blackbuild.klum.cast.spi;
+    requires org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.ast to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.ast.converters to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.ast.mutators to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.layer3 to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.validation to com.blackbuild.klum.cast.compiler;
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -215,12 +215,14 @@ class JpmsPackageBoundaryTest extends Specification {
     }
 
     private static ProcessResult compileNamedSchema() {
-        compileSchema([
+        List<String> command = [
                 '--module-path', modulePathEntries().join(File.pathSeparator),
                 '--add-modules', 'ALL-MODULE-PATH',
                 '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler',
                 '--classpath', modulePathEntries().join(File.pathSeparator)
-        ])
+        ]
+        assertNamedModuleCommand(command)
+        compileSchema(command)
     }
 
     private static ProcessResult compileClasspathSchema() {
@@ -258,6 +260,19 @@ class JpmsPackageBoundaryTest extends Specification {
         builder.environment().remove('CLASSPATH')
         Process process = builder.start()
         new ProcessResult(process.waitFor(), process.inputStream.text, output)
+    }
+
+    private static void assertNamedModuleCommand(List<String> command) {
+        assert command.containsAll([
+                '--module-path',
+                '--add-modules', 'ALL-MODULE-PATH',
+                '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler'
+        ])
+        assert !command.any { option ->
+            ['--add-reads', '--add-exports', '--patch-module'].any { forbidden ->
+                option == forbidden || option.startsWith("${forbidden}=")
+            }
+        }
     }
 
     private static List<String> modulePathEntries() {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -28,6 +28,7 @@ import spock.lang.Specification
 
 import java.lang.module.ModuleFinder
 import java.nio.file.Path
+import java.nio.file.Files
 import java.util.jar.JarFile
 
 @Issue("391")
@@ -94,6 +95,71 @@ class JpmsPackageBoundaryTest extends Specification {
         ] as Set
     }
 
+    def "artifacts publish the approved explicit module contracts"() {
+        given:
+        def descriptors = artifacts().collectEntries { name, jar ->
+            [(name): ModuleFinder.of(jar).findAll().first().descriptor()]
+        }
+
+        expect:
+        descriptors.collectEntries { name, descriptor -> [(name): descriptor.name()] } == [
+                annotations   : 'com.blackbuild.klum.ast.annotations',
+                runtime       : 'com.blackbuild.klum.ast.runtime',
+                compiler      : 'com.blackbuild.klum.ast.compiler',
+                jackson       : 'com.blackbuild.klum.ast.jackson',
+                beanValidation: 'com.blackbuild.klum.ast.validation.bean'
+        ]
+        exportedPackages(descriptors.annotations) == [
+                'com.blackbuild.klum.ast',
+                'com.blackbuild.klum.ast.copy',
+                'com.blackbuild.klum.ast.layer3'
+        ] as Set
+        exportedPackages(descriptors.runtime) == [
+                'com.blackbuild.klum.ast.runtime',
+                'com.blackbuild.klum.ast.runtime.validation'
+        ] as Set
+        exportedPackages(descriptors.compiler).empty
+        exportedPackages(descriptors.jackson) == ['com.blackbuild.klum.ast.jackson'] as Set
+        exportedPackages(descriptors.beanValidation) == ['com.blackbuild.klum.ast.validation.bean'] as Set
+        qualifiedOpenTargets(descriptors.compiler) == [
+                'com.blackbuild.klum.ast.compiler.internal.ast'           : ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.ast.converters': ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.ast.mutators'  : ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.layer3'        : ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.validation'    : ['com.blackbuild.klum.cast.compiler'] as Set
+        ]
+        !descriptors.compiler.provides().any { it.service() == 'org.codehaus.groovy.transform.ASTTransformation' }
+        descriptors.runtime.uses().containsAll([
+                'com.blackbuild.klum.ast.runtime.PhaseAction',
+                'com.blackbuild.klum.ast.runtime.validation.InstanceValidator'
+        ])
+        descriptors.beanValidation.provides().any {
+            it.service() == 'com.blackbuild.klum.ast.runtime.validation.InstanceValidator' &&
+                    it.providers() == ['com.blackbuild.klum.ast.validation.bean.internal.JSR380Validator']
+        }
+        descriptors.jackson.provides().any {
+            it.service() == 'com.fasterxml.jackson.databind.Module' &&
+                    it.providers() == ['com.blackbuild.klum.ast.jackson.KlumAstModule']
+        }
+    }
+
+    def "Groovy 4 and 5 activate local transformations from the named compiler module"() {
+        given:
+        boolean namedGroovy = GroovySystem.version.startsWith('4.') || GroovySystem.version.startsWith('5.')
+
+        when:
+        ProcessResult classpathResult = compileClasspathSchema()
+        ProcessResult namedModuleResult = namedGroovy ? compileNamedSchema() : null
+
+        then:
+        assert classpathResult.exitCode == 0 : classpathResult.output
+        Files.exists(classpathResult.outputDirectory.resolve('NamedRoot.class'))
+
+        and: 'Groovy 3 remains classpath-only while Groovy 4 and 5 also prove the named-module path.'
+        !namedGroovy || namedModuleResult.exitCode == 0
+        !namedGroovy || Files.exists(namedModuleResult.outputDirectory.resolve('NamedRoot.class'))
+    }
+
     private static Map<String, Set<String>> packageOwners(Map<String, Set<String>> packagesByArtifact) {
         Map<String, Set<String>> owners = new LinkedHashMap<>()
         packagesByArtifact.each { artifact, packageNames ->
@@ -106,6 +172,16 @@ class JpmsPackageBoundaryTest extends Specification {
 
     private static Set<String> packages(Path jar) {
         ModuleFinder.of(jar).findAll().first().descriptor().packages()
+    }
+
+    private static Set<String> exportedPackages(def descriptor) {
+        descriptor.exports().findAll { !it.isQualified() }.collect { it.source() } as Set
+    }
+
+    private static Map<String, Set<String>> qualifiedOpenTargets(def descriptor) {
+        descriptor.opens().collectEntries { opened ->
+            [(opened.source()): opened.targets()]
+        }
     }
 
     private static Set<String> resourceNames(Path jar) {
@@ -136,5 +212,78 @@ class JpmsPackageBoundaryTest extends Specification {
 
     private static Path jarPath(String property) {
         Path.of(System.getProperty(property))
+    }
+
+    private static ProcessResult compileNamedSchema() {
+        compileSchema([
+                '--module-path', modulePathEntries().join(File.pathSeparator),
+                '--add-modules', 'ALL-MODULE-PATH',
+                '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler',
+                '--classpath', modulePathEntries().join(File.pathSeparator)
+        ])
+    }
+
+    private static ProcessResult compileClasspathSchema() {
+        compileSchema([
+                '--class-path', modulePathEntries().join(File.pathSeparator),
+                'org.codehaus.groovy.tools.FileSystemCompiler'
+        ])
+    }
+
+    private static ProcessResult compileSchema(List<String> compilerCommand) {
+        Path fixture = Files.createTempDirectory('klum-jpms-schema')
+        Path source = fixture.resolve('NamedSchema.groovy')
+        Path output = fixture.resolve('classes')
+        Files.createDirectories(output)
+        Files.writeString(source, '''
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Required
+            import com.blackbuild.klum.ast.layer3.Cluster
+
+            @DSL class NamedRoot {
+                @Required String name
+                @Cluster Map<String, NamedChild> children
+            }
+
+            @DSL class NamedChild {}
+        '''.stripIndent())
+
+        List<String> command = [Path.of(System.getProperty('java.home'), 'bin', 'java').toString()]
+        command.addAll(compilerCommand)
+        command.addAll([
+                '-d', output.toString(),
+                source.toString()
+        ])
+        ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true)
+        builder.environment().remove('CLASSPATH')
+        Process process = builder.start()
+        new ProcessResult(process.waitFor(), process.inputStream.text, output)
+    }
+
+    private static List<String> modulePathEntries() {
+        List<String> paths = artifacts().values()*.toString()
+        paths.addAll((System.getProperty('java.class.path') + File.pathSeparator +
+                System.getProperty('jpmsAdapterModulePath')).split(File.pathSeparator).findAll { entry ->
+            String name = Path.of(entry).fileName.toString()
+            [
+                    'groovy-3.', 'groovy-4.', 'groovy-5.',
+                    'anno-docimal-annotations-', 'anno-docimal-ast-', 'anno-docimal-global-ast-',
+                    'klum-cast-annotations-', 'klum-cast-compile-', 'klum-cast-spi-', 'jspecify-',
+                    'jackson-', 'jakarta.validation-api-', 'hibernate-validator-', 'jboss-logging-', 'classmate-'
+            ].any { marker -> name.startsWith(marker) }
+        })
+        paths.unique()
+    }
+
+    private static class ProcessResult {
+        int exitCode
+        String output
+        Path outputDirectory
+
+        ProcessResult(int exitCode, String output, Path outputDirectory) {
+            this.exitCode = exitCode
+            this.output = output
+            this.outputDirectory = outputDirectory
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add explicit descriptors for the five accepted KlumAST artifacts without changing the Groovy 3 classpath artifact
- document local-transform activation and the narrow Klum Cast reflective opening required by established validator bindings
- add a Groovy 4/5 named-module activation probe plus Groovy 3/4/5 ordinary-classpath comparison

## Why

The package-ownership slices removed JPMS split packages. This completes the approved JP-3 descriptor contract and proves annotation-triggered DSL/mutator, converter, and Layer 3 activation without workaround flags.

## Impact

No public API or import migration is introduced. Groovy 3 remains classpath-only; Groovy 4/5 gain the explicit named-module contract.

Related #391

## Validation

- ./gradlew check
- ./gradlew :klum-ast:test :klum-ast:groovy4Tests :klum-ast:groovy5Tests --rerun-tasks
- descriptor ownership, exports/opens, services, JAR/source-JAR packaging, and workaround-flag guard