### PR TITLE
Document completed-object traversal

### DIFF
--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -53,6 +53,35 @@ validation location. Neither is a substitute for the construction or structural 
 Traversal follows composed DSL values only. Owner and `LINK` edges are not followed, and identity-based cycle protection
 ensures that object graphs remain safe even when DSL types override `equals`.
 
+(See: `CompletedObjectSupportDocumentaryTest#'traverses a deployment composition without following linked services'`.)
+
+```groovy
+@DSL class Deployment {
+    Service api
+    List<Service> services
+    @Field(FieldType.LINK) Service catalogService
+}
+
+@DSL class Service {
+    @Key String name
+    @Owner Deployment deployment
+}
+
+def catalog = Service.Create.With('catalog') {}
+def deployment = Deployment.Create.With {
+    api('api') {}
+    services {
+        service('worker') {}
+    }
+    catalogService catalog
+}
+def structure = KlumObjectSupport.of(deployment).structure
+
+assert structure.getRelativePath(deployment.services[0]) == 'services[0]'
+assert KlumObjectSupport.of(deployment.api).structure.singleOwner.get().is(deployment)
+assert structure.findAll(Service).keySet() == ['<root>.api', '<root>.services[0]']
+```
+
 ## Stored validation
 
 (See: `CompletedObjectSupportDocumentaryTest#'reads stored validation results for a completed deployment'`.)

--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -56,6 +56,7 @@ ensures that object graphs remain safe even when DSL types override `equals`.
 (See: `CompletedObjectSupportDocumentaryTest#'traverses a deployment composition without following linked services'`.)
 
 ```groovy
+given:
 @DSL class Deployment {
     Service api
     List<Service> services
@@ -68,6 +69,8 @@ ensures that object graphs remain safe even when DSL types override `equals`.
 }
 
 def catalog = Service.Create.With('catalog') {}
+
+when:
 def deployment = Deployment.Create.With {
     api('api') {}
     services {
@@ -77,6 +80,7 @@ def deployment = Deployment.Create.With {
 }
 def structure = KlumObjectSupport.of(deployment).structure
 
+then:
 assert structure.getRelativePath(deployment.services[0]) == 'services[0]'
 assert KlumObjectSupport.of(deployment.api).structure.singleOwner.get().is(deployment)
 assert structure.findAll(Service).keySet() == ['<root>.api', '<root>.services[0]']

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
@@ -32,6 +32,49 @@ import spock.lang.Tag
 class CompletedObjectSupportDocumentaryTest extends AbstractDSLSpec {
 
     @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Completed-Object-Support.md#ownership-paths-and-traversal")
+    def "traverses a deployment composition without following linked services"() {
+        given:
+        createClass '''
+            import com.blackbuild.klum.ast.FieldType
+            import com.blackbuild.klum.ast.Owner
+
+            @DSL class Deployment {
+                Service api
+                List<Service> services
+                @Field(FieldType.LINK) Service catalogService
+            }
+
+            @DSL class Service {
+                @Key String name
+                @Owner Deployment deployment
+            }
+        '''
+        def catalog = Service.Create.With('catalog') {}
+
+        when:
+        def deployment = clazz.Create.With {
+            api('api') {}
+            services {
+                service('worker') {}
+            }
+            catalogService catalog
+        }
+        def structure = KlumObjectSupport.of(deployment).structure
+        def visitedServicePaths = []
+        structure.visit(Service) { path, service -> visitedServicePaths << path }
+
+        then:
+        KlumObjectSupport.of(deployment.api).structure.singleOwner.get().is(deployment)
+        structure.getRelativePath(deployment.services[0]) == 'services[0]'
+        structure.findAll(Service) == [
+                '<root>.api'       : deployment.api,
+                '<root>.services[0]': deployment.services[0],
+        ]
+        visitedServicePaths == ['<root>.api', '<root>.services[0]']
+    }
+
+    @Issue("491")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Completed-Object-Support.md#stored-validation")
     def "reads stored validation results for a completed deployment"() {
         given:


### PR DESCRIPTION
## Summary

- Add a #491 documentary deployment traversal path for completed-object structure support.
- Add the aligned ownership and traversal example to the current user documentation.

## Scope

- Covers direct owner lookup, relative paths, typed traversal, and `LINK` exclusion.
- Does not alter validation APIs or migration policy; the current `getResult()` / `getSubtreeResults()` contract remains unchanged.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.CompletedObjectSupportDocumentaryTest`
- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests --tests com.blackbuild.klum.ast.CompletedObjectSupportDocumentaryTest`
- `./gradlew :klum-ast:groovy5Tests --tests com.blackbuild.klum.ast.CompletedObjectSupportDocumentaryTest`
- `./gradlew check`
- `git diff --check origin/master...HEAD`

Related: #491