### PR TITLE
Add completed-object support documentary test

### DIFF
--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -55,6 +55,21 @@ ensures that object graphs remain safe even when DSL types override `equals`.
 
 ## Stored validation
 
+(See: `CompletedObjectSupportDocumentaryTest#'reads stored validation results for a completed deployment'`.)
+
+```groovy
+def deployment = Deployment.Create.With {
+    service {}
+}
+def validation = KlumObjectSupport.of(deployment).validation
+
+assert validation.result.issues
+assert validation.subtreeResults == [
+    validation.result,
+    KlumObjectSupport.of(deployment.service).validation.result
+]
+```
+
 `getValidation().getResult()` returns the result already stored for the target object.
 `getValidation().getSubtreeResults()` reads all stored results for that target and its owned composition subtree.
 `verify()` uses the configured failure level, while `verify(level)` uses the supplied level. These operations only inspect

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import com.blackbuild.klum.ast.runtime.KlumObjectSupport
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class CompletedObjectSupportDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Completed-Object-Support.md#stored-validation")
+    def "reads stored validation results for a completed deployment"() {
+        given:
+        createClass '''
+            @DSL class Deployment {
+                @Required(level = Validate.Level.WARNING)
+                String releaseName
+
+                Service service
+            }
+
+            @DSL class Service {
+                @Required(level = Validate.Level.WARNING)
+                String endpoint
+            }
+        '''
+
+        when:
+        def deployment = clazz.Create.With {
+            service {}
+        }
+        def deploymentValidation = KlumObjectSupport.of(deployment).validation
+        def deploymentResult = deploymentValidation.result
+        def serviceResult = KlumObjectSupport.of(deployment.service).validation.result
+
+        then:
+        deploymentResult.issues.size() == 1
+        serviceResult.issues.size() == 1
+        deploymentValidation.subtreeResults == [deploymentResult, serviceResult]
+    }
+}


### PR DESCRIPTION
Adds the focused Completed Object Support documentary cohort for the `Stored validation` happy path.\n\nIt links `CompletedObjectSupportDocumentaryTest#'reads stored validation results for a completed deployment'` with the page and demonstrates the current `getResult()` / `getSubtreeResults()` contract.\n\nValidation:\n- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.CompletedObjectSupportDocumentaryTest`\n- `./gradlew :klum-ast:test`\n- `./gradlew :klum-ast:groovy4Tests`\n- `./gradlew :klum-ast:groovy5Tests`\n- `./gradlew check`\n- `git diff --check`\n\nRelated: #491\n\nThis is one partial cohort. The campaign ledger and repository-wide audit remain deferred; no API or migration policy is changed.