### PR TITLE
Add validation policy documentary coverage

### DIFF
--- a/docs/user/Validation.md
+++ b/docs/user/Validation.md
@@ -386,6 +386,18 @@ In the normal case, only errors lead to a `KlumValidationException` being thrown
 in `KlumValidationResult` objects. Use `KlumObjectSupport.of(object).getValidation().getResult()` for one object or
 `getSubtreeResults()` for that object and its owned subtree.
 
+(See: `ValidationPolicyDocumentaryTest#'records a warning-level validation result without failing construction'`.)
+
+```groovy
+@DSL
+class Release {
+    @Required(level = Validate.Level.WARNING)
+    String releaseNotes
+}
+```
+
+`Release.Create.One()` succeeds and retains a `WARNING` issue for `releaseNotes` in its stored validation result.
+
 The level on which the validation causes an exception can be overridden by the `klum.validation.failOnLevel` system property.
 
 ## Deprecations
@@ -399,26 +411,59 @@ The warning message for a deprecated field is taken from the `@deprecated` javad
 
 If a `@Notify` annotation is present alongside the `@Deprecated` annotation, the `@Notify` is used to determine the warning behavior.
 
+(See: `ValidationPolicyDocumentaryTest#'reports a documented deprecation only for a manually configured legacy field'`.)
+
+```groovy
+@DSL
+class Release {
+    /**
+     * @deprecated Use releaseChannel instead.
+     */
+    @Deprecated
+    String legacyChannel
+}
+```
+
+When a Model Writer sets `legacyChannel`, the stored result records a `DEPRECATION` issue with the documented replacement.
+
 ## `@Notify`
 
 The `@Notify` annotation can be placed on any field to raise an issue if the field is set or unset after the apply phase. This is especially useful in combination with `@Default` and layer3 annotations `@AutoCreate` and `@LinkTo`.
+
+(See: `ValidationPolicyDocumentaryTest#'reports a missing manually configured field'`.)
 
 ```groovy
 @DSL
 class MyModel {
     @AutoCreate
-    @Notify(isUnset = "Value will be autocreated, which might lead to unexpected behavior")
+    @Notify(ifUnset = "Value will be autocreated, which might lead to unexpected behavior")
     String shouldBeSetManually
 }
 @DSL
 class AnotherModel {
     @LinkTo
-    @Notify(isSet = "This value will usually be linked automatically, and should only be set manually if you know what you are doing", level = Validate.Level.INFO)
+    @Notify(ifSet = "This value will usually be linked automatically, and should only be set manually if you know what you are doing", level = Validate.Level.INFO)
     String autoLinked
 }
 ```
 
 As with most issue-related annotations, the issue level can be set via the `level` parameter. The default is WARNING.
+
+`@Notify` can deliberately replace the default `@Deprecated` behavior for the same field:
+
+(See: `ValidationPolicyDocumentaryTest#'uses Notify to replace the default deprecated-field policy'`.)
+
+```groovy
+@DSL
+class Release {
+    @Notify(ifSet = "Use releaseChannel instead.", level = Validate.Level.INFO)
+    @Deprecated
+    String legacyChannel
+}
+```
+
+When a Model Writer sets `legacyChannel`, the stored result contains the `INFO` issue from `@Notify`, rather than a
+`DEPRECATION` issue.
 
 ## Suppress Further Issues
 

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/ValidationPolicyDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/ValidationPolicyDocumentaryTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import com.blackbuild.klum.ast.runtime.KlumObjectSupport
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class ValidationPolicyDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("145")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#validation-levels")
+    def "records a warning-level validation result without failing construction"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Release {
+                @Required(level = Validate.Level.WARNING)
+                String releaseNotes
+            }
+        '''
+
+        when:
+        def release = clazz.Create.One()
+
+        then:
+        def result = KlumObjectSupport.of(release).validation.result
+        result.maxLevel == Validate.Level.WARNING
+        result.message.endsWith("- WARNING #releaseNotes: Field 'releaseNotes' must be set")
+    }
+
+    @Issue("145")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#deprecations")
+    def "reports a documented deprecation only for a manually configured legacy field"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Release {
+                /**
+                 * @deprecated Use releaseChannel instead.
+                 */
+                @Deprecated
+                String legacyChannel
+            }
+        '''
+
+        when:
+        def automaticallyConfiguredRelease = clazz.Create.One()
+
+        then:
+        KlumObjectSupport.of(automaticallyConfiguredRelease).validation.result.issues.empty
+
+        when:
+        def release = clazz.Create.With {
+            legacyChannel 'nightly'
+        }
+
+        then:
+        def result = KlumObjectSupport.of(release).validation.result
+        result.maxLevel == Validate.Level.DEPRECATION
+        result.message.endsWith("- DEPRECATION #legacyChannel: Use releaseChannel instead.")
+    }
+
+    @Issue("407")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#notify")
+    def "reports a missing manually configured field"() {
+        given:
+        createClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.Notify
+
+            @DSL
+            class Release {
+                @Notify(ifUnset = 'Choose a release channel before publishing.')
+                String releaseChannel
+            }
+        '''
+
+        when:
+        def release = clazz.Create.One()
+
+        then:
+        def result = KlumObjectSupport.of(release).validation.result
+        result.maxLevel == Validate.Level.WARNING
+        result.message.endsWith("- WARNING #releaseChannel: Choose a release channel before publishing.")
+    }
+
+    @Issue("407")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Validation.md#notify")
+    def "uses Notify to replace the default deprecated-field policy"() {
+        given:
+        createClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.Notify
+
+            @DSL
+            class Release {
+                @Notify(ifSet = 'Use releaseChannel instead.', level = Validate.Level.INFO)
+                @Deprecated
+                String legacyChannel
+            }
+        '''
+
+        when:
+        def release = clazz.Create.With {
+            legacyChannel 'nightly'
+        }
+
+        then:
+        def result = KlumObjectSupport.of(release).validation.result
+        result.maxLevel == Validate.Level.INFO
+        result.message.endsWith("- INFO #legacyChannel: Use releaseChannel instead.")
+    }
+}


### PR DESCRIPTION
## Summary

- add executable documentary coverage for Validation Levels, deprecated fields, and `@Notify` set/unset policy
- demonstrate stored non-error results and `@Notify` precedence over `@Deprecated`
- correct the documented `@Notify` member names to `ifSet` and `ifUnset`

Related: #491

## Ledger impact

Completes the selected `Validation.md` cohort: **Validation Levels**, **Deprecations**, and **`@Notify`**. It leaves #491 open and does not change the JSR380 cohort or the audit ledger.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.ValidationPolicyDocumentaryTest`
- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `./gradlew check`
- `git diff --check`
- two-axis standards/spec review
