### PR TITLE
Document completed-object path distinction

### DIFF
--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -35,6 +35,28 @@ The final 4.0 facade names the Builder/factory call path `getConstructionPath()`
 through which the object was created. `getModelPath()` reports the object's structural location in the completed model.
 These answer different questions and are not interchangeable.
 
+(See: `CompletedObjectSupportDocumentaryTest#'reports distinct construction and structural paths for a completed deployment'`.)
+
+```groovy
+@DSL class Deployment {
+    Service service
+}
+
+@DSL class Service {
+}
+
+def deployment = Deployment.Create.With {
+    service {}
+}
+def deploymentSupport = KlumObjectSupport.of(deployment)
+def serviceSupport = KlumObjectSupport.of(deployment.service)
+
+assert deploymentSupport.constructionPath == '$/Deployment.With'
+assert serviceSupport.constructionPath == '$/Deployment.With/service'
+assert deploymentSupport.modelPath == '<root>'
+assert serviceSupport.modelPath == '<root>.service'
+```
+
 There is no public `getBreadcrumbPath()` alias. `BreadcrumbCollector` remains an internal implementation name. The
 construction path is not provenance: KlumAST does not retain a source-lineage, applied-Template, or lifecycle-event
 record.

--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -38,6 +38,7 @@ These answer different questions and are not interchangeable.
 (See: `CompletedObjectSupportDocumentaryTest#'reports distinct construction and structural paths for a completed deployment'`.)
 
 ```groovy
+given:
 @DSL class Deployment {
     Service service
 }
@@ -45,12 +46,14 @@ These answer different questions and are not interchangeable.
 @DSL class Service {
 }
 
+when:
 def deployment = Deployment.Create.With {
     service {}
 }
 def deploymentSupport = KlumObjectSupport.of(deployment)
 def serviceSupport = KlumObjectSupport.of(deployment.service)
 
+then:
 assert deploymentSupport.constructionPath == '$/Deployment.With'
 assert serviceSupport.constructionPath == '$/Deployment.With/service'
 assert deploymentSupport.modelPath == '<root>'

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CompletedObjectSupportDocumentaryTest.groovy
@@ -31,6 +31,35 @@ import spock.lang.Tag
 @Tag("documentary")
 class CompletedObjectSupportDocumentaryTest extends AbstractDSLSpec {
 
+    @Issue("390")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Completed-Object-Support.md#construction-and-structural-model-paths")
+    def "reports distinct construction and structural paths for a completed deployment"() {
+        given:
+        createClass '''
+            @DSL class Deployment {
+                Service service
+            }
+
+            @DSL class Service {
+            }
+        '''
+
+        when:
+        def deployment = clazz.Create.With {
+            service {}
+        }
+        def deploymentSupport = KlumObjectSupport.of(deployment)
+        def serviceSupport = KlumObjectSupport.of(deployment.service)
+
+        then:
+        deploymentSupport.constructionPath == '$/Deployment.With'
+        serviceSupport.constructionPath == '$/Deployment.With/service'
+        deploymentSupport.modelPath == '<root>'
+        serviceSupport.modelPath == '<root>.service'
+        deploymentSupport.constructionPath != deploymentSupport.modelPath
+        serviceSupport.constructionPath != serviceSupport.modelPath
+    }
+
     @Issue("491")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Completed-Object-Support.md#ownership-paths-and-traversal")
     def "traverses a deployment composition without following linked services"() {


### PR DESCRIPTION
## Summary
- Add an executable root-and-subtree construction/structural-path happy path.
- Add its aligned example and immediate back-reference under Completed Object Support.

## Scope
- Covers only construction and structural model paths.
- Validation APIs, including getResult() and getSubtreeResults(), are unchanged.

## Validation
- ./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.CompletedObjectSupportDocumentaryTest
- ./gradlew :klum-ast:test
- ./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests
- ./gradlew check
- git diff --check
- Standards review: pass; Spec review: pass

Related: #491