### PR TITLE
Add managed Jackson importer documentary test

### DIFF
--- a/docs/user/Jackson-Integration.md
+++ b/docs/user/Jackson-Integration.md
@@ -84,6 +84,8 @@ modules, and data-format factories stay under the integration's control.
 DSL Objects. Configure the caller-owned mapper with `KlumAstModule`, then capture one importer and provide one input per
 operation:
 
+(See: `JacksonImporterDocumentaryTest#'imports a completed release through the managed importer'`.)
+
 ```java
 KlumJacksonImporter importer = KlumJacksonImporter.using(mapper);
 Order order = importer.readRoot(Order.class, KlumJacksonInput.parser(parser));

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterDocumentaryTest.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterDocumentaryTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//file:noinspection GrPackage
+package com.blackbuild.klum.ast.jackson
+
+import com.blackbuild.klum.ast.AbstractDSLSpec
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class JacksonImporterDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Jackson-Integration.md#managed-import")
+    def "imports a completed release through the managed importer"() {
+        given:
+        createClass('''
+            package pk
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+
+            @DSL
+            class Release {
+                @JsonProperty("release_name")
+                String name
+                String lifecycle
+
+                @PostApply
+                void markImported() { lifecycle = "imported:$name" }
+            }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+
+        when:
+        def release = KlumJacksonImporter.using(mapper).readRoot(
+                clazz,
+                KlumJacksonInput.parser(mapper.factory.createParser('{"release_name":"season-4"}')))
+
+        then:
+        release.name == "season-4"
+        release.lifecycle == "imported:season-4"
+    }
+}


### PR DESCRIPTION
## Summary
- add one focused executable happy path for managed Jackson root import
- link JacksonImporterDocumentaryTest directly from the Managed Import documentation heading
- leave the #464 YAML interoperability workflow and importer API contracts unchanged

## Validation
- `./gradlew :klum-ast-jackson:test --tests com.blackbuild.klum.ast.jackson.JacksonImporterDocumentaryTest`
- `./gradlew :klum-ast-jackson:test`
- `./gradlew groovy4Tests`
- `./gradlew groovy5Tests`
- `./gradlew check`
- `git diff --check`

Related: #491