### PR TITLE
Recognize DSL interface child relationships

### DIFF
--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
@@ -404,6 +404,6 @@ public class DslHelper {
             valueType = fieldAnnotation.defaultImpl();
         else if (valueType.isAnnotationPresent(DSL.class))
             valueType = FactoryHelper.getTypeOrDefaultType(valueType);
-        return isDslType(valueType);
+        return isDslType(valueType) || valueType.isAnnotationPresent(DSL.class);
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
@@ -1998,6 +1998,36 @@ import org.codehaus.groovy.control.CompilePhase
         rwClazz.metaClass.getMetaMethod("foo", Closure) == null
     }
 
+    @Issue('https://github.com/klum-dsl/klum-ast/issues/611')
+    def 'DSL-interface child creation materializes the configured implementation'() {
+        given:
+        createClass('''
+            @DSL class Service {
+                Endpoint endpoint
+            }
+
+            @DSL class HttpEndpoint implements Endpoint {
+                String url
+            }
+
+            @DSL interface Endpoint {
+                String getUrl()
+            }
+        ''')
+
+        when:
+        def httpEndpoint = getClass('HttpEndpoint')
+        instance = clazz.Create.With {
+            endpoint(httpEndpoint) {
+                url 'https://example.test'
+            }
+        }
+
+        then:
+        getClass('HttpEndpoint').isInstance(instance.endpoint)
+        instance.endpoint.url == 'https://example.test'
+    }
+
     def 'classloader is injectable for copyFrom'() {
         given:
         def loader = GroovySpy(GroovyClassLoader)


### PR DESCRIPTION
Fixes the missing Builder graph relationship classification for fields typed as an annotated DSL interface.

A generated interface child is now collected, materialized, and assigned normally; the regression covers `Service { Endpoint endpoint }` with a configured `HttpEndpoint`.

Related: #611

Validation: focused regression, klum-ast Groovy 3 suite, Groovy 4/5 compatibility lanes, and `./gradlew check`.

No public API or documentation changes.