### PR TITLE
Complete named-schema JPMS acceptance (#391)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 - Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0.
 - Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes. Invalid `@Overwrite.Single(MERGE)` strategies on non-DSL fields are rejected during compilation ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
 
+## Java modules
+
+- Named schema modules are supported with Groovy 4 and 5; Groovy 3 remains supported on the ordinary classpath. A named schema requires the documented `org.apache.groovy` dependency and a qualified `opens` directive to KlumAST runtime, Jackson when used, and Hibernate Validator when Bean Validation is used. No JVM module-path workaround flags are required ([#391](https://github.com/klum-dsl/klum-ast/issues/391)).
+
 ## Builder-first construction
 
 - Added the portable `build-domain-first-schema` skill, task-oriented domain-first guidance, and an executable Layer 3 smart-home journey. The fixture separates generic API, fixed floorplan Schema, registered Model script, and API-only `client-demo`; it covers Cluster projection, provider-polymorphic Builder calls, `@DefaultValues` labels, and a bounded field-test artifact ([#471](https://github.com/klum-dsl/klum-ast/issues/471)).

--- a/docs/implementation/evidence/issue-391-jp1b-named-schema-fixture.md
+++ b/docs/implementation/evidence/issue-391-jp1b-named-schema-fixture.md
@@ -1,0 +1,54 @@
+# #391 JP-1b real named-schema fixture evidence
+
+This record is fresh positive evidence from the JP-1b fixture. It does not
+reuse the historical blocked-evidence commit `8f1f66e5`.
+
+## Proven contract
+
+`JpmsPackageBoundaryTest` builds a consumer-owned `fixture.schema` from a real
+`@DSL` Groovy source plus separate Java and `@CompileStatic` Groovy consumers.
+The ordinary classpath fixture runs in every Groovy lane. It proves annotation
+transformation, generated `Station.Create.One()` factories, protected Builder
+`@PostCreate`/`@PostTree` callbacks, Builder Materialization, validation,
+runtime `PhaseAction` and Bean Validation `InstanceValidator` service loading,
+Jackson export, and static-Groovy factory consumption.
+
+Groovy 3 proves that ordinary classpath contract only. Groovy 4 and 5 additionally
+compile with the named `org.apache.groovy` compiler module, package and inspect
+the user-owned schema descriptor, and execute the Java and static-Groovy
+consumers as named modules.
+
+The named descriptor is intentionally exact:
+
+```java
+opens fixture.schema to com.blackbuild.klum.ast.runtime,
+    com.fasterxml.jackson.databind,
+    org.hibernate.validator;
+```
+
+The runtime opening supports generated Builder lifecycle and materialization;
+Jackson Databind owns its export reflection; Hibernate Validator owns field
+constraint reflection. The Bean Validation adapter declares its non-transitive
+ClassMate runtime dependency and `requires com.fasterxml.classmate`, so
+module-path consumers resolve the provider without a local launch workaround.
+
+The fixture scans every generated schema class for
+`com.blackbuild.klum.ast.runtime.internal` references, checks the public
+template-adapter/factory visibility and constructors, and retains the protected
+lifecycle-method shape. Every named command rejects `--add-reads`,
+`--add-exports`, and `--patch-module` (including equals forms).
+
+## Validation
+
+All focused lanes pass:
+
+```text
+./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.JpmsPackageBoundaryTest
+./gradlew :klum-ast:groovy4Tests --tests com.blackbuild.klum.ast.JpmsPackageBoundaryTest
+./gradlew :klum-ast:groovy5Tests --tests com.blackbuild.klum.ast.JpmsPackageBoundaryTest
+BUILD SUCCESSFUL
+```
+
+This completes JP-1b's real-schema acceptance evidence for ADR 0014. It does
+not authorize broad package moves, additional exports, or general module
+migration work.

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -13,6 +13,37 @@ and treat the completed-model export as a separately owned external projection. 
 use repeated imports as a Jackson-specific merge/layering mechanism; [#304](https://github.com/klum-dsl/klum-ast/issues/304)
 owns source-neutral composition.
 
+### Named modules and Groovy
+
+Groovy 3 remains an ordinary-classpath configuration. Do not add a KlumAST
+`module-info.java` to a Groovy 3 schema or compensate with JVM module flags.
+
+Groovy 4 and 5 schemas may be named modules and must require
+`org.apache.groovy`, the annotations/runtime modules, and `requires static
+com.blackbuild.klum.ast.compiler`; add adapter modules only when used. A schema
+that uses Jackson and Jakarta Bean Validation has this narrow descriptor shape:
+
+```java
+module example.schema {
+    requires com.blackbuild.klum.ast.annotations;
+    requires com.blackbuild.klum.ast.runtime;
+    requires static com.blackbuild.klum.ast.compiler;
+    requires com.blackbuild.klum.ast.jackson;
+    requires com.blackbuild.klum.ast.validation.bean;
+    requires org.apache.groovy;
+
+    exports example.schema;
+    opens example.schema to com.blackbuild.klum.ast.runtime,
+        com.fasterxml.jackson.databind,
+        org.hibernate.validator;
+}
+```
+
+Keep the runtime opening for generated Builder lifecycle/materialization. Add
+the Jackson and Hibernate Validator targets only when those adapters inspect
+the schema; do not substitute `--add-reads`, `--add-exports`, or
+`--patch-module` flags.
+
 ## KlumCast 0.4 RC dependencies
 
 KlumAST 4.0 uses the immutable KlumCast `0.4.0-rc.2` artifact set: `klum-cast-annotations`, `klum-cast-spi`, and

--- a/klum-ast-bean-validation/build.gradle
+++ b/klum-ast-bean-validation/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     api project(':klum-ast-runtime')
     api 'jakarta.validation:jakarta.validation-api:3.0.2'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.3.Final'
+    implementation 'com.fasterxml:classmate:1.5.1'
 
     sharedTests project(':klum-ast')
     // just to make intellij happy, base classes are actually included as sources

--- a/klum-ast-bean-validation/src/main/module-info/module-info.java
+++ b/klum-ast-bean-validation/src/main/module-info/module-info.java
@@ -1,6 +1,7 @@
 module com.blackbuild.klum.ast.validation.bean {
     requires transitive com.blackbuild.klum.ast.runtime;
     requires transitive jakarta.validation;
+    requires com.fasterxml.classmate;
     requires org.hibernate.validator;
     exports com.blackbuild.klum.ast.validation.bean;
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
@@ -149,9 +149,29 @@ public class DslHelper {
     }
 
     public static <T> T getFieldValue(Object container, String name) {
-        return (T) DslHelper.getCachedField(container.getClass(), name)
-                .map(f -> f.getProperty(container))
+        return (T) getField(container.getClass(), name)
+                .map(field -> getFieldValue(container, field))
                 .orElse(null);
+    }
+
+    static Object getFieldValue(Object container, Field field) {
+        try {
+            if (!field.trySetAccessible())
+                throw new KlumModelException("Cannot access field " + field);
+            return field.get(container);
+        } catch (IllegalAccessException exception) {
+            throw new KlumModelException("Could not read field " + field, exception);
+        }
+    }
+
+    static void setFieldValue(Object container, Field field, Object value) {
+        try {
+            if (!field.trySetAccessible())
+                throw new KlumModelException("Cannot access field " + field);
+            field.set(container, value);
+        } catch (IllegalAccessException exception) {
+            throw new KlumModelException("Could not write field " + field, exception);
+        }
     }
 
     public static FieldType getKlumFieldType(Field field) {
@@ -301,11 +321,11 @@ public class DslHelper {
     }
 
     public static Object getAttributeValue(String name, Object instance) {
-        Optional<CachedField> cachedField = getCachedField(instance.getClass(), name);
+        Optional<Field> field = getField(instance.getClass(), name);
 
         // cannot use .map, because value can be null
-        if (cachedField.isPresent())
-            return cachedField.get().getProperty(instance);
+        if (field.isPresent())
+            return getFieldValue(instance, field.get());
 
         throw new MissingPropertyException(name, instance.getClass());
     }

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
@@ -164,6 +164,8 @@ public class DslHelper {
         }
     }
 
+    // User-owned schema modules open their packages to this runtime for model access.
+    @SuppressWarnings("java:S3011")
     static void setFieldValue(Object container, Field field, Object value) {
         try {
             if (!field.trySetAccessible())

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder.java
@@ -196,9 +196,9 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
 
     /** Internal Builder hook that assigns one completed relationship without exposing a model mutator. */
     protected final void $assignMaterializedRelationship(String fieldName) {
-        CachedField target = DslHelper.getCachedField(completedModel.getClass(), fieldName)
+        Field target = DslHelper.getField(completedModel.getClass(), fieldName)
                 .orElseThrow(() -> new MissingPropertyException(fieldName, completedModel.getClass()));
-        target.setProperty(completedModel, $materializeRelationship(fieldName));
+        setFieldValue(completedModel, target, $materializeRelationship(fieldName));
     }
 
     private static List<InternalKlumBuilder<?>> collectGraph(InternalKlumBuilder<?> root) {
@@ -386,13 +386,13 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
     }
 
     public <T> T getInstanceAttribute(String attributeName) {
-        return (T) getCachedField(attributeName).getProperty(this);
+        return (T) getFieldValue(this, getField(attributeName));
     }
 
     public <T> T getInstanceAttributeOrGetter(String attributeName) {
-        Optional<CachedField> field = DslHelper.getCachedField(getClass(), attributeName);
+        Optional<Field> field = DslHelper.getField(getClass(), attributeName);
         if (field.isPresent())
-            return (T) field.get().getProperty(this);
+            return (T) getFieldValue(this, field.get());
         return (T) InvokerHelper.getProperty(this, attributeName);
     }
 
@@ -404,7 +404,7 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
         assertMutable();
         Field schemaField = DslHelper.getField(modelType, name).orElse(null);
         Object normalized = schemaField != null ? normalizeForField(schemaField, value) : value;
-        getCachedField(name).setProperty(this, normalized);
+        setFieldValue(this, getField(name), normalized);
     }
 
     public Field getField(String name) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/LifecycleHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/LifecycleHelper.java
@@ -23,13 +23,14 @@
  */
 package com.blackbuild.klum.ast.runtime.internal;
 
+import com.blackbuild.klum.ast.runtime.KlumModelException;
 import com.blackbuild.klum.ast.runtime.internal.process.PhaseDriver;
 import groovy.lang.Closure;
-import org.codehaus.groovy.runtime.InvokerHelper;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -56,15 +57,41 @@ public class LifecycleHelper {
         DslHelper.getMethodsAnnotatedWith(rw.getClass(), annotation)
                 .map(Method::getName)
                 .distinct()
+                .map(name -> resolveLifecycleMethod(rw.getClass(), name))
                 .forEach(method -> {
                     try {
-                        PhaseDriver.setCurrentMember(method);
-                        InvokerHelper.invokeMethod(rw, method, null);
+                        PhaseDriver.setCurrentMember(method.getName());
+                        invokeLifecycleMethod(rw, method);
                     } finally {
                         PhaseDriver.setCurrentMember(null);
                     }
                 });
         executeLifecycleClosures(builder, annotation);
+    }
+
+    private static Method resolveLifecycleMethod(Class<?> type, String name) {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            try {
+                return current.getDeclaredMethod(name);
+            } catch (NoSuchMethodException ignored) {
+                // continue through the Builder hierarchy to preserve virtual lifecycle dispatch
+            }
+        }
+        throw new KlumModelException("No lifecycle method named " + name + " found on " + type.getName());
+    }
+
+    private static void invokeLifecycleMethod(Object target, Method method) {
+        try {
+            if (!method.trySetAccessible())
+                throw new KlumModelException("Cannot access lifecycle method " + method);
+            method.invoke(target);
+        } catch (InvocationTargetException exception) {
+            if (exception.getCause() instanceof RuntimeException runtimeException)
+                throw runtimeException;
+            throw new KlumModelException("Could not execute lifecycle method " + method, exception.getCause());
+        } catch (IllegalAccessException exception) {
+            throw new KlumModelException("Could not execute lifecycle method " + method, exception);
+        }
     }
 
     /**

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/TemplateManager.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/TemplateManager.java
@@ -68,8 +68,8 @@ public class TemplateManager {
     public static boolean isTemplate(Object value) {
         return value != null
                 && DslHelper.isDslObject(value)
-                && DslHelper.getCachedField(value.getClass(), KlumModelProxy.NAME_IN_MODEL)
-                .map(field -> field.getProperty(value))
+                && DslHelper.getField(value.getClass(), KlumModelProxy.NAME_IN_MODEL)
+                .map(field -> DslHelper.getFieldValue(value, field))
                 .filter(KlumTemplateProxy.class::isInstance)
                 .isPresent();
     }

--- a/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/DslHelperTest.groovy
+++ b/klum-ast-runtime/src/test/groovy/com/blackbuild/klum/ast/util/DslHelperTest.groovy
@@ -23,7 +23,36 @@
  */
 package com.blackbuild.klum.ast.runtime.internal
 
+import com.blackbuild.klum.ast.runtime.KlumModelException
+import spock.lang.Issue
+
 class DslHelperTest extends AbstractRuntimeTest {
+
+    @Issue("391")
+    def "field value access reports an inaccessible field"() {
+        given:
+        def field = String.getDeclaredField('value')
+
+        when:
+        DslHelper.getFieldValue('value', field)
+
+        then:
+        def exception = thrown(KlumModelException)
+        exception.message.startsWith('Cannot access field')
+    }
+
+    @Issue("391")
+    def "field value assignment reports an inaccessible field"() {
+        given:
+        def field = String.getDeclaredField('value')
+
+        when:
+        DslHelper.setFieldValue('value', field, null)
+
+        then:
+        def exception = thrown(KlumModelException)
+        exception.message.startsWith('Cannot access field')
+    }
 
     void "getField returns correct Field"() {
         given:

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1415,8 +1415,10 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         DslAstHelper.registerAsVerbProvider(factoryClass);
 
         if (factoryIsGeneric)
-            factoryClass.addConstructor(0, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY,
+            factoryClass.addConstructor(ACC_PUBLIC, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY,
                     ctorSuperS(classX(annotatedClass)));
+        else
+            factoryClass.addConstructor(ACC_PUBLIC, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, block());
 
         overrideFactoryMethods(factoryClass, defaultImpl);
         createAsBuilderFactoryAccessor(defaultImpl);

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
@@ -92,7 +92,7 @@ class TemplateMethods {
         templateAdapter = new InnerClassNode(
                 annotatedClass,
                 annotatedClass.getName() + "$_Template",
-                ACC_STATIC | ACC_FINAL | ACC_SYNTHETIC,
+                ACC_PUBLIC | ACC_STATIC | ACC_FINAL | ACC_SYNTHETIC,
                 OBJECT_TYPE,
                 new ClassNode[] { GeneratedDslSupport.of(annotatedClass).getTemplateInterface() },
                 MixinNode.EMPTY_ARRAY

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/LifecycleSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/LifecycleSpec.groovy
@@ -25,6 +25,7 @@ package com.blackbuild.klum.ast
 
 
 import com.blackbuild.klum.ast.runtime.DefaultKlumPhase
+import com.blackbuild.klum.ast.runtime.KlumModelException
 import com.blackbuild.klum.ast.runtime.KlumPhase
 import com.blackbuild.klum.ast.runtime.internal.process.PhaseDriver
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
@@ -411,6 +412,52 @@ class LifecycleSpec extends AbstractDSLSpec {
         then:
         instance.caller == ["FromOverridden", "otherParent", "child"]
 
+    }
+
+    @Issue("391")
+    def "lifecycle runtime exceptions are preserved"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Foo {
+                @PostCreate
+                void postCreate() {
+                    throw new IllegalStateException('expected lifecycle failure')
+                }
+            }
+        '''
+
+        when:
+        create('pk.Foo') {}
+
+        then:
+        def exception = thrown(IllegalStateException)
+        exception.message == 'expected lifecycle failure'
+    }
+
+    @Issue("391")
+    def "lifecycle checked exceptions are wrapped"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Foo {
+                @PostCreate
+                void postCreate() {
+                    throw new Exception('expected checked lifecycle failure')
+                }
+            }
+        '''
+
+        when:
+        create('pk.Foo') {}
+
+        then:
+        def exception = thrown(KlumModelException)
+        exception.cause.message == 'expected checked lifecycle failure'
     }
 
     def "lifecycle methods are moved to RW class and made protected"() {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -26,10 +26,13 @@ package com.blackbuild.klum.ast
 import spock.lang.Issue
 import spock.lang.Specification
 
-import java.lang.module.ModuleFinder
-import java.nio.file.Path
-import java.nio.file.Files
 import java.io.DataInputStream
+import java.lang.module.ModuleFinder
+import java.lang.module.ModuleDescriptor
+import java.lang.reflect.Modifier
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.jar.JarFile
 
 @Issue("391")
@@ -124,6 +127,9 @@ class JpmsPackageBoundaryTest extends Specification {
         exportedPackages(descriptors.compiler).empty
         exportedPackages(descriptors.jackson) == ['com.blackbuild.klum.ast.jackson'] as Set
         exportedPackages(descriptors.beanValidation) == ['com.blackbuild.klum.ast.validation.bean'] as Set
+        descriptors.beanValidation.requires()*.name().contains('com.fasterxml.classmate')
+        !descriptors.beanValidation.requires().find { it.name() == 'com.fasterxml.classmate' }
+                .modifiers().contains(ModuleDescriptor.Requires.Modifier.TRANSITIVE)
         qualifiedOpenTargets(descriptors.compiler) == [
                 'com.blackbuild.klum.ast.compiler.internal.ast'           : [
                         'org.apache.groovy',
@@ -172,9 +178,37 @@ class JpmsPackageBoundaryTest extends Specification {
         !namedGroovy || Files.exists(namedModuleResult.outputDirectory.resolve('NamedRoot.class'))
 
         and: 'the class-file owner and descriptor scanner finds no runtime-internal reference in any generated named-schema class'
-        !namedGroovy || !Files.walk(namedModuleResult.outputDirectory).withCloseable { paths ->
+        if (namedGroovy) {
+            assertNoRuntimeInternalReferences(namedModuleResult.outputDirectory)
+            assertGeneratedHelperContract(namedModuleResult.outputDirectory, 'NamedRoot', '$_Template', true)
+            assertGeneratedHelperContract(namedModuleResult.outputDirectory, 'NamedRoot', '$_Factory', false)
+        }
+    }
+
+    private static void assertNoRuntimeInternalReferences(Path classes) {
+        assert !Files.walk(classes).withCloseable { paths ->
             paths.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith('.class') }
                     .any(this::hasRuntimeInternalReference)
+        }
+    }
+
+    private static void assertGeneratedHelperContract(Path classes, String modelName, String suffix, boolean synthetic) {
+        new URLClassLoader([classes.toUri().toURL()] as URL[], JpmsPackageBoundaryTest.classLoader).withCloseable { loader ->
+            Class<?> helper = Class.forName(modelName + suffix, false, loader)
+            assert Modifier.isPublic(helper.modifiers)
+            assert Modifier.isStatic(helper.modifiers)
+            assert Modifier.isFinal(helper.modifiers)
+            assert helper.synthetic == synthetic
+            assert Modifier.isPublic(helper.getDeclaredConstructor().modifiers)
+        }
+    }
+
+    private static void assertProtectedLifecycleContract(Path classes) {
+        new URLClassLoader([classes.toUri().toURL()] as URL[], JpmsPackageBoundaryTest.classLoader).withCloseable { loader ->
+            Class<?> builder = Class.forName('fixture.schema.Station$Builder', false, loader)
+            ['recordCreate', 'recordTree'].each { methodName ->
+                assert Modifier.isProtected(builder.getDeclaredMethod(methodName).modifiers)
+            }
         }
     }
 
@@ -234,6 +268,24 @@ class JpmsPackageBoundaryTest extends Specification {
         }
     }
 
+    def "a real schema and consumer prove the classpath and named-module contracts"() {
+        given:
+        boolean namedGroovy = GroovySystem.version.startsWith('4.') || GroovySystem.version.startsWith('5.')
+
+        when:
+        ProcessResult classpathResult = executeRealSchemaFixture(false)
+        ProcessResult namedModuleResult = namedGroovy ? executeRealSchemaFixture(true) : null
+
+        then: 'all supported Groovy generations retain the ordinary classpath consumer contract'
+        assert classpathResult.exitCode == 0 : classpathResult.output
+        assertFixtureOutput(classpathResult)
+
+        and: 'only Groovy 4 and 5 prove the user-owned schema on the module path'
+        !namedGroovy || namedModuleResult.exitCode == 0
+        if (namedGroovy)
+            assertFixtureOutput(namedModuleResult)
+    }
+
     private static Map<String, Set<String>> packageOwners(Map<String, Set<String>> packagesByArtifact) {
         Map<String, Set<String>> owners = new LinkedHashMap<>()
         packagesByArtifact.each { artifact, packageNames ->
@@ -264,6 +316,12 @@ class JpmsPackageBoundaryTest extends Specification {
                 entry.name.startsWith('META-INF/services/') && !entry.directory
             }.collect { it.name } as Set
         }
+    }
+
+    private static void assertFixtureOutput(ProcessResult result) {
+        assert result.output.readLines().contains(
+                'java=true;station=North;events=create,tree,validate;phase=true;validator=true;json=true') : result.output
+        assert result.output.readLines().last() == 'static=true' : result.output
     }
 
     private static Map<String, Path> artifacts() {
@@ -304,6 +362,333 @@ class JpmsPackageBoundaryTest extends Specification {
                 '--class-path', modulePathEntries().join(File.pathSeparator),
                 'org.codehaus.groovy.tools.FileSystemCompiler'
         ])
+    }
+
+    private static ProcessResult executeRealSchemaFixture(boolean named) {
+        Path fixture = Files.createTempDirectory(named ? 'klum-jpms-named-schema' : 'klum-classpath-schema')
+        Path schemaSources = fixture.resolve('schema-sources')
+        Path schemaClasses = fixture.resolve('schema-classes')
+        Path consumerSources = fixture.resolve('consumer-sources')
+        Path consumerClasses = fixture.resolve('consumer-classes')
+        Files.createDirectories(schemaSources.resolve('fixture/schema'))
+        Files.createDirectories(schemaClasses)
+        Files.createDirectories(consumerSources.resolve('fixture/consumer'))
+        Files.createDirectories(consumerClasses)
+        Files.writeString(schemaSources.resolve('fixture/schema/Station.groovy'), realSchemaSource())
+        Files.writeString(consumerSources.resolve('fixture/consumer/StaticConsumer.groovy'), staticGroovyConsumerSource())
+
+        ProcessResult schemaCompilation = compileGroovySchema(schemaSources, schemaClasses, named)
+        if (schemaCompilation.exitCode != 0)
+            return schemaCompilation
+
+        if (named)
+            assertProtectedLifecycleContract(schemaClasses)
+
+        Path schemaArtifact = named ? compileAndPackageNamedSchema(schemaSources, schemaClasses) : schemaClasses
+
+        ProcessResult staticConsumerCompilation = compileStaticGroovyConsumer(
+                schemaArtifact, consumerSources, consumerClasses, named)
+        if (staticConsumerCompilation.exitCode != 0)
+            return staticConsumerCompilation
+
+        Files.writeString(consumerSources.resolve('fixture/consumer/Main.java'), realConsumerSource())
+        if (named)
+            Files.writeString(consumerSources.resolve('module-info.java'), namedConsumerDescriptor())
+
+        ProcessResult consumerCompilation = compileConsumer(schemaArtifact, consumerSources, consumerClasses, named)
+        if (consumerCompilation.exitCode != 0)
+            return consumerCompilation
+        runConsumer(schemaArtifact, consumerClasses, named)
+    }
+
+    private static ProcessResult compileGroovySchema(Path sources, Path output, boolean named) {
+        List<String> compilerCommand = named ? [
+                '--module-path', modulePathEntries().join(File.pathSeparator),
+                '--add-modules', 'ALL-MODULE-PATH',
+                '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler',
+                '--classpath', modulePathEntries().join(File.pathSeparator)
+        ] : [
+                '--class-path', modulePathEntries().join(File.pathSeparator),
+                'org.codehaus.groovy.tools.FileSystemCompiler'
+        ]
+        if (named)
+            assertNamedModuleCommand(compilerCommand)
+        List<String> command = [javaExecutable()]
+        command.addAll(compilerCommand)
+        command.addAll([
+                '-d', output.toString(),
+                sources.resolve('fixture/schema/Station.groovy').toString()
+        ])
+        execute(command, output)
+    }
+
+    private static Path compileAndPackageNamedSchema(Path sources, Path classes) {
+        Files.writeString(sources.resolve('module-info.java'), namedSchemaDescriptor())
+        List<String> descriptorArguments = [
+                '--module-path', modulePathEntries().join(File.pathSeparator),
+                '-d', classes.toString(),
+                sources.resolve('module-info.java').toString()
+        ]
+        assertNoPortabilityWorkarounds(descriptorArguments)
+        ProcessResult descriptorCompilation = compileJava(descriptorArguments, classes)
+        assert descriptorCompilation.exitCode == 0 : descriptorCompilation.output
+
+        Path archive = classes.parent.resolve('fixture.schema.jar')
+        ProcessResult packaging = execute([
+                jarExecutable(), '--create', '--file', archive.toString(), '-C', classes.toString(), '.'
+        ], classes)
+        assert packaging.exitCode == 0 : packaging.output
+        assertNamedSchemaDescriptor(archive)
+        assertNoRuntimeInternalReferences(classes)
+        archive
+    }
+
+    private static ProcessResult compileStaticGroovyConsumer(Path schemaArtifact, Path sources, Path output, boolean named) {
+        List<String> compilerCommand = named ? [
+                '--module-path', modulePath(schemaArtifact),
+                '--add-modules', 'ALL-MODULE-PATH',
+                '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler',
+                '--classpath', modulePath(schemaArtifact)
+        ] : [
+                '--class-path', classpath(schemaArtifact),
+                'org.codehaus.groovy.tools.FileSystemCompiler'
+        ]
+        if (named)
+            assertNamedModuleCommand(compilerCommand)
+        List<String> command = [javaExecutable()]
+        command.addAll(compilerCommand)
+        command.addAll([
+                '-d', output.toString(),
+                sources.resolve('fixture/consumer/StaticConsumer.groovy').toString()
+        ])
+        execute(command, output)
+    }
+
+    private static ProcessResult compileConsumer(Path schemaArtifact, Path sources, Path output, boolean named) {
+        List<String> arguments = named ? [
+                '--module-path', modulePath(schemaArtifact),
+                '-d', output.toString(),
+                sources.resolve('module-info.java').toString(),
+                sources.resolve('fixture/consumer/Main.java').toString()
+        ] : [
+                '--class-path', classpath(schemaArtifact),
+                '-d', output.toString(),
+                sources.resolve('fixture/consumer/Main.java').toString()
+        ]
+        if (named)
+            assertNoPortabilityWorkarounds(arguments)
+        compileJava(arguments, output)
+    }
+
+    private static ProcessResult runConsumer(Path schemaArtifact, Path consumerClasses, boolean named) {
+        List<String> javaCommand = named ? [
+                javaExecutable(),
+                '--module-path', modulePath(schemaArtifact, consumerClasses),
+                '-m', 'fixture.consumer/fixture.consumer.Main'
+        ] : [
+                javaExecutable(),
+                '--class-path', [consumerClasses, schemaArtifact, *modulePathEntries()].join(File.pathSeparator),
+                'fixture.consumer.Main'
+        ]
+        if (named)
+            assertNoPortabilityWorkarounds(javaCommand)
+        ProcessResult javaConsumer = execute(javaCommand, consumerClasses)
+        if (javaConsumer.exitCode != 0)
+            return javaConsumer
+
+        List<String> staticGroovyCommand = named ? [
+                javaExecutable(),
+                '--module-path', modulePath(schemaArtifact, consumerClasses),
+                '-m', 'fixture.consumer/fixture.consumer.StaticConsumer'
+        ] : [
+                javaExecutable(),
+                '--class-path', [consumerClasses, schemaArtifact, *modulePathEntries()].join(File.pathSeparator),
+                'fixture.consumer.StaticConsumer'
+        ]
+        if (named)
+            assertNoPortabilityWorkarounds(staticGroovyCommand)
+        ProcessResult staticConsumer = execute(staticGroovyCommand, consumerClasses)
+        new ProcessResult(staticConsumer.exitCode, javaConsumer.output + staticConsumer.output, consumerClasses)
+    }
+
+    private static ProcessResult compileJava(List<String> arguments, Path output) {
+        List<String> command = [javacExecutable()]
+        command.addAll(arguments)
+        execute(command, output)
+    }
+
+    private static ProcessResult execute(List<String> command, Path output) {
+        ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true)
+        builder.environment().remove('CLASSPATH')
+        Process process = builder.start()
+        new ProcessResult(process.waitFor(), process.inputStream.text, output)
+    }
+
+    private static String modulePath(Path... additionalEntries) {
+        [*additionalEntries, *modulePathEntries()].join(File.pathSeparator)
+    }
+
+    private static String classpath(Path schemaArtifact) {
+        [schemaArtifact, *modulePathEntries()].join(File.pathSeparator)
+    }
+
+    private static String realSchemaSource() {
+        '''
+            package fixture.schema
+
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.PostCreate
+            import com.blackbuild.klum.ast.PostTree
+            import com.blackbuild.klum.ast.Validate
+            import com.blackbuild.klum.ast.runtime.KlumBuilder
+            import jakarta.validation.constraints.Min
+
+            import java.util.List
+
+            @DSL
+            class Station {
+                static final List<String> EVENTS = []
+
+                String name = 'North'
+
+                @Min(1L)
+                int capacity = 4
+
+                @PostCreate
+                void recordCreate() {
+                    assert this instanceof KlumBuilder
+                    Station.EVENTS << 'create'
+                }
+
+                @PostTree
+                void recordTree() {
+                    assert this instanceof KlumBuilder
+                    Station.EVENTS << 'tree'
+                }
+
+                @Validate
+                void recordValidation() {
+                    assert !(this instanceof KlumBuilder)
+                    Station.EVENTS << 'validate'
+                }
+
+                static List<String> eventLog() {
+                    EVENTS
+                }
+            }
+        '''.stripIndent()
+    }
+
+    private static String namedSchemaDescriptor() {
+        '''
+            module fixture.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.runtime;
+                requires static com.blackbuild.klum.ast.compiler;
+                requires com.blackbuild.klum.ast.jackson;
+                requires com.blackbuild.klum.ast.validation.bean;
+                requires org.apache.groovy;
+
+                exports fixture.schema;
+                opens fixture.schema to com.blackbuild.klum.ast.runtime, com.fasterxml.jackson.databind, org.hibernate.validator;
+            }
+        '''.stripIndent()
+    }
+
+    private static String namedConsumerDescriptor() {
+        '''
+            module fixture.consumer {
+                requires fixture.schema;
+                requires com.blackbuild.klum.ast.runtime;
+                requires com.blackbuild.klum.ast.jackson;
+                requires com.blackbuild.klum.ast.validation.bean;
+                requires com.fasterxml.jackson.databind;
+                requires org.apache.groovy;
+
+                uses com.blackbuild.klum.ast.runtime.PhaseAction;
+                uses com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+            }
+        '''.stripIndent()
+    }
+
+    private static String realConsumerSource() {
+        '''
+            package fixture.consumer;
+
+            import com.blackbuild.klum.ast.runtime.PhaseAction;
+            import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
+            import com.fasterxml.jackson.databind.ObjectMapper;
+            import fixture.schema.Station;
+
+            import java.util.List;
+            import java.util.ServiceLoader;
+
+            public class Main {
+                public static void main(String[] arguments) throws Exception {
+                    Station station = Station.Create.One();
+                    if (!"North".equals(station.getName()))
+                        throw new AssertionError("Generated factory did not materialize the schema default");
+                    if (station.getCapacity() != 4)
+                        throw new AssertionError("Bean Validation schema value was not materialized");
+                    if (!Station.eventLog().equals(List.of("create", "tree", "validate")))
+                        throw new AssertionError("Builder lifecycle and model validation did not run in order");
+                    boolean phaseActionLoaded = ServiceLoader.load(PhaseAction.class).stream()
+                            .anyMatch(provider -> provider.type().getName()
+                                    .equals("com.blackbuild.klum.ast.runtime.internal.validation.ValidationPhase"));
+                    if (!phaseActionLoaded)
+                        throw new AssertionError("Runtime phase action was not discovered");
+                    boolean beanValidatorLoaded = ServiceLoader.load(InstanceValidator.class).stream()
+                            .anyMatch(provider -> provider.type().getName()
+                                    .equals("com.blackbuild.klum.ast.validation.bean.internal.JSR380Validator"));
+                    if (!beanValidatorLoaded)
+                        throw new AssertionError("Bean Validation provider was not discovered");
+                    String json = new ObjectMapper().findAndRegisterModules().writeValueAsString(station);
+                    if (!json.contains("\\\"name\\\":\\\"North\\\"") || !json.contains("\\\"capacity\\\":4"))
+                        throw new AssertionError("Jackson did not export the opened schema package: " + json);
+                    System.out.println("java=true;station=North;events=create,tree,validate;phase=true;validator=true;json=true");
+                }
+            }
+        '''.stripIndent()
+    }
+
+    private static String staticGroovyConsumerSource() {
+        '''
+            package fixture.consumer
+
+            import fixture.schema.Station
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticConsumer {
+                static void main(String[] arguments) {
+                    Station station = Station.Create.One()
+                    assert station.name == 'North'
+                    assert station.capacity == 4
+                    println 'static=true'
+                }
+            }
+        '''.stripIndent()
+    }
+
+    private static void assertNamedSchemaDescriptor(Path archive) {
+        def descriptor = ModuleFinder.of(archive).findAll().first().descriptor()
+        assert descriptor.name() == 'fixture.schema'
+        assert descriptor.requires()*.name().containsAll([
+                'com.blackbuild.klum.ast.annotations',
+                'com.blackbuild.klum.ast.runtime',
+                'com.blackbuild.klum.ast.compiler',
+                'com.blackbuild.klum.ast.jackson',
+                'com.blackbuild.klum.ast.validation.bean',
+                'org.apache.groovy'
+        ])
+        assert exportedPackages(descriptor) == ['fixture.schema'] as Set
+        assert qualifiedOpenTargets(descriptor) == [
+                'fixture.schema': [
+                        'com.blackbuild.klum.ast.runtime',
+                        'com.fasterxml.jackson.databind',
+                        'org.hibernate.validator'
+                ] as Set
+        ]
     }
 
     private static ProcessResult compileSchema(List<String> compilerCommand) {
@@ -351,11 +736,27 @@ class JpmsPackageBoundaryTest extends Specification {
                 '--add-modules', 'ALL-MODULE-PATH',
                 '-m', 'org.apache.groovy/org.codehaus.groovy.tools.FileSystemCompiler'
         ])
+        assertNoPortabilityWorkarounds(command)
+    }
+
+    private static void assertNoPortabilityWorkarounds(Collection<String> command) {
         assert !command.any { option ->
             ['--add-reads', '--add-exports', '--patch-module'].any { forbidden ->
                 option == forbidden || option.startsWith("${forbidden}=")
             }
         }
+    }
+
+    private static String javaExecutable() {
+        Path.of(System.getProperty('java.home'), 'bin', 'java').toString()
+    }
+
+    private static String javacExecutable() {
+        Path.of(System.getProperty('java.home'), 'bin', 'javac').toString()
+    }
+
+    private static String jarExecutable() {
+        Path.of(System.getProperty('java.home'), 'bin', 'jar').toString()
     }
 
     private static List<String> modulePathEntries() {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -275,7 +275,8 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         foo.getField('Template').type == template
         template.interface && Modifier.isPublic(template.modifiers)
         template.isAssignableFrom(adapter)
-        !Modifier.isPublic(adapter.modifiers)
+        Modifier.isPublic(adapter.modifiers)
+        Modifier.isPublic(adapter.getDeclaredConstructor().modifiers)
 
         and: 'the full Template capability remains present and only configuration closures expose Builder typing'
         template.getMethod('With', base, Closure).genericReturnType.typeName == 'C'


### PR DESCRIPTION
Related: #391

## What changed

Adds the positive, user-owned named-schema acceptance fixture: Groovy 3 remains ordinary classpath, while Groovy 4 and 5 compile and run the schema and consumer as named modules. The fixture covers generated helper and factory construction, protected lifecycle dispatch, Builder materialization, Java and `@CompileStatic` Groovy consumers, runtime services, Jackson, and Bean Validation.

The runtime paths now use bounded reflective Field and Method access under the schema’s approved qualified opening. Bean Validation declares its direct ClassMate dependency and module requirement. The fixture requires exactly the qualified opening to `com.blackbuild.klum.ast.runtime`, `com.fasterxml.jackson.databind`, and `org.hibernate.validator`; no broad export or JVM workaround flag is added.

## Validation

- `./gradlew check`
- `git diff --check origin/master...HEAD`
- focused G3 classpath plus G4/G5 named-schema acceptance
- local Standards and Spec reviews

Issue #391 remains open for its broader JPMS follow-up work.