### PR TITLE
Bridge generated Builder runtime linkage

### DIFF
--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.runtime.generated;
+
+import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
+import com.blackbuild.klum.ast.runtime.KlumPhase;
+import groovy.lang.Closure;
+
+/**
+ * Generated-code linkage base for Builder implementations emitted by the DSL transformation.
+ *
+ * <p>This type is not a handwritten client API, mutable Builder extension point, or Builder-phase
+ * SPI. Generated Builders retain their model-package {@code Foo_DSL.Builder} contracts; this base
+ * only keeps their bytecode independent of the runtime's internal package.</p>
+ *
+ * @param <M> the completed model type
+ */
+public abstract class GeneratedKlumBuilder<M> extends InternalKlumBuilder<M> {
+
+    protected GeneratedKlumBuilder(Class<M> modelType) {
+        super(modelType);
+    }
+
+    @Override
+    protected void $assignRelationships() {
+        super.$assignRelationships();
+    }
+
+    protected final void $copyFromRecipe(Object template) {
+        super.copyFromRecipe(template);
+    }
+
+    protected final <T> T $setSingleField(String fieldOrMethodName, T value) {
+        return super.setSingleField(fieldOrMethodName, value);
+    }
+
+    protected final void $scheduleApplyLater(Closure<?> closure) {
+        super.scheduleApplyLater(closure);
+    }
+
+    protected final void $scheduleApplyLater(KlumPhase phase, Closure<?> closure) {
+        super.scheduleApplyLater(phase, closure);
+    }
+
+    protected final void $scheduleApplyLater(Integer number, Closure<?> closure) {
+        super.scheduleApplyLater(number, closure);
+    }
+
+    @Override
+    public void applyLater(Closure<?> closure) {
+        super.applyLater(closure);
+    }
+
+    @Override
+    public void applyLater(KlumPhase phase, Closure<?> closure) {
+        super.applyLater(phase, closure);
+    }
+
+    @Override
+    public void applyLater(Integer number, Closure<?> closure) {
+        super.applyLater(number, closure);
+    }
+}

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
@@ -36,6 +36,7 @@ import groovy.lang.Closure;
  *
  * @param <M> the completed model type
  */
+@SuppressWarnings({"java:S100", "java:S1185"}) // generated-code ABI hooks and owner bridges
 public abstract class GeneratedKlumBuilder<M> extends InternalKlumBuilder<M> {
 
     protected GeneratedKlumBuilder(Class<M> modelType) {

--- a/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/generated/ModuleMarker.java
+++ b/klum-ast-runtime/src/main/module-info/com/blackbuild/klum/ast/runtime/generated/ModuleMarker.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.runtime.generated;
+
+/** Marker source that lets the descriptor compiler validate this generated-code linkage package. */
+final class ModuleMarker {
+
+    private ModuleMarker() {
+    }
+}

--- a/klum-ast-runtime/src/main/module-info/module-info.java
+++ b/klum-ast-runtime/src/main/module-info/module-info.java
@@ -3,6 +3,7 @@ module com.blackbuild.klum.ast.runtime {
     requires transitive org.apache.groovy;
     requires static com.blackbuild.annodocimal.annotations;
     exports com.blackbuild.klum.ast.runtime;
+    exports com.blackbuild.klum.ast.runtime.generated;
     exports com.blackbuild.klum.ast.runtime.validation;
     exports com.blackbuild.klum.ast.runtime.internal to
             com.blackbuild.klum.ast.compiler,

--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilderTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilderTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.runtime.generated
+
+import com.blackbuild.klum.ast.runtime.DefaultKlumPhase
+import com.blackbuild.klum.ast.runtime.KlumPhase
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('391')
+class GeneratedKlumBuilderTest extends Specification {
+
+    def "generated Builder bridge delegates state and lifecycle hooks"() {
+        given:
+        def builder = new BridgeBuilder()
+        def applied = []
+
+        when:
+        builder.assignRelationships()
+        builder.setValue('configured')
+        builder.copyRecipe(new BridgeModel(value: 'recipe'))
+        builder.schedule { applied << 'default' }
+        builder.schedule(DefaultKlumPhase.DEFAULT) { applied << 'phase' }
+        builder.schedule(DefaultKlumPhase.DEFAULT.number) { applied << 'number' }
+        builder.applyLater { applied << 'public-default' }
+        builder.applyLater(DefaultKlumPhase.DEFAULT) { applied << 'public-phase' }
+        builder.applyLater(DefaultKlumPhase.DEFAULT.number) { applied << 'public-number' }
+        builder.executeApplyLaterClosures(DefaultKlumPhase.APPLY_LATER.number)
+        builder.executeApplyLaterClosures(DefaultKlumPhase.DEFAULT.number)
+
+        then:
+        builder.value == 'configured'
+        applied == ['default', 'public-default', 'phase', 'number', 'public-phase', 'public-number']
+    }
+
+    private static class BridgeModel {
+        String value
+    }
+
+    private static class BridgeBuilder extends GeneratedKlumBuilder<BridgeModel> {
+        String value
+
+        BridgeBuilder() {
+            super(BridgeModel)
+        }
+
+        @Override
+        protected Class<? extends BridgeModel> $modelImplementationType() {
+            BridgeModel
+        }
+
+        void assignRelationships() {
+            $assignRelationships()
+        }
+
+        void setValue(String value) {
+            $setSingleField('value', value)
+        }
+
+        void copyRecipe(BridgeModel recipe) {
+            $copyFromRecipe(recipe)
+        }
+
+        void schedule(Closure<?> closure) {
+            $scheduleApplyLater(closure)
+        }
+
+        void schedule(KlumPhase phase, Closure<?> closure) {
+            $scheduleApplyLater(phase, closure)
+        }
+
+        void schedule(Integer phase, Closure<?> closure) {
+            $scheduleApplyLater(phase, closure)
+        }
+    }
+}

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -32,6 +32,7 @@ import com.blackbuild.klum.ast.runtime.KlumUnkeyedModelObject;
 import com.blackbuild.klum.ast.compiler.internal.doc.DocUtil;
 import com.blackbuild.klum.ast.runtime.DefaultKlumPhase;
 import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
+import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumFactory;
 import com.blackbuild.klum.ast.runtime.internal.KlumObjectCompanion;
 import com.blackbuild.klum.ast.compiler.internal.layer3.ClusterFactoryBuilder;
@@ -113,6 +114,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     public static final ClassNode KEYED_BUILDER_FACTORY = make(KlumFactory.KeyedBuilderFactory.class);
     public static final ClassNode UNKEYED_BUILDER_FACTORY = make(KlumFactory.UnkeyedBuilderFactory.class);
     public static final ClassNode KLUM_BUILDER = make(InternalKlumBuilder.class);
+    public static final ClassNode GENERATED_KLUM_BUILDER = make(GeneratedKlumBuilder.class);
     public static final ClassNode OBJECT_COMPANION = make(KlumObjectCompanion.class);
     public static final ClassNode EQUALS_HASHCODE_ANNOT = make(EqualsAndHashCode.class);
     public static final ClassNode TOSTRING_ANNOT = make(ToString.class);
@@ -278,7 +280,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         if (parentRW != null) {
             builderBase = parentRW.getPlainNodeReference();
         } else {
-            builderBase = KLUM_BUILDER;
+            builderBase = GENERATED_KLUM_BUILDER;
         }
 
         rwClass = new InnerClassNode(

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
@@ -27,7 +27,7 @@ import com.blackbuild.klum.ast.Field;
 import com.blackbuild.klum.ast.FieldType;
 import com.blackbuild.klum.ast.KlumGenerated;
 import com.blackbuild.klum.ast.runtime.internal.BreadCrumbVerbInterceptor;
-import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
+import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.runtime.internal.LanguageHelper;
 import com.blackbuild.klum.ast.layer3.LinkTo;
 import com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper;
@@ -94,7 +94,7 @@ public class DslAstHelper {
         // fields still hold the common Builder abstraction until a concrete subtype is chosen.
         if (classNode.isInterface())
             return GenericsUtils.makeClassSafeWithGenerics(
-                    ClassHelper.make(InternalKlumBuilder.class),
+                    ClassHelper.make(GeneratedKlumBuilder.class),
                     new GenericsType(classNode.getPlainNodeReference())
             );
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -25,7 +25,7 @@ package com.blackbuild.klum.ast.compiler.internal.ast;
 
 import com.blackbuild.annodocimal.ast.AstDocumentation;
 import com.blackbuild.klum.ast.KlumGenerated;
-import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
+import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumBuilder;
 import groovy.lang.DelegatesTo;
 import org.codehaus.groovy.ast.AnnotatedNode;
@@ -274,7 +274,7 @@ public final class GeneratedDslSupport {
         ClassNode parent = model.getUnresolvedSuperClass(false);
         if (!DslAstHelper.isDSLObject(parent)) {
             builderImplementation.setSuperClass(GenericsUtils.makeClassSafeWithGenerics(
-                    ClassHelper.make(InternalKlumBuilder.class),
+                    ClassHelper.make(GeneratedKlumBuilder.class),
                     new GenericsType(implementationSelfModel)
             ));
             return implementationSelfModel;

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
@@ -26,8 +26,8 @@ package com.blackbuild.klum.ast.compiler.internal.ast;
 import com.blackbuild.annodocimal.ast.AstDocumentation;
 import com.blackbuild.annodocimal.ast.Documentation;
 import com.blackbuild.klum.ast.runtime.internal.FactoryHelper;
-import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
 import com.blackbuild.klum.ast.runtime.internal.TemplateManager;
+import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.compiler.internal.reflect.AstReflectionBridge;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -53,7 +53,7 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
 
     private static final ClassNode FACTORY_HELPER_TYPE = make(FactoryHelper.class);
     private static final ClassNode TEMPLATE_MANAGER_TYPE = make(TemplateManager.class);
-    private static final ClassNode KLUM_BUILDER_TYPE = make(InternalKlumBuilder.class);
+    private static final ClassNode KLUM_BUILDER_TYPE = make(GeneratedKlumBuilder.class);
 
     private final String proxyMethodName;
     private final Expression proxyTarget;
@@ -71,13 +71,22 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
     }
 
     public static ProxyMethodBuilder createProxyMethod(String name, String proxyMethodName) {
-        return new ProxyMethodBuilder(varX("this"), name, proxyMethodName)
+        return new ProxyMethodBuilder(varX("this"), name, generatedBuilderHook(proxyMethodName))
                 .targetType(KLUM_BUILDER_TYPE);
     }
 
     public static ProxyMethodBuilder createProxyMethod(String name) {
-        return new ProxyMethodBuilder(varX("this"), name, name)
+        return new ProxyMethodBuilder(varX("this"), name, generatedBuilderHook(name))
                 .targetType(KLUM_BUILDER_TYPE);
+    }
+
+    private static String generatedBuilderHook(String methodName) {
+        return switch (methodName) {
+            case "copyFromRecipe" -> "$copyFromRecipe";
+            case "setSingleField" -> "$setSingleField";
+            case "scheduleApplyLater" -> "$scheduleApplyLater";
+            default -> methodName;
+        };
     }
 
     public static ProxyMethodBuilder createFactoryMethod(String name, ClassNode factoryType) {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
@@ -24,6 +24,7 @@
 package com.blackbuild.klum.ast
 
 import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder
+import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder
 import com.blackbuild.klum.ast.runtime.KlumBuilder
 import com.blackbuild.klum.ast.runtime.internal.FactoryHelper
 import com.blackbuild.klum.ast.runtime.KlumModelException
@@ -42,6 +43,7 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         Object value
     }
 
+    @Issue('391')
     def "factory configures a Builder and returns a completed model"() {
         given:
         createClass '''
@@ -75,7 +77,7 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         }
 
         then:
-        rwClazz.superclass == InternalKlumBuilder
+        rwClazz.superclass == GeneratedKlumBuilder
         instance.value == "configured:builder-only"
         clazz.initializerCalls == 1
         clazz.declaredFields*.name.contains("scratch") == false

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -30,6 +30,7 @@ import spock.lang.Specification
 import java.lang.module.ModuleFinder
 import java.nio.file.Path
 import java.nio.file.Files
+import java.nio.charset.StandardCharsets
 import java.util.jar.JarFile
 
 @Issue("391")
@@ -56,6 +57,7 @@ class JpmsPackageBoundaryTest extends Specification {
         packagesByArtifact.annotations.contains('com.blackbuild.klum.ast')
         !packagesByArtifact.runtime.contains('com.blackbuild.klum.ast')
         packagesByArtifact.runtime.contains('com.blackbuild.klum.ast.runtime')
+        packagesByArtifact.runtime.contains('com.blackbuild.klum.ast.runtime.generated')
         packagesByArtifact.runtime.contains('com.blackbuild.klum.ast.runtime.validation')
         packagesByArtifact.runtime.contains('com.blackbuild.klum.ast.runtime.internal')
         packagesByArtifact.runtime.contains('com.blackbuild.klum.ast.runtime.internal.layer3')
@@ -117,6 +119,7 @@ class JpmsPackageBoundaryTest extends Specification {
         ] as Set
         exportedPackages(descriptors.runtime) == [
                 'com.blackbuild.klum.ast.runtime',
+                'com.blackbuild.klum.ast.runtime.generated',
                 'com.blackbuild.klum.ast.runtime.validation'
         ] as Set
         exportedPackages(descriptors.compiler).empty
@@ -172,6 +175,12 @@ class JpmsPackageBoundaryTest extends Specification {
         and: 'Groovy 3 remains classpath-only while Groovy 4 and 5 also prove the named-module path.'
         !namedGroovy || namedModuleResult.exitCode == 0
         !namedGroovy || Files.exists(namedModuleResult.outputDirectory.resolve('NamedRoot.class'))
+
+        and: 'the positive fixture remains pending until its generated model has no internal runtime linkage'
+        !namedGroovy || !new String(
+                Files.readAllBytes(namedModuleResult.outputDirectory.resolve('NamedRoot.class')),
+                StandardCharsets.ISO_8859_1
+        ).contains('com/blackbuild/klum/ast/runtime/internal')
     }
 
     private static Map<String, Set<String>> packageOwners(Map<String, Set<String>> packagesByArtifact) {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -87,6 +87,7 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         [builder, collectionFactory, clusterFactory].every { publicSignatures(it).every { !it.contains('\$_') } }
     }
 
+    @Issue('391')
     def "preserves inherited Builder self-model typing"() {
         given:
         Class<?> baseBuilder = getClass('sample.Base_DSL$Builder')
@@ -106,11 +107,17 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
 
         and: 'hidden implementations thread the same leaf model type without a second capability'
         baseImplementation.typeParameters*.name == ['SELF']
-        baseImplementation.genericSuperclass.typeName == 'com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder<SELF>'
+        baseImplementation.genericSuperclass.typeName == 'com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder<SELF>'
         fooImplementation.typeParameters*.name == ['SELF']
         fooImplementation.typeParameters[0].bounds*.typeName == ['sample.Foo']
         fooImplementation.genericSuperclass.typeName == 'sample.Base$Builder<SELF>'
         !fooImplementation.genericInterfaces*.typeName.any { it.startsWith('com.blackbuild.klum.ast.runtime.KlumBuilder') }
+
+        and: 'the hidden Builder implementation links only the reviewed generated-runtime bridge'
+        [baseImplementation, fooImplementation].every { implementation ->
+            classFileConstants(implementation).every { !it.contains('com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder') }
+        }
+        classFileConstants(baseImplementation).contains('com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder')
     }
 
     def "public Builder contracts expose the zero-operation KlumBuilder capability"() {


### PR DESCRIPTION
## Summary

- introduce the generated-runtime Builder bridge and export only `runtime.generated`
- retarget generated Builder superclass, signature, and proxy linkage away from `InternalKlumBuilder`
- add bytecode-level linkage evidence while preserving Builder-first behavior

## Scope

This is the Builder-state slice only. Materialization token/model state, breadcrumbs, clusters, and omitted-projection helpers remain for later ABI slices.

Related: #391

## Validation

- focused Groovy 3 Builder, generated-support, and JPMS tests
- Groovy 4 and Groovy 5 lanes
- root `check`
- diff check and two-axis local review
