### PR TITLE
Document Basics fixed keys with executable test

### DIFF
--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -857,6 +857,8 @@ This is useful if the member is derived from some value of the owner.
 
 For example, consider the following classes:
 
+(See: `FixedKeysDocumentaryTest#'derives a keyed database name from its server'`.)
+
 ```groovy
 given: // Schema
 @DSL

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/FixedKeysDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/FixedKeysDocumentaryTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+class FixedKeysDocumentaryTest extends AbstractDSLSpec {
+
+    @Issue("186")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Basics.md#fixed-keys")
+    def "derives a keyed database name from its server"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Database {
+                @Key String name
+            }
+
+            @DSL
+            class Server {
+                @Key String name
+                @Field(key = { name })
+                Database database
+            }
+        '''
+
+        when:
+        def server = getClass('Server').Create.With('INT') {
+            database { }
+        }
+
+        then:
+        server.name == 'INT'
+        server.database.name == 'INT'
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an executable Fixed Keys happy path for deriving a child key from its owner.
- Links the Basics Fixed keys example directly to that documentary test.

## Scope

The method traces the established Fixed Keys contract to historical governing issue #186 (merged PR #200). Static `FieldName`, generated-overload shape, and invalid-placement scenarios remain focused coverage in `FixedKeySpec`.

The #491 audit file is intentionally untouched; its Fixed Keys defer entry needs separate Hive curation reconciliation.

Related: #491

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.FixedKeysDocumentaryTest`
- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.FixedKeySpec`
- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `./gradlew check`
- `git diff --check origin/master...HEAD`

## Local review

Standards and Spec review passed; the final test carries governing issue #186 rather than the #491 audit issue.