### PR TITLE
Draft generated-schema runtime linkage decision

### DIFF
--- a/docs/adr/0015-generated-schema-runtime-linkage.md
+++ b/docs/adr/0015-generated-schema-runtime-linkage.md
@@ -1,0 +1,148 @@
+# Generated-schema runtime linkage boundary
+
+Date: 2026-07-28
+
+Status: Proposed
+
+Tracking issue: [#391 — Define Java modules and finalize public packages for 4.0](https://github.com/klum-dsl/klum-ast/issues/391)
+
+Implementation plan: [ADR 0015 implementation plan](../implementation/adr-0015-generated-schema-runtime-linkage.md)
+
+Parent decisions: [ADR 0003 — Builder-first materialization](0003-builder-first-materialization.md),
+[ADR 0004 — AsBuilder composition](0004-asbuilder-composition-protocol.md),
+[ADR 0005 — generated DSL support API](0005-generated-dsl-support-api.md), and
+[ADR 0014 — Groovy 4/5 JPMS boundary](0014-groovy4-jpms-boundary.md).
+
+## Context
+
+ADR 0014 correctly confines ordinary runtime implementation packages and gives
+only the compiler and Jackson adapter their checked qualified exports. The
+generated-schema ABI inventory now identifies a conflicting fact: some emitted
+classes are defined in the Schema Developer's module, not in either of those
+KlumAST modules. They directly name or invoke types in
+`com.blackbuild.klum.ast.runtime.internal...`.
+
+The principal links are the generated `Foo$Builder` superclass and construction
+hooks (`InternalKlumBuilder` and its materialization token), the generated
+model companion descriptor, the current public `Foo.Template` handler,
+breadcrumb collection/cluster calls, cluster queries, and omitted-projection
+fallback. A qualified export to the compiler cannot authorize the JVM linkage
+of an arbitrary named schema module. The exact inventory is recorded in
+[the #391 JP-ABI evidence](../implementation/evidence/issue-391-jp-abi-generated-schema-runtime.md).
+
+Leaving this unresolved would make the JP-4 named-schema fixture fail, or
+would pressure the project to use broad internal exports or consumer JVM flags.
+Both outcomes contradict ADR 0014's positive export list and portable Groovy
+4/5 module-path contract.
+
+## Decision
+
+### Add one generated-runtime ABI package
+
+The runtime artifact owns a new generally exported package:
+
+```text
+com.blackbuild.klum.ast.runtime.generated
+```
+
+It is the only runtime package whose purpose is compiler-emitted linkage in a
+Schema Developer's module. It is a stable 4.x binary contract after the
+intentional 3.x-to-4.0 recompilation break, but is neither a general client API
+nor a third-party extension SPI. Its types and members use generated-only
+Javadoc and reserved `$klum$` operation names where a generated class must call
+an operation directly.
+
+The package contains only these narrow roles:
+
+- a public abstract generated Builder base implementing `KlumBuilder<M>`, with
+  the protected/public construction hooks presently emitted against
+  `InternalKlumBuilder`;
+- an opaque public materialization token and generated object-state descriptor
+  required by protected generated constructors and private generated fields;
+- static generated helpers for breadcrumb, cluster, and omitted-projection
+  operations currently emitted against internal helpers; and
+- a public generated Template facade used by `Foo.Template` and implemented by
+  an internal handler. `Foo_DSL.Template` becomes the schema-specific public
+  type when Template operations must be named by generated/client code.
+
+The exact member set is frozen from the JP-ABI inventory during JP-ABI-1. Each
+member must have a generated class-file call site or descriptor; convenience
+operations, raw Builder state, lifecycle driver access, reflection, traversal,
+and general mutation APIs do not enter this package.
+
+### Retarget emitted bytecode, keep mechanics internal
+
+The compiler generates only public annotations, schema types, existing runtime
+API types, and `runtime.generated` types in descriptors and direct calls. It
+does not emit a reference to `runtime.internal`, `.internal.process`, or
+`.internal.layer3`.
+
+`InternalKlumBuilder`, companions, Template recipes/handlers, collection and
+cluster mechanics, and all lifecycle implementation remain internal. They may
+implement or be delegated to by the generated-runtime ABI but are not exported
+to schema modules. The compiler/Jackson qualified exports in ADR 0014 remain
+limited to their own checked implementation linkage.
+
+The schema module continues to require the existing runtime module and open
+its DSL packages to it. No schema adds a `requires` clause for an internal
+KlumAST package, and the schema plugin never writes a module descriptor.
+
+### Freeze the public generated contracts honestly
+
+`Foo_DSL.Factory`, `Foo_DSL.Builder`, and their collection/cluster factory
+interfaces remain the supported build-time interfaces from ADR 0005. Clients
+may name but not implement or subclass them. `KlumBuilder<T>` remains the
+zero-operation public capability; the generated Builder base is not a mutable
+client Builder API.
+
+The current public `Foo.Template` field must no longer expose an internal
+handler descriptor. It is retargeted to the generated Template facade, which
+is the condition ADR 0005 anticipated for a `Foo_DSL.Template` contract.
+Neither this facade nor the generated-runtime package changes root-vs-Builder
+construction, Construction-session ownership, Materialization, Template
+serialization, or Jackson behavior.
+
+### Prove it in real named schemas
+
+The named-schema fixture required by ADR 0014 JP-4 becomes the acceptance
+authority. It compiles and runs a Groovy 4 and Groovy 5 schema module with a
+root, relationship/collection or cluster operation, Template, and omitted
+projection path; then exercises Java and `@CompileStatic` Groovy consumers.
+The fixture must link without `--add-exports`, `--add-opens`, `--add-reads`,
+or patched modules. Groovy 3 remains classpath-only and retains its explicit
+negative module-path guidance.
+
+## Consequences
+
+- Named schemas use one explicit, minimal framework ABI rather than a hidden
+  dependency on the compiler's qualified exports.
+- The runtime module gains a small additional export whose compatibility is
+  reviewed as generated bytecode ABI; its scope stays distinct from client and
+  extension APIs.
+- Existing classpath schemas recompile for 4.0 and retain behavior, while
+  Groovy 4/5 named schemas gain a portable linkage boundary.
+- The compiler must retain an automated inventory that rejects emitted
+  `runtime.internal` references before a release candidate.
+- Current user migration guidance remains valid; named-module documentation is
+  added only after the JP-4 fixture passes.
+
+## Rejected alternatives
+
+**Export all runtime internals.** This would freeze lifecycle, reflection,
+companions, and mechanics as public API, directly reversing ADR 0014's
+positive export boundary.
+
+**Add each schema module to qualified runtime exports.** Schema module names
+are user-owned and unbounded; a published descriptor cannot enumerate them.
+
+**Use consumer JVM flags.** `--add-exports`, `--add-opens`, `--add-reads`, or
+patched modules make a local launch work but are not portable Schema Developer
+contracts and are already rejected by ADR 0014.
+
+**Treat hidden generated classes as exempt from JPMS.** Access checks apply to
+the defining schema module even when the class or member is synthetic or not a
+supported client API.
+
+**Keep `Foo.Template` typed to the internal handler.** Its public field
+descriptor already leaks an internal name; preserving it would make that leak
+the de facto 4.x schema ABI.

--- a/docs/implementation/adr-0015-generated-schema-runtime-linkage.md
+++ b/docs/implementation/adr-0015-generated-schema-runtime-linkage.md
@@ -1,0 +1,163 @@
+# ADR 0015 implementation plan: generated-schema runtime linkage
+
+This plan implements proposed [ADR 0015](../adr/0015-generated-schema-runtime-linkage.md)
+for [#391](https://github.com/klum-dsl/klum-ast/issues/391). It is a prerequisite
+for ADR 0014's JP-4 named-schema fixture; it does not reopen the five artifact
+identities, introduce a third-party Builder SPI, or make Groovy 3 modular.
+
+## Confirmed failure path
+
+The runtime descriptor exports `runtime` and `runtime.validation` generally,
+but confines `runtime.internal`, `.internal.process`, and `.internal.layer3`
+to checked compiler/Jackson consumers. The transformation nevertheless emits
+schema classes that use those packages. In particular, `Foo$Builder` extends
+`InternalKlumBuilder`; generated constructors and private state name its token
+and companion; `Foo.Template` names `BoundTemplateHandler`; and generated
+cluster, breadcrumb, and omitted-projection code invokes internal helpers.
+
+The compiler has access through its qualified exports, but its generated class
+is defined by the Schema Developer's named module. That module cannot link the
+internal references. The full source-backed list and exclusions are in
+[the JP-ABI inventory](evidence/issue-391-jp-abi-generated-schema-runtime.md).
+
+## Compatibility constraints
+
+- The runtime module retains only its approved public API, validation API, and
+  the new minimal generated-runtime package; all other internals remain
+  non-exported or qualified only to the compiler/Jackson adapter.
+- Generated `Foo_DSL` contracts remain the supported build-time interfaces;
+  generated implementation names remain unsupported.
+- `KlumBuilder<T>` remains zero-operation. The new generated Builder base is
+  framework linkage only, not a client mutation API or Builder-phase SPI.
+- `Foo.Template` must not retain a public internal-handler descriptor. A
+  generated Template facade is compatible with ADR 0005's conditional
+  `Foo_DSL.Template` seam.
+- Groovy 3 stays classpath-only. Groovy 4 and 5 must each prove the real module
+  boundary. No workaround flags, automatic-module fallback, descriptor rewrite,
+  or source-mirror module input is allowed.
+- All generated model semantics remain unchanged: one Construction session,
+  Builder-first lifecycle, Materialization at phase 40, object-companion
+  encapsulation, Template recipe serialization limits, and ordinary Jackson
+  interoperability.
+
+## Tracer bullets and commits
+
+### JP-ABI-1 — Freeze the emitted-linkage inventory and bridge vocabulary
+
+Add an automated class-file/AST inventory that records every generated
+descriptor and direct call outside schema/JDK/Groovy types. Define
+`runtime.generated` with only the roles approved by ADR 0015: generated Builder
+base, opaque token/object state, static helpers, and Template facade. The
+inventory must fail when generated output names a `runtime.internal...` type.
+
+**Acceptance:** the inventory covers representative keyed/unkeyed DSL Objects,
+inheritance, collection/cluster factories, Templates, and omitted projections;
+it classifies each bridge member to a direct generated use. No bridge type has
+a client-extension or generic mutation API.
+
+**Commit boundary:** commit the inventory and empty/narrow bridge types with
+their contract tests. Do not move generated emission in the same commit.
+
+### JP-ABI-2 — Bridge Builder, model-state, and Template descriptors
+
+Move the generated Builder superclass and required construction hooks behind
+the generated Builder base. Retarget generated model constructors and private
+state to the opaque generated token/object-state descriptors. Replace the
+public `Foo.Template` internal-handler field with the generated Template
+facade, keeping its internal implementation and existing Template behavior.
+
+**Acceptance:** generated class descriptors contain no `InternalKlumBuilder`,
+materialization-token, companion, or `BoundTemplateHandler` internal name;
+the existing Builder-first, Template, copy-source, and Java/static-Groovy
+generated-interface tests pass unchanged in behavior. `Foo_DSL.Template`, if
+introduced, accurately mirrors the emitted facade.
+
+**Commit boundary:** one vertical runtime/transform/test commit. Keep the old
+internal implementation delegating to the bridge only where it does not leave
+a generated reference behind.
+
+### JP-ABI-3 — Bridge generated helper calls and remove residual leaks
+
+Retarget breadcrumb collection/cluster operations, cluster query calls, and
+omitted-projection fallback to the static generated helpers. Re-run the
+inventory against representative bytecode and remove every residual emitted
+`runtime.internal` reference. Keep `FactoryHelper` and `TemplateManager`
+internal unless a new bytecode scan proves a direct generated use.
+
+**Acceptance:** all generated direct calls resolve through `runtime`, schema,
+or `runtime.generated` packages; runtime internal packages are neither general
+exports nor schema-module requirements. Dynamic diagnostics remain unchanged.
+
+**Commit boundary:** one generated-helper/runtime delegation commit with the
+affected relationship, cluster, and projection tests.
+
+### JP-ABI-4 — Prove the named Schema Developer boundary
+
+Extend ADR 0014 JP-4 with a real Groovy 4/5 schema module and a Java consumer
+module. Compile and run DSL/mutator, converter, and Layer 3 transformation
+activation; root and Builder-producing factories; collection/cluster behavior;
+Template creation; and the omitted-projection rejection path. Include a Java
+consumer and an `@CompileStatic` Groovy consumer naming `Foo_DSL` interfaces.
+
+The fixture's user-owned descriptor requires the public annotations/runtime
+modules and `org.apache.groovy`, opens its DSL package to the runtime, and
+requires the compiler only as specified by ADR 0014. It does not name an
+internal or generated-runtime module because the bridge package belongs to the
+existing runtime module.
+
+**Acceptance:** Groovy 4 and 5 fixtures pass on the module path with no
+workaround flags; `jar --describe-module` exposes the expected generated-runtime
+package and no broad internal export. The equivalent Groovy 3 named-module
+attempt fails with documented classpath-only remediation; classpath fixtures
+remain green for Groovy 3, 4, and 5.
+
+**Commit boundary:** fixture harness/minimal schema first; then client,
+Template, and adapter assertions as focused commits if the harness remains
+independently green.
+
+### JP-ABI-5 — Complete release-facing verification and guidance
+
+Regenerate the #468 public inventory and the JP-ABI scan from published
+candidates. Update ADR 0014's implementation record, module descriptor
+assertions, Schema-plugin remediation, user migration/module guidance,
+Javadocs, and `CHANGES.md` only after the named fixture proves the boundary.
+
+**Acceptance:** release checks reject a generated internal reference; the
+documentation explains Groovy 4/5 named use, Groovy 3 classpath-only use, and
+the fact that `Foo_DSL` mirrors are IDE metadata rather than module sources.
+
+**Commit boundary:** release inventory/assertions, then user/documentation
+closure once the executable evidence is present.
+
+## Test map
+
+| Concern | Existing seam | Required addition |
+| --- | --- | --- |
+| Generated public interfaces and Java/static-Groovy clients | `GeneratedDslSupportSpec` | Assert bridge-free public descriptors and generated Template facade. |
+| Builder/materialization and companion state | `BuilderFirstSpec`, `KlumObjectSupportSpec`, lifecycle tests | Assert bridge-backed constructors/state preserve materialization behavior. |
+| Template behavior and serialization boundary | `TemplatesSpec`, copy-source tests | Assert `Foo.Template` names only its facade and keeps recipe behavior. |
+| Collection/cluster and omitted projections | relationship/cluster specs, `BuilderProjectionSpec` | Assert static bridge helpers preserve results and diagnostics. |
+| JPMS packages and descriptors | `JpmsPackageBoundaryTest`, `JpmsGroovyModuleIdentityTest` | Reject emitted internal references and inspect the one new exported package. |
+| Real consumer module | ADR 0014 JP-4 fixture | Run Groovy 4/5 named schemas and the Groovy 3 negative case. |
+
+New executable tests carry `@Issue("391")`; a user-visible module example is
+documentary only when JP-ABI-5 publishes it under `docs/user/`.
+
+## Risks and open questions
+
+| Risk or question | Control or decision point |
+| --- | --- |
+| The minimum bridge grows into a second general runtime API. | JP-ABI-1 admits only inventory-proven emitted symbols and keeps the package's generated-only documentation/review gate. |
+| A private or synthetic descriptor is missed. | Scan complete class-file constant pools and descriptors, not only public methods. |
+| `Foo_DSL.Template` changes a promised generated shape. | ADR 0005 expressly reserves it for Template-specific methods; JP-ABI-2 proves the real field/facade shape before freezing it. |
+| Schema module requirements change unexpectedly. | JP-ABI-4 compiles a user-owned descriptor; plugin work reports the final directives but never writes them. |
+| Groovy 3 appears to work through an accidental flag. | Retain the negative named-module fixture and inspect the launched command line. |
+
+## Issue-to-slice mapping
+
+| Issue/decision | Slices |
+| --- | --- |
+| #391 / ADR 0014 module boundary | JP-ABI-1 through JP-ABI-5; JP-ABI-4 is the JP-4 gate. |
+| #394 / ADR 0005 generated support API | JP-ABI-2 Template facade and generated-interface mirror parity. |
+| #431 / ADR 0004 Builder-producing protocol | JP-ABI-2 Builder bridge and JP-ABI-4 active-session fixture. |
+| #468 public inventory | JP-ABI-1 and JP-ABI-5 descriptor review. |

--- a/docs/implementation/evidence/issue-391-jp-abi-generated-schema-runtime.md
+++ b/docs/implementation/evidence/issue-391-jp-abi-generated-schema-runtime.md
@@ -1,0 +1,70 @@
+# #391 JP-ABI generated-schema runtime inventory
+
+This local evidence inventory separates the stable, client-visible generated
+schema contract from runtime symbols embedded in generated schema bytecode. It
+does not decide the package move or module descriptor; it supplies the ABI
+input for that decision.
+
+## Public generated-schema contract
+
+| Generated contract | Runtime ABI it names | Evidence and compatibility implication |
+| --- | --- | --- |
+| `Foo_DSL`, `Foo_DSL.Factory`, `Foo_DSL.Builder<SELF extends Foo>`, and the per-field collection/cluster factory interfaces | `KlumBuilder<SELF>` | `GeneratedDslSupport` creates the public namespace and links hidden implementations to it. A root Builder extends the zero-operation `KlumBuilder`; child Builders extend their parent public Builder while retaining the leaf `SELF` type. This is the stable generated-client type system, not the hidden Builder hierarchy. [Generator](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java), [runtime capability](../../../klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/KlumBuilder.java). |
+| `public static final Foo.Create` | Field: `Foo_DSL.Factory`; Factory method: `KlumFactory<T>` plus `BuilderFactory`, `KeyedBuilderFactory`, and `UnkeyedBuilderFactory` | The transform creates the hidden `KlumFactory` implementation then retargets `Create` to the public factory interface. `Foo_DSL.Factory.getAsBuilder()` is specialized to a public `KlumFactory.*BuilderFactory<Foo, Foo_DSL.Builder<Foo>>` descriptor (Groovy `AsBuilder`). These descriptors are required by generated Java and static-Groovy consumers. [Transform](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java), [factory API](../../../klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/KlumFactory.java). |
+| Model marker interface and `applyLater(DefaultKlumPhase, Closure)` overload | `KlumModelObject`, `KlumKeyedModelObject`, `KlumUnkeyedModelObject`, `DefaultKlumPhase` | The transform implements exactly one model marker based on keyed/abstract state and emits the phase overload. These types are part of emitted model/Builder descriptors and must remain in the runtime's exported generated-hook surface. [Transform](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java). |
+
+`GeneratedDslSupportSpec` compiles Java and `@CompileStatic` Groovy consumers
+using `Foo_DSL`, `KlumFactory`, and `KlumBuilder`, and asserts that the tested
+Builder/factory public signatures contain no `$_` implementation spelling. It
+is executable evidence for those public contracts, not an exhaustive audit of
+every generated schema member. [Test](../../../klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy).
+
+## Runtime linkage embedded in emitted schema classes
+
+The following symbols are not a third-party extension API, but generated class
+files directly name or invoke them. A named schema module must be able to link
+them; the compiler's access to them is not enough.
+
+| Emitted use | Current runtime symbol(s) | Why it is ABI-relevant |
+| --- | --- | --- |
+| Hidden `Foo$Builder` superclass and generated mutable DSL methods | `runtime.internal.InternalKlumBuilder<SELF>`; its collection/map/field/link/copy and `scheduleApplyLater` hooks | The hidden Builder extends this type. Generated proxy methods invoke its concrete hooks, including `setSingleField`, `addNewDslElementToCollection`, `addNewDslElementToMap`, `addElementsFromScriptsToCollection`, and `addElementsFromScriptsToMap`. [Generated hierarchy](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java), [proxy generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java), [runtime hooks](../../../klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder.java). |
+| Protected synthetic model and template constructors; root-model state | `InternalKlumBuilder.MaterializationToken`, `InternalKlumBuilder.$requireMaterializationToken`, `$snapshotField`, `$createCompanion`, and `runtime.internal.KlumObjectCompanion` | The transform emits a constructor with the token in its descriptor, calls the three internal hooks, and declares a synthetic companion field with the internal companion type. Private or synthetic does not remove those constant-pool/linkage references. [Model generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java). |
+| Public `Foo.Template` field (current implementation) and template methods | `runtime.internal.BoundTemplateHandler<T>` | `Foo.Template` is currently a public static field whose declared type is `BoundTemplateHandler<T>`. This is both a public descriptor leak and generated execution linkage, despite ADR 0005 reserving a future public `Foo_DSL.Template` contract. `TemplateManager` is an implementation dependency of that handler, not a direct emitted-schema reference. [Template generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java), [handler](../../../klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/BoundTemplateHandler.java), [ADR 0005](../../adr/0005-generated-dsl-support-api.md). |
+| Generated collection/cluster factory methods | `runtime.internal.process.BreadcrumbCollector` | Collection/cluster closure methods call `BreadcrumbCollector.withBreadcrumb(...)`. `FactoryHelper` is not listed: its `ProxyMethodBuilder` helper has no current generated call site, so it is runtime implementation rather than proven direct schema-bytecode linkage. [Collection generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/AlternativesClassBuilder.java), [cluster generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/layer3/ClusterFactoryBuilder.java), [proxy builder](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java). |
+| `@Cluster` model methods and omitted Builder-projection fallback | `runtime.internal.layer3.ClusterModel`, `runtime.internal.OmittedProjectionSupport` | Generated method bodies call `ClusterModel` query methods and synthetic `methodMissing` calls `OmittedProjectionSupport.handle`. [Cluster generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/layer3/ClusterTransformation.java), [fallback generation](../../../klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/OmittedProjectionCatalog.java). |
+
+## JPMS decision constraint
+
+The present runtime descriptor exports only `runtime` and `runtime.validation`
+to all consumers. Its `runtime.internal` and `.internal.process` packages are
+qualified only to the compiler and Jackson modules; `.internal.layer3` is
+qualified only to the compiler module. [Runtime descriptor](../../../klum-ast-runtime/src/main/module-info/module-info.java).
+
+Consequently, those qualified exports do not authorize generated bytecode
+defined in an arbitrary named schema module. A Groovy 4/5 named-schema fixture
+must therefore prove a deliberate generated-runtime linkage boundary. The
+decision needs to choose one of these bounded outcomes before descriptors
+freeze:
+
+1. Move/introduce the minimum generated-bytecode hooks in a dedicated runtime
+   package exported to schema modules, with a stable 4.x compatibility policy;
+   or
+2. Eliminate each direct generated reference in favor of an already exported
+   runtime façade.
+
+Do not solve this by broadly exporting the current `internal` packages or by
+using `--add-exports`/patch-module flags. Those options conflict with ADR 0014's
+positive export list and portable named-schema requirement. The resulting
+generated-linkage package, if one remains necessary, is a tightly scoped ABI
+for compiler-emitted code—not a general SPI or client extension surface.
+[ADR 0014](../../adr/0014-groovy4-jpms-boundary.md), [#468 export handoff](../issue-468-jvm-public-inventory.md).
+
+## Compatibility baseline
+
+The public generated interfaces and their runtime descriptors are 4.x API
+after the intentional 3.x-to-4.0 recompilation break. The internal-linkage
+set is also binary-significant for independently compiled schemas once named
+schemas are supported; it must receive an explicit owner, export disposition,
+and generated Java/static-Groovy plus Groovy 4/5 named-module fixture coverage.
+The AnnoDocimal `Foo_DSL` mirror is only IDE metadata and is not alternate ABI
+evidence. [ADR 0005](../../adr/0005-generated-dsl-support-api.md), [ADR 0014](../../adr/0014-groovy4-jpms-boundary.md).


### PR DESCRIPTION
## Summary

- add a source-backed inventory of public generated-schema ABI and direct runtime linkage
- propose ADR 0015: a narrow `com.blackbuild.klum.ast.runtime.generated` boundary for compiler-emitted schema bytecode
- add JP-ABI tracer bullets through the Groovy 4/5 named-schema fixture

## Why

Generated schema classes are defined in Schema Developer modules but currently link runtime-internal types. The compiler's qualified export cannot authorize arbitrary named schema modules, so ADR 0014's JP-4 fixture needs an explicit minimal bridge rather than broad exports or JVM flags.

## Developer impact

`Foo_DSL` and its generated Builder interfaces remain in each model's own package. The proposed generated-runtime package is framework linkage only, not a client API or third-party SPI. The draft also identifies the current `Foo.Template` internal descriptor leak.

## Validation

- `git diff --check`
- source-backed ABI audit against the transformation and runtime module descriptor

No Gradle command was run; this PR contains documentation only.