### PR TITLE
Qualify KlumCast validator reflection opens

### DIFF
--- a/docs/adr/0014-groovy4-jpms-boundary.md
+++ b/docs/adr/0014-groovy4-jpms-boundary.md
@@ -101,13 +101,23 @@ module provides `InstanceValidator`; the Jackson module provides the Jackson
 KlumAST compiler transformations are annotation-triggered local transforms,
 not global `META-INF/services` transforms. For Groovy 4/5, the compiler module
 requires `org.apache.groovy` and opens `compiler.internal.ast`,
-`.ast.converters`, `.ast.mutators`, and `.layer3` only to that module, allowing
-Groovy to instantiate the transformations named by the public annotations. It
-also opens `compiler.internal.validation` only to
-`com.blackbuild.klum.cast.compiler`: the established
-`@KlumCastValidator` bindings require Klum Cast to reflectively instantiate
-their internal validation checks. That narrow reflective opening is neither an
-export nor generic reflection access. The compiler exports none of these
+`.ast.converters`, `.ast.mutators`, and `.layer3` to that module, allowing
+Groovy to instantiate the transformations named by the public annotations.
+
+The established `@KlumCastValidator` route separately requires Klum Cast to
+reflectively instantiate exactly these compiler-internal checks:
+
+| Package | Check classes | Qualified target |
+| --- | --- | --- |
+| `compiler.internal.ast` | `FieldAstValidator` | `com.blackbuild.klum.cast.compiler` |
+| `compiler.internal.ast.mutators` | `WriteAccessMethodCheck` | `com.blackbuild.klum.cast.compiler` |
+| `compiler.internal.layer3` | `DefaultValuesCheck` | `com.blackbuild.klum.cast.compiler` |
+| `compiler.internal.validation` | `CheckDslAnnotation`, `CheckForPrimitiveBoolean`, `OverwriteMapCheck`, `OverwriteSingleCheck`, `ValidateAnnotationCheck` | `com.blackbuild.klum.cast.compiler` |
+
+The validation package was already opened to that exact target; JP-3b adds the
+three missing package-target directives, starting with the mutator check that
+exposed the named-schema failure. These narrow reflective openings are neither
+exports nor generic reflection access. The compiler exports none of these
 implementation packages and declares no
 `provides org.codehaus.groovy.transform.ASTTransformation` clause. Groovy 3
 has no descriptor alternative and remains classpath-only.

--- a/docs/implementation/adr-0014-groovy4-jpms-boundary.md
+++ b/docs/implementation/adr-0014-groovy4-jpms-boundary.md
@@ -67,11 +67,19 @@ together.
 Move compiler implementation into its internal package and create its
 Groovy-4/5 descriptor with `org.apache.groovy`. Compiler transformations remain
 annotation-triggered local transforms: open `compiler.internal.ast`,
-`.ast.converters`, `.ast.mutators`, and `.layer3` only to `org.apache.groovy`;
+`.ast.converters`, `.ast.mutators`, and `.layer3` to `org.apache.groovy`;
 open `compiler.internal.validation` only to
 `com.blackbuild.klum.cast.compiler` for the established
-`@KlumCastValidator`-based reflective validator binding. The latter is not an
-export or generic reflection opening. Do not declare a global
+`@KlumCastValidator`-based reflective validator binding. The complete
+KlumCast-reflected inventory is `FieldAstValidator` in `compiler.internal.ast`,
+`WriteAccessMethodCheck` in `compiler.internal.ast.mutators`,
+`DefaultValuesCheck` in `compiler.internal.layer3`, and
+`CheckDslAnnotation`, `CheckForPrimitiveBoolean`, `OverwriteMapCheck`,
+`OverwriteSingleCheck`, and `ValidateAnnotationCheck` in
+`compiler.internal.validation`. Therefore `ast`, `ast.mutators`, and `layer3`
+also open only to `com.blackbuild.klum.cast.compiler`; `validation` already has
+that directive. `ast.converters` remains Groovy-only. These openings are not
+exports or generic reflection access. Do not declare a global
 `ASTTransformation` provider or export compiler implementation packages. Groovy
 3 retains the common classpath artifact with no descriptor alternative. Move Jackson and Bean Validation implementation
 linkage to internal packages, retaining only their documented public adapters.
@@ -85,6 +93,11 @@ export exists. A Groovy 4/5 named-module probe activates DSL/mutator, converter,
 and Layer 3 annotations without `--add-reads`, `--add-exports`,
 `--patch-module`, or equivalent flags; the matching ordinary classpath evidence
 remains green in Groovy 3, 4, and 5.
+
+**JP-3b boundary acceptance:** descriptor evidence asserts the complete
+compiler `opens` map, including the three KlumCast-qualified validator packages
+and the Groovy-only converter package, so a future check cannot widen the
+boundary by adding an unqualified open or another target.
 
 **Commit boundary:** compiler descriptor/move, then adapter descriptor/service
 work. Each commit retains a buildable descriptor set.

--- a/docs/implementation/evidence/issue-391-jp3-adr-conformance-audit.md
+++ b/docs/implementation/evidence/issue-391-jp3-adr-conformance-audit.md
@@ -50,6 +50,24 @@ proves the bounded runtime-internal linkage candidates:
 Those observations are inputs to JP-3's qualified exports, not authorization
 to add a broad export or a third-party SPI.
 
+## KlumCast reflective-validator inventory
+
+The public annotation bindings name eight compiler implementation checks. Klum
+Cast reflectively instantiates them through the established
+`@KlumCastValidator` route; they are not exported APIs:
+
+| Compiler package | Bound checks | JP-3b qualified opening |
+| --- | --- | --- |
+| `compiler.internal.ast` | `FieldAstValidator` | Add `com.blackbuild.klum.cast.compiler` alongside the existing Groovy target. |
+| `compiler.internal.ast.mutators` | `WriteAccessMethodCheck` | Add `com.blackbuild.klum.cast.compiler` alongside the existing Groovy target. |
+| `compiler.internal.layer3` | `DefaultValuesCheck` | Add `com.blackbuild.klum.cast.compiler` alongside the existing Groovy target. |
+| `compiler.internal.validation` | `CheckDslAnnotation`, `CheckForPrimitiveBoolean`, `OverwriteMapCheck`, `OverwriteSingleCheck`, `ValidateAnnotationCheck` | Already open only to `com.blackbuild.klum.cast.compiler`. |
+
+`compiler.internal.ast.converters` has no `@KlumCastValidator` binding and
+remains open only to Groovy. No other compiler package is a reflected KlumCast
+validator category, so no further directive or architectural decision is
+required.
+
 ## Blocking descriptor ambiguity
 
 The relocation is clean, but the full ADR conformance check is **not clean**.

--- a/klum-ast/src/main/module-info/module-info.java
+++ b/klum-ast/src/main/module-info/module-info.java
@@ -7,9 +7,15 @@ module com.blackbuild.klum.ast.compiler {
     requires com.blackbuild.klum.cast.compiler;
     requires com.blackbuild.klum.cast.spi;
     requires org.apache.groovy;
-    opens com.blackbuild.klum.ast.compiler.internal.ast to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.ast to
+            org.apache.groovy,
+            com.blackbuild.klum.cast.compiler;
     opens com.blackbuild.klum.ast.compiler.internal.ast.converters to org.apache.groovy;
-    opens com.blackbuild.klum.ast.compiler.internal.ast.mutators to org.apache.groovy;
-    opens com.blackbuild.klum.ast.compiler.internal.layer3 to org.apache.groovy;
+    opens com.blackbuild.klum.ast.compiler.internal.ast.mutators to
+            org.apache.groovy,
+            com.blackbuild.klum.cast.compiler;
+    opens com.blackbuild.klum.ast.compiler.internal.layer3 to
+            org.apache.groovy,
+            com.blackbuild.klum.cast.compiler;
     opens com.blackbuild.klum.ast.compiler.internal.validation to com.blackbuild.klum.cast.compiler;
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -122,10 +122,19 @@ class JpmsPackageBoundaryTest extends Specification {
         exportedPackages(descriptors.jackson) == ['com.blackbuild.klum.ast.jackson'] as Set
         exportedPackages(descriptors.beanValidation) == ['com.blackbuild.klum.ast.validation.bean'] as Set
         qualifiedOpenTargets(descriptors.compiler) == [
-                'com.blackbuild.klum.ast.compiler.internal.ast'           : ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.ast'           : [
+                        'org.apache.groovy',
+                        'com.blackbuild.klum.cast.compiler'
+                ] as Set,
                 'com.blackbuild.klum.ast.compiler.internal.ast.converters': ['org.apache.groovy'] as Set,
-                'com.blackbuild.klum.ast.compiler.internal.ast.mutators'  : ['org.apache.groovy'] as Set,
-                'com.blackbuild.klum.ast.compiler.internal.layer3'        : ['org.apache.groovy'] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.ast.mutators'  : [
+                        'org.apache.groovy',
+                        'com.blackbuild.klum.cast.compiler'
+                ] as Set,
+                'com.blackbuild.klum.ast.compiler.internal.layer3'        : [
+                        'org.apache.groovy',
+                        'com.blackbuild.klum.cast.compiler'
+                ] as Set,
                 'com.blackbuild.klum.ast.compiler.internal.validation'    : ['com.blackbuild.klum.cast.compiler'] as Set
         ]
         !descriptors.compiler.provides().any { it.service() == 'org.codehaus.groovy.transform.ASTTransformation' }


### PR DESCRIPTION
## Summary

Adds the three evidence-backed qualified JPMS opens that let KlumCast instantiate its name-bound internal checks in a named compiler module.

- Opens `compiler.internal.ast`, `compiler.internal.ast.mutators`, and `compiler.internal.layer3` to `com.blackbuild.klum.cast.compiler` alongside their existing Groovy target.
- Keeps `compiler.internal.ast.converters` Groovy-only and retains the existing validation-package opening.
- Records the exact eight-check inventory in ADR 0014, its implementation plan, and conformance evidence.
- Makes the compiler descriptor's complete `opens` map fail closed in `JpmsPackageBoundaryTest`.

## Why

KlumCast resolves name-bound `@KlumCastValidator` checks with `Class.forName` and reflectively invokes their no-argument constructors. The mutator check exposed the missing qualified-open boundary in the fresh named-schema scenario.

## Impact

No public exports, APIs, package moves, runtime flags, or migration changes. The change enables only the established internal KlumCast validator-instantiation path for Groovy 4/5 named schemas.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.JpmsPackageBoundaryTest`
- `./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests --tests com.blackbuild.klum.ast.JpmsPackageBoundaryTest`
- `./gradlew :klum-ast:test :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- `git diff --check`

Related: #391

The broader JPMS issue remains open; JP-1b retains the end-to-end fresh named-schema acceptance rerun.
