### PR TITLE
Document Builder-first migration happy path

### DIFF
--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -37,6 +37,20 @@ Compile and execute at least one real root configuration. A unit test that calls
 simplest repeatable migration check; an existing root script is equally suitable. A project-less script can also obtain
 KlumAST with `@Grab`, but the complete standalone-script setup will be documented separately.
 
+Build owned children through the generated method on that root Builder, so the entire configuration shares one lifecycle.
+(See: `BuilderFirstMigrationDocumentaryTest#'builds a representative deployment through one Builder lifecycle'`.)
+
+```groovy
+def deployment = Deployment.Create.With {
+    environment 'production'
+    service {
+        image 'catalog:1.0'
+    }
+}
+
+assert deployment.service.image == 'catalog:1.0'
+```
+
 | Runtime failure | What to do |
 | --- | --- |
 | An independent factory cannot start while construction is active | A nested `Child.Create.With` would start a second lifecycle, which is forbidden. Call the generated child method on the parent Builder. Framework extensions can use `Child.Create.AsBuilder` and attach the result in the same session. |

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class BuilderFirstMigrationDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Builder-First-Migration.md#2-compile-and-run-a-representative-model")
+    def "builds a representative deployment through one Builder lifecycle"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Deployment {
+                String environment
+                Service service
+            }
+
+            @DSL
+            class Service {
+                String image
+            }
+        '''
+
+        when:
+        def deployment = clazz.Create.With {
+            environment 'production'
+            service {
+                image 'catalog:1.0'
+            }
+        }
+
+        then:
+        deployment.environment == 'production'
+        deployment.service.image == 'catalog:1.0'
+    }
+}


### PR DESCRIPTION
## Summary

- add an executable Builder-first migration happy path for a root factory and owned child
- link the test to the exact migration-guide heading and add the aligned guide example

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.BuilderFirstMigrationDocumentaryTest`
- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests`
- `./gradlew :klum-ast:groovy5Tests`
- `./gradlew check`
- `git diff --check`

Related: #491

Issue #491 remains open. This PR adds one Builder-first migration documentary cohort and leaves the repository audit, JSON/#464, and Layer 3/#474 work unchanged.
