### PR TITLE
Document Bean Validation examples for #491

### DIFF
--- a/docs/user/Validation.md
+++ b/docs/user/Validation.md
@@ -502,13 +502,13 @@ import com.blackbuild.klum.ast.validation.bean.Level
 }
 ```
 
-The resulting issue names the constrained member and retains the constraint message. Payloads other than the provided `Level` types are not mapped to a Klum validation level.
+The resulting issue names the constrained member and retains the constraint message.
 
 ### Using the Gradle Plugin
 
 When using the [gradle plugin](Gradle-Plugins.md), the dependency version can be omitted:
 
-(See: `KlumAstSchemaPluginTest#'schema plugin aligns an optional Bean Validation module to its BOM'`.)
+(See: `BeanValidationGradleDocumentaryTest#'schema plugin aligns an optional Bean Validation module to its BOM'`.)
 
 ```groovy
 plugins {

--- a/docs/user/Validation.md
+++ b/docs/user/Validation.md
@@ -471,47 +471,53 @@ later to apply the configured failure level without rerunning validators.
 
 ## JSR380 Validation
 
-Using the optional module `klum-ast-bean-validation` it is possible to use the JSR380 validation framework. By default, this includes Hibernate-Validator 8 as dependency, this can be exchanged using default gradle mechanisms (with version 3, this will change to hibernate validator 9).
+The optional `klum-ast-bean-validation` module adds Jakarta Bean Validation support. It exposes the Jakarta Validation API and includes Hibernate Validator as its implementation.
 
-With the dependency in the classpath, JSR380 annotations are automatically evaluated during the validation phase in addition to standard klum validation.
+With the module on the classpath, Jakarta constraint annotations are evaluated during the validation phase in addition to standard Klum validation.
+
+(See: `BeanValidationDocumentaryTest#'accepts a release with a satisfied Jakarta validation constraint'`.)
 
 ```groovy
 import jakarta.validation.constraints.Size
 
-@DSL class Foo {
-    @Size(min = 2, max = 4, message = "Must be between 2 and 4 values")
-    List<String> values
+@DSL class Release {
+    @Size(min = 2, max = 4, message = "Choose between two and four approvers")
+    List<String> approvers
 }
 ```
 
 ### Validation Levels and JSR380
 
-Levels are provided using the `jakarta.validation.Payload` interface. The class `com.blackbuild.klum.ast.validation.bean.Level` provides inner classes for each value of `Validate.Level`. When set on an annotation, an occuring violation will be set to that level:
+Levels are provided using the `jakarta.validation.Payload` interface. The class `com.blackbuild.klum.ast.validation.bean.Level` provides inner classes for each value of `Validate.Level`. When set on a constraint, a violation is recorded at that level.
+
+(See: `BeanValidationDocumentaryTest#'records a Jakarta constraint violation at its payload-selected level'`.)
 
 ```groovy
 import jakarta.validation.constraints.Size
 import com.blackbuild.klum.ast.validation.bean.Level
 
-@DSL class Foo {
-    @Size(min = 2, payload = Level.ERROR)
-    List<String> values
+@DSL class Release {
+    @Size(min = 2, payload = Level.WARNING, message = "Choose at least two approvers")
+    List<String> approvers
 }
 ```
 
-Note that other payloads are ignored.
+The resulting issue names the constrained member and retains the constraint message. Payloads other than the provided `Level` types are not mapped to a Klum validation level.
 
 ### Using the Gradle Plugin
 
 When using the [gradle plugin](Gradle-Plugins.md), the dependency version can be omitted:
 
+(See: `KlumAstSchemaPluginTest#'schema plugin aligns an optional Bean Validation module to its BOM'`.)
+
 ```groovy
 plugins {
-    id 'com.blackbuild.klum-ast-schema:2.2.0'
-    id "maven-publish"
+    id 'com.blackbuild.klum-ast-schema'
 }
 
 dependencies {
-    // will be set to the version of the plugin (2.2.0)
-    api 'com.blackbuild.klum:klum-ast-bean-validation'
+    api 'com.blackbuild.klum.ast:klum-ast-bean-validation'
 }
 ```
+
+The schema plugin imports the matching `klum-ast-bom`, which supplies the optional module version.

--- a/klum-ast-bean-validation/src/test/groovy/com/blackbuild/klum/ast/validation/bean/BeanValidationDocumentaryTest.groovy
+++ b/klum-ast-bean-validation/src/test/groovy/com/blackbuild/klum/ast/validation/bean/BeanValidationDocumentaryTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.validation.bean
+
+import com.blackbuild.klum.ast.AbstractDSLSpec
+import com.blackbuild.klum.ast.Validate
+import com.blackbuild.klum.ast.runtime.KlumObjectSupport
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class BeanValidationDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#jsr380-validation")
+    def "accepts a release with a satisfied Jakarta validation constraint"() {
+        given:
+        createClass '''
+            package pk
+
+            import jakarta.validation.constraints.Size
+
+            @DSL
+            class Release {
+                @Size(min = 2, max = 4, message = 'Choose between two and four approvers')
+                List<String> approvers
+            }
+        '''
+
+        when:
+        def release = clazz.Create.With {
+            approvers 'dana', 'lee'
+        }
+
+        then:
+        release.approvers == ['dana', 'lee']
+    }
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#validation-levels-and-jsr380")
+    def "records a Jakarta constraint violation at its payload-selected level"() {
+        given:
+        createClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.validation.bean.Level
+            import jakarta.validation.constraints.Size
+
+            @DSL
+            class Release {
+                @Size(min = 2, payload = Level.WARNING, message = 'Choose at least two approvers')
+                List<String> approvers
+            }
+        '''
+
+        when:
+        def release = clazz.Create.With {
+            approvers 'dana'
+        }
+        def result = KlumObjectSupport.of(release).validation.result
+
+        then:
+        result.has(Validate.Level.WARNING)
+        result.issues*.member == ['approvers']
+        result.issues*.level == [Validate.Level.WARNING]
+        result.issues*.message == ['Choose at least two approvers']
+    }
+}

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/BeanValidationGradleDocumentaryTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/BeanValidationGradleDocumentaryTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Specification
+import spock.lang.Tag
+
+@Tag("documentary")
+class BeanValidationGradleDocumentaryTest extends Specification {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#using-the-gradle-plugin")
+    def "schema plugin aligns an optional Bean Validation module to its BOM"() {
+        given:
+        Project project = ProjectBuilder.builder().build()
+        String pluginVersion = PluginHelper.determineOwnVersion()
+        project.pluginManager.apply(KlumAstSchemaPlugin)
+
+        when:
+        project.dependencies.add("api", "com.blackbuild.klum.ast:klum-ast-bean-validation")
+
+        then:
+        project.configurations.api.dependencies.any {
+            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bean-validation" && it.version == null
+        }
+        project.configurations.api.dependencies.any {
+            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bom" && it.version == pluginVersion
+        }
+    }
+}

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumAstSchemaPluginTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumAstSchemaPluginTest.groovy
@@ -33,7 +33,10 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
+import spock.lang.Issue
+import spock.lang.See
 import spock.lang.Specification
+import spock.lang.Tag
 
 class KlumAstSchemaPluginTest extends Specification {
 
@@ -100,6 +103,25 @@ class KlumAstSchemaPluginTest extends Specification {
 
         then:
         project.publishing.publications.size() == 1
+    }
+
+    @Issue("491")
+    @Tag("documentary")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#using-the-gradle-plugin")
+    def "schema plugin aligns an optional Bean Validation module to its BOM"() {
+        given:
+        project.getPluginManager().apply(KlumAstSchemaPlugin)
+
+        when:
+        project.dependencies.add("api", "com.blackbuild.klum.ast:klum-ast-bean-validation")
+
+        then:
+        project.configurations.api.dependencies.any {
+            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bean-validation" && it.version == null
+        }
+        project.configurations.api.dependencies.any {
+            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bom" && it.version == version
+        }
     }
 
 }

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumAstSchemaPluginTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumAstSchemaPluginTest.groovy
@@ -33,10 +33,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
-import spock.lang.Issue
-import spock.lang.See
 import spock.lang.Specification
-import spock.lang.Tag
 
 class KlumAstSchemaPluginTest extends Specification {
 
@@ -103,25 +100,6 @@ class KlumAstSchemaPluginTest extends Specification {
 
         then:
         project.publishing.publications.size() == 1
-    }
-
-    @Issue("491")
-    @Tag("documentary")
-    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#using-the-gradle-plugin")
-    def "schema plugin aligns an optional Bean Validation module to its BOM"() {
-        given:
-        project.getPluginManager().apply(KlumAstSchemaPlugin)
-
-        when:
-        project.dependencies.add("api", "com.blackbuild.klum.ast:klum-ast-bean-validation")
-
-        then:
-        project.configurations.api.dependencies.any {
-            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bean-validation" && it.version == null
-        }
-        project.configurations.api.dependencies.any {
-            it.group == "com.blackbuild.klum.ast" && it.name == "klum-ast-bom" && it.version == version
-        }
     }
 
 }


### PR DESCRIPTION
## Summary
- add executable documentary coverage for Jakarta constraint declaration and payload-selected issue levels
- document the optional Bean Validation module and its schema-plugin BOM alignment
- correct the Validation.md dependency snippet to the current artifact coordinates

## Ledger impact
Completes the claimed Validation.md optional Bean Validation / JSR380 cohort only. The #491 audit file is unchanged; integration, payload-edge, and unsupported standalone/Grab paths remain outside this slice.

## Verification
- `./gradlew :klum-ast-bean-validation:test --tests com.blackbuild.klum.ast.validation.bean.BeanValidationDocumentaryTest`
- `./gradlew :klum-ast-gradle-plugin:test --tests com.blackbuild.klum.ast.gradle.BeanValidationGradleDocumentaryTest`
- `./gradlew :klum-ast-bean-validation:groovy4Tests :klum-ast-bean-validation:groovy5Tests`
- `./gradlew check`
- two-axis review: Spec pass; Standards pass with one intentional judgment call for the dedicated class-level documentary tag required by this cohort

Related: #491

This pull request leaves #491 open.