### PR TITLE
Add type-checked FAQ documentary test

### DIFF
--- a/docs/user/FAQ.md
+++ b/docs/user/FAQ.md
@@ -6,6 +6,24 @@ A Groovy `ModelBuilder` relies heavily on dynamic methods and properties. In com
 described construction API that can be used with `@TypeChecked` or `@CompileStatic`. It also exposes
 `@DelegatesTo` metadata that modern IDEs can use for Builder-closure assistance.
 
+(See: `FAQDocumentaryTest#'configures a generated Builder from a type-checked model script'`.)
+
+```groovy
+@DSL
+class Deployment {
+    String environment
+}
+
+@TypeChecked
+class TypeCheckedDeploymentConfiguration {
+    static Deployment create() {
+        Deployment.Create.With {
+            environment 'production'
+        }
+    }
+}
+```
+
 ## Why don't I get code completion in my IDE?
 
 For a current IntelliJ setup, use the Gradle Schema plugin and refresh the generated source mirrors after Schema changes:

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FAQDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FAQDocumentaryTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class FAQDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/FAQ.md#why-an-ast-and-not-just-use-a-modelbuilder")
+    def "configures a generated Builder from a type-checked model script"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Deployment {
+                String environment
+            }
+        '''
+
+        when:
+        Class<?> typeCheckedConfiguration = createSecondaryClass '''
+            import groovy.transform.TypeChecked
+            import pk.Deployment
+
+            @TypeChecked
+            class TypeCheckedDeploymentConfiguration {
+                static Deployment create() {
+                    Deployment.Create.With {
+                        environment 'production'
+                    }
+                }
+            }
+        '''
+        def deployment = typeCheckedConfiguration.create()
+
+        then:
+        deployment.environment == 'production'
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused executable FAQ documentary test for the generated type-checked factory path
- link the exact FAQ heading to the test and mirror the happy-path example

Related: #491

This is one partial FAQ cohort; issue #491 remains open for the remaining audit and reconciliation work.

## Validation
- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.FAQDocumentaryTest`
- `./gradlew :klum-ast:test groovy4Tests groovy5Tests check`
- `git diff --check`

## Scope boundary
Only `docs/user/FAQ.md` and `FAQDocumentaryTest` are included. The FAQ IDE-completion, name, and library-comparison entries remain for separate cohorts.