### PR TITLE
Validate packaged Helm overwrite strategies

### DIFF
--- a/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/copy/Overwrite.java
+++ b/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/copy/Overwrite.java
@@ -26,7 +26,6 @@ package com.blackbuild.klum.ast.copy;
 import com.blackbuild.klum.ast.internal.cast.NeedsDSLClass;
 import com.blackbuild.klum.cast.KlumCastValidated;
 import com.blackbuild.klum.cast.KlumCastValidator;
-import com.blackbuild.klum.cast.checks.NeedsOneOf;
 import com.blackbuild.klum.cast.checks.NeedsType;
 
 import java.lang.annotation.ElementType;
@@ -37,11 +36,11 @@ import java.lang.annotation.Target;
 /**
  * Handles how values are copied from one object to another.
  */
-@Target({ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE})
+@Target({ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @KlumCastValidated
 @NeedsDSLClass
-@NeedsOneOf(value = {"singles", "collections", "maps"})
+@KlumCastValidator("com.blackbuild.klum.ast.compiler.internal.validation.OverwriteStrategiesCheck")
 public @interface Overwrite {
 
     Overwrite.Single singles() default @Overwrite.Single(OverwriteStrategy.Single.INHERIT);

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/validation/OverwriteStrategiesCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/validation/OverwriteStrategiesCheck.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.compiler.internal.validation;
+
+import com.blackbuild.klum.ast.copy.Overwrite;
+import com.blackbuild.klum.cast.spi.Check;
+import com.blackbuild.klum.cast.spi.CheckContext;
+import com.blackbuild.klum.cast.spi.Diagnostic;
+import org.codehaus.groovy.ast.AnnotationNode;
+
+import java.util.List;
+
+public class OverwriteStrategiesCheck implements Check {
+
+    private static final List<String> STRATEGY_MEMBERS = List.of("singles", "collections", "maps");
+
+    @Override
+    public List<Diagnostic> check(CheckContext context) {
+        AnnotationNode configuredOverwrite = getConfiguredOverwrite(context.getValidatedAnnotation());
+        boolean hasStrategy = STRATEGY_MEMBERS.stream().anyMatch(configuredOverwrite.getMembers()::containsKey);
+        if (hasStrategy) return List.of();
+        return List.of(new Diagnostic(getClass().getName(),
+                "At least one of " + STRATEGY_MEMBERS + " must be set", configuredOverwrite));
+    }
+
+    private AnnotationNode getConfiguredOverwrite(AnnotationNode validatedAnnotation) {
+        if (isOverwrite(validatedAnnotation)) return validatedAnnotation;
+        return validatedAnnotation.getClassNode().getAnnotations().stream()
+                .filter(this::isOverwrite)
+                .findFirst()
+                .orElse(validatedAnnotation);
+    }
+
+    private boolean isOverwrite(AnnotationNode annotation) {
+        return annotation.getClassNode().getName().equals(Overwrite.class.getName());
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastCheckSpiMigrationTest.groovy
@@ -32,6 +32,7 @@ import com.blackbuild.klum.ast.compiler.internal.validation.CheckDslAnnotation
 import com.blackbuild.klum.ast.compiler.internal.validation.CheckForPrimitiveBoolean
 import com.blackbuild.klum.ast.compiler.internal.validation.OverwriteMapCheck
 import com.blackbuild.klum.ast.compiler.internal.validation.OverwriteSingleCheck
+import com.blackbuild.klum.ast.compiler.internal.validation.OverwriteStrategiesCheck
 import com.blackbuild.klum.ast.compiler.internal.validation.ValidateAnnotationCheck
 import com.blackbuild.klum.cast.KlumCastValidator
 import com.blackbuild.klum.cast.spi.Check
@@ -50,6 +51,7 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
             CheckForPrimitiveBoolean,
             OverwriteMapCheck,
             OverwriteSingleCheck,
+            OverwriteStrategiesCheck,
             ValidateAnnotationCheck,
     ]
 
@@ -64,7 +66,7 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
         checkType << CHECK_TYPES
     }
 
-    def "annotation artifact retains the eight supported name bindings"() {
+    def "annotation artifact retains the nine supported name bindings"() {
         expect:
         annotationTypes
                 .collect { it.getAnnotationsByType(KlumCastValidator).toList() }
@@ -73,7 +75,7 @@ class KlumCastCheckSpiMigrationTest extends AbstractDSLSpec {
                 .toSet() == CHECK_TYPES*.name.toSet()
 
         where:
-        annotationTypes = [Field, DSL, WriteAccess, Validate, Overwrite.Single, Overwrite.Map, DefaultValues]
+        annotationTypes = [Field, DSL, WriteAccess, Validate, Overwrite, Overwrite.Single, Overwrite.Map, DefaultValues]
     }
 
     @Unroll

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OverwriteStrategyTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OverwriteStrategyTest.groovy
@@ -26,6 +26,7 @@ package com.blackbuild.klum.ast
 
 import com.blackbuild.klum.ast.runtime.internal.CopyHandler
 import com.blackbuild.klum.ast.runtime.internal.FactoryHelper
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -472,6 +473,77 @@ class OverwriteStrategyTest extends AbstractDSLSpec {
         then:
         instance.inners.a.foo == 1
         instance.inners.a.bar == 2
+    }
+
+    @Issue("581")
+    def "Helm overwrite compiles dynamically and applies its packaged strategies"() {
+        given:
+        createClass """
+            package pk
+
+            import com.blackbuild.klum.ast.copy.HelmOverwrite
+
+            @DSL class Service {
+                @Key String key
+                String host
+                String port
+            }
+
+            @HelmOverwrite
+            @DSL class Configuration {
+                String image
+                List<String> args
+                Map<String, Service> services
+            }
+        """
+
+        when:
+        def target = builder(Configuration) {
+            image "target"
+            args = ["target"]
+            service("web") {
+                host "target"
+            }
+        }
+        def source = builder(Configuration) {
+            image "source"
+            args = []
+            service("web") {
+                port "source"
+            }
+            service("metrics") {
+                host "metrics"
+            }
+        }
+        CopyHandler.copyToFrom(target, source)
+
+        then: "MERGE replaces simple scalar values and merges DSL map values"
+        target.image == "source"
+        target.services.web.host == "target"
+        target.services.web.port == "source"
+        target.services.metrics.host == "metrics"
+
+        and: "ALWAYS_REPLACE accepts an empty donor collection"
+        target.args == []
+    }
+
+    @Issue("581")
+    def "incomplete direct overwrite declaration remains rejected"() {
+        when:
+        createClass """
+            package pk
+
+            import com.blackbuild.klum.ast.copy.Overwrite
+
+            @Overwrite
+            @DSL class IncompleteConfiguration {
+                String image
+            }
+        """
+
+        then:
+        def error = thrown(MultipleCompilationErrorsException)
+        error.message.contains("At least one of [singles, collections, maps] must be set")
     }
 
 }


### PR DESCRIPTION
## Summary

- recognize `@Overwrite` as an annotation-type strategy preset and validate the effective `@Overwrite` declaration
- make dynamically compiled DSL classes using `@HelmOverwrite` valid
- cover scalar, empty-collection, and DSL-map Helm strategy behavior while retaining rejection of incomplete direct `@Overwrite`

## Why

KlumCast validated the outer `@HelmOverwrite` use while `NeedsOneOf` inspected only its members. The actual overwrite strategies are declared on the preset's `@Overwrite` meta-annotation. The runtime also did not classify `@Overwrite` as a meta-annotation strategy source.

## Compatibility and scope

No migration action or documentation change is required. This is a focused preset-validation fix; it does not add multi-layer composition, runtime strategy policy, or a generic overwrite redesign. The blocked #491 documentary cohort remains separate.

Related: #581

Issue #581 remains open pending Hive reconciliation.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.OverwriteStrategyTest`
- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests`
- `./gradlew :klum-ast:groovy5Tests`
- `./gradlew check`
- two-axis local review against `origin/master`