### PR TITLE
Document Basics default implementation

### DIFF
--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -370,6 +370,8 @@ Note that, as in the above example, this behaviour, while working with non dsl a
 Using the `defaultImpl` attribute of the `Field` annotation, you can specify a default implementation for a field. That way,
 dsl methods are created as if the field were of the specified type. This is especially useful for interface as field type.
 
+(See: `BasicsDefaultImplementationDocumentaryTest#'configures a default implementation through an interface field'`.)
+
 ```groovy
 given: // Schema
 @DSL

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BasicsDefaultImplementationDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BasicsDefaultImplementationDocumentaryTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class BasicsDefaultImplementationDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("491")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Basics.md#default-implementation")
+    def "configures a default implementation through an interface field"() {
+        given:
+        createClass '''
+            @DSL
+            class ServiceConfiguration {
+                @Field(defaultImpl = HttpEndpoint)
+                Endpoint endpoint
+            }
+
+            interface Endpoint {
+                String getUrl()
+            }
+
+            @DSL
+            class HttpEndpoint implements Endpoint {
+                String url
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            endpoint(url: 'https://catalog.example.test')
+        }
+
+        then:
+        getClass('HttpEndpoint').isInstance(instance.endpoint)
+        instance.endpoint.url == 'https://catalog.example.test'
+    }
+}


### PR DESCRIPTION
## Summary
- Add one executable documentary happy path for an interface field with `@Field(defaultImpl = ...)`.
- Link the `Default Implementation` Basics heading to the exact documentary test method.

## Intentional boundary
- This small cohort covers only the field-level default-implementation path.
- `DSL Interfaces` remains unselected: on current master its documented explicit implementation call left the completed field null during source review, so no behavior or documentation policy is asserted here.
- Interface-level defaults, collection/map defaults, and virtual-field defaults remain outside this slice.

## Validation
- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.BasicsDefaultImplementationDocumentaryTest`
- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.DefaultImplTest`
- `./gradlew :klum-ast:test :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- `./gradlew check`
- Standards and Spec review against `origin/master` (no findings)

Related: #491