### PR TITLE
Validate named Schema modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Java modules
 
-- Named schema modules are supported with Groovy 4 and 5; Groovy 3 remains supported on the ordinary classpath. A named schema requires the documented `org.apache.groovy` dependency and a qualified `opens` directive to KlumAST runtime, Jackson when used, and Hibernate Validator when Bean Validation is used. No JVM module-path workaround flags are required ([#391](https://github.com/klum-dsl/klum-ast/issues/391)).
+- Named schema modules are supported with Groovy 4 and 5; Groovy 3 remains supported on the ordinary classpath. The Schema plugin validates the user-owned descriptor as part of `check` and Maven publication, reporting copyable missing directives without editing it. A named schema requires the documented `org.apache.groovy` dependency and a qualified `opens` directive to KlumAST runtime, Jackson when used, and Hibernate Validator when Bean Validation is used. No JVM module-path workaround flags are required ([#391](https://github.com/klum-dsl/klum-ast/issues/391)).
 
 ## Builder-first construction
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ materialize structurally immutable completed DSL Objects before validation. See 
 
 3.0 dropped support for Groovy 2.x and Java 11; the minimum Java version is 17, with Groovy 3, 4, and 5 supported.
 
+For 4.0 Schema projects, Groovy 4/5 support named Java modules while Groovy 3
+remains classpath-only. The Gradle Schema plugin validates a user-owned
+`module-info.java`; see the [Gradle plugin guide](docs/user/Gradle-Plugins.md)
+and [migration guidance](docs/user/Migration.md).
+
 Users of 1.2.0 (or lower) should take a look at the historical [Migration](https://klum-dsl.github.io/klum-ast/3.0.1/Migration/) guidance.
 
 2.2 was the final 2.x feature release and introduced the current validation model. See

--- a/docs/user/Getting-Started.md
+++ b/docs/user/Getting-Started.md
@@ -35,6 +35,13 @@ klumSchema {
 
 For a new project, Groovy 3 is the justified default: it is KlumAST's baseline and keeps the first build small. Keep an existing supported Groovy line instead. Groovy 3 uses `org.codehaus.groovy`; Groovy 4 and 5 use `org.apache.groovy`. The plugin selects matching Groovy and Spock dependencies.
 
+If this Schema must be a Java named module, use Groovy 4 or 5 and add the
+user-owned `src/main/java/module-info.java` described in [[Migration#Named
+modules and Groovy]]. The Schema plugin validates that descriptor as part of
+`check` (and Maven publication) but never writes it. Groovy 3 remains an
+ordinary-classpath setup; do not create a descriptor or add JPMS workaround
+flags for it.
+
 Place Schema classes in `src/main/groovy`, add one root `@DSL` type, and write a test in `src/test/groovy` that constructs a completed model through `Create.With`. Run `./gradlew test` before expanding the model. Use the model plugin only when a separate configured-model artifact is needed; see [[Gradle Plugins]].
 
 ```groovy

--- a/docs/user/Gradle-Plugins.md
+++ b/docs/user/Gradle-Plugins.md
@@ -50,6 +50,25 @@ This plugin is used in schema projects (as well as `api` as defined by [Layer3])
   - `klum-ast-runtime` as api dependency
   - both dependencies are added without explicit versions; the version is enforced by importing the `klum-ast-bom` platform at the plugin's version
 
+### Named Schema modules
+
+The Schema plugin validates a user-owned `src/main/java/module-info.java` through
+`validateKlumSchemaModule`. It is included in `check` and, when `maven-publish`
+is applied, before Maven publication. The task never edits the descriptor.
+
+Groovy 4 and 5 may use a named Schema module. Its descriptor requires the
+annotations and runtime modules, `requires static com.blackbuild.klum.ast.compiler`,
+and `org.apache.groovy`; when the project declares the Jackson or Bean Validation
+adapter, it must also require that adapter and open each Schema package to its
+reflection target. See [[Migration#Named modules and Groovy]] for a complete
+descriptor example.
+
+Groovy 3 is classpath-only for KlumAST Schema projects. If it finds a descriptor,
+the validation task fails with a copyable remediation: remove `module-info.java`
+and use the ordinary classpath, or move the Schema to Groovy 4 or 5. Do not add
+`--add-reads`, `--add-exports`, `--patch-module`, or similar workaround flags.
+Generated `Foo_DSL` mirrors remain IntelliJ metadata, never module sources.
+
 This means that a fully working schema project can be set up with the following minimal build.gradle:
 
 ```groovy

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -44,6 +44,16 @@ the Jackson and Hibernate Validator targets only when those adapters inspect
 the schema; do not substitute `--add-reads`, `--add-exports`, or
 `--patch-module` flags.
 
+The Schema plugin validates this user-owned descriptor through
+`validateKlumSchemaModule`, which is part of `check` and Maven publication. It
+reports copyable missing `requires` and qualified `opens` directives but never
+rewrites `module-info.java`. The generated `Foo_DSL` mirrors used for IntelliJ
+completion are not module sources, compiler inputs, or publication inputs.
+
+Recompile schemas and clients for 4.0. Java-serialized 3.x graphs are not 4.0
+migration inputs, and Java serialization is not a cross-version persistence
+format; own external compatibility data and migrations in the Schema.
+
 ## KlumCast 0.4 RC dependencies
 
 KlumAST 4.0 uses the immutable KlumCast `0.4.0-rc.2` artifact set: `klum-cast-annotations`, `klum-cast-spi`, and

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
@@ -45,6 +45,8 @@ import java.util.Set;
 @NonNullApi
 public class KlumAstSchemaPlugin extends AbstractKlumPlugin<KlumExtension> {
 
+    private static final String MODULE_INFO = "**/module-info.java";
+
     @Override
     protected void registerExtension() {
         extension = project.getExtensions().create("klumSchema", KlumExtension.class);
@@ -74,11 +76,11 @@ public class KlumAstSchemaPlugin extends AbstractKlumPlugin<KlumExtension> {
                 task -> {
                     task.setGroup("verification");
                     task.setDescription("Validates a user-owned Schema module descriptor for the configured Groovy generation.");
-                    task.getDescriptorFiles().from(main.getAllSource().matching(pattern -> pattern.include("**/module-info.java")));
+                    task.getDescriptorFiles().from(main.getAllSource().matching(pattern -> pattern.include(MODULE_INFO)));
                     task.getSchemaSources().from(project.fileTree("src/main", tree -> {
                         tree.include("**/*.java", "**/*.groovy");
-                        tree.exclude("**/module-info.java");
-                    }), main.getAllSource().matching(pattern -> pattern.exclude("**/module-info.java")));
+                        tree.exclude(MODULE_INFO);
+                    }), main.getAllSource().matching(pattern -> pattern.exclude(MODULE_INFO)));
                     task.getGroovyVersion().convention(project.getExtensions()
                             .getByType(GroovyDependenciesExtension.class).getGroovyVersion());
                     task.getOptionalAdapterModules().addAll(project.provider(this::optionalAdapterModules));

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
@@ -25,6 +25,9 @@ package com.blackbuild.klum.ast.gradle;
 
 import com.blackbuild.annodocimal.plugin.AnnoDocimalGroovyPlugin;
 import com.blackbuild.annodocimal.plugin.SourceProjectionTask;
+import com.blackbuild.klum.ast.gradle.convention.GroovyDependenciesExtension;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.Directory;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -33,6 +36,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 
@@ -64,6 +68,23 @@ public class KlumAstSchemaPlugin extends AbstractKlumPlugin<KlumExtension> {
         java.withJavadocJar();
 
         SourceSet main = java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        TaskProvider<ValidateKlumSchemaModule> validateModule = project.getTasks().register(
+                "validateKlumSchemaModule",
+                ValidateKlumSchemaModule.class,
+                task -> {
+                    task.setGroup("verification");
+                    task.setDescription("Validates a user-owned Schema module descriptor for the configured Groovy generation.");
+                    task.getDescriptorFiles().from(main.getAllSource().matching(pattern -> pattern.include("**/module-info.java")));
+                    task.getSchemaSources().from(project.fileTree("src/main", tree -> {
+                        tree.include("**/*.java", "**/*.groovy");
+                        tree.exclude("**/module-info.java");
+                    }), main.getAllSource().matching(pattern -> pattern.exclude("**/module-info.java")));
+                    task.getGroovyVersion().convention(project.getExtensions()
+                            .getByType(GroovyDependenciesExtension.class).getGroovyVersion());
+                    task.getOptionalAdapterModules().addAll(project.provider(this::optionalAdapterModules));
+                });
+        project.getTasks().named("check", task -> task.dependsOn(validateModule));
+        project.getTasks().withType(AbstractPublishToMaven.class).configureEach(task -> task.dependsOn(validateModule));
         Provider<Directory> mirrorDirectory =
                 project.getLayout().getBuildDirectory().dir("generated/sources/klum-dsl-ide/main");
         TaskProvider<SourceProjectionTask> createMirrors = project.getTasks().register(
@@ -87,5 +108,23 @@ public class KlumAstSchemaPlugin extends AbstractKlumPlugin<KlumExtension> {
         moduleIdea.getModule().getGeneratedSourceDirs().add(mirrorDirectory.get().getAsFile());
 
         project.getTasks().named("javadoc", Javadoc.class, task -> task.exclude("**/*_DSL.java"));
+    }
+
+    private Set<String> optionalAdapterModules() {
+        Set<String> modules = new java.util.LinkedHashSet<>();
+        for (String configurationName : Set.of("api", "implementation", "compileOnly")) {
+            Configuration configuration = project.getConfigurations().findByName(configurationName);
+            if (configuration == null)
+                continue;
+            for (Dependency dependency : configuration.getDependencies()) {
+                if (!"com.blackbuild.klum.ast".equals(dependency.getGroup()))
+                    continue;
+                if ("klum-ast-jackson".equals(dependency.getName()))
+                    modules.add("com.blackbuild.klum.ast.jackson");
+                if ("klum-ast-bean-validation".equals(dependency.getName()))
+                    modules.add("com.blackbuild.klum.ast.validation.bean");
+            }
+        }
+        return modules;
     }
 }

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
@@ -1,0 +1,209 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Validates the user-owned JPMS descriptor of a Schema project.
+ */
+public abstract class ValidateKlumSchemaModule extends DefaultTask {
+
+    private static final Set<String> REQUIRED_MODULES = Set.of(
+            "com.blackbuild.klum.ast.annotations",
+            "com.blackbuild.klum.ast.runtime",
+            "com.blackbuild.klum.ast.compiler",
+            "org.apache.groovy");
+    private static final Map<String, String> ADAPTER_OPEN_TARGETS = Map.of(
+            "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
+            "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
+    private static final Pattern REQUIRES = Pattern.compile("\\brequires\\s+((?:(?:static|transitive)\\s+)*)?([\\w.]+)\\s*;");
+    private static final Pattern OPENS = Pattern.compile("\\bopens\\s+([\\w.]+)\\s+to\\s+([^;]+);");
+    private static final Pattern PACKAGE = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*(?:;|$)", Pattern.MULTILINE);
+
+    @InputFiles
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getDescriptorFiles();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getSchemaSources();
+
+    @Input
+    public abstract Property<String> getGroovyVersion();
+
+    @Input
+    public abstract SetProperty<String> getOptionalAdapterModules();
+
+    @TaskAction
+    public void validateDescriptor() {
+        Set<File> descriptors = getDescriptorFiles().getFiles();
+        if (descriptors.isEmpty())
+            return;
+
+        File descriptor = descriptors.iterator().next();
+        if (groovyMajorVersion() == 3) {
+            throw new GradleException("""
+                    KlumAST schema module '%s' cannot use module-info.java with Groovy 3.
+                    Groovy 3 is a supported classpath-only configuration. Remove module-info.java and compile/run this Schema on the ordinary classpath, or use Groovy 4 or 5 for a named module.
+                    The Schema plugin will not rewrite module-info.java or add JVM module-path workaround flags.
+                    """.formatted(getProject().getPath()).trim());
+        }
+
+        String source = read(descriptor);
+        Map<String, Set<String>> required = requiredModules(source);
+        Map<String, Set<String>> openedPackages = openedPackages(source);
+        Set<String> expectedModules = new LinkedHashSet<>(REQUIRED_MODULES);
+        Set<String> adapterModules = new LinkedHashSet<>(getOptionalAdapterModules().get());
+        required.keySet().stream().filter(ADAPTER_OPEN_TARGETS::containsKey).forEach(adapterModules::add);
+        expectedModules.addAll(adapterModules);
+
+        List<String> problems = new ArrayList<>();
+        expectedModules.stream()
+                .filter(module -> !isRequired(required, module))
+                .forEach(module -> problems.add("missing `" + requiresDirective(module) + "`"));
+
+        Set<String> targets = new LinkedHashSet<>();
+        targets.add("com.blackbuild.klum.ast.runtime");
+        adapterModules.stream()
+                .map(ADAPTER_OPEN_TARGETS::get)
+                .forEach(targets::add);
+        schemaPackages().forEach(schemaPackage -> {
+            Set<String> openedTo = openedPackages.getOrDefault(schemaPackage, Set.of());
+            targets.stream().filter(target -> !openedTo.contains(target)).forEach(target ->
+                    problems.add("missing `opens " + schemaPackage + " to " + target + ";`"));
+        });
+
+        if (!problems.isEmpty())
+            throw new GradleException(remediation(problems, targets, adapterModules));
+    }
+
+    private int groovyMajorVersion() {
+        String configured = getGroovyVersion().get();
+        int separator = configured.indexOf('.');
+        return Integer.parseInt(separator < 0 ? configured : configured.substring(0, separator));
+    }
+
+    private Set<String> schemaPackages() {
+        Set<String> packages = new LinkedHashSet<>();
+        Set<File> sources = new LinkedHashSet<>(getSchemaSources().getFiles());
+        sources.addAll(getProject().fileTree("src/main", tree -> {
+            tree.include("**/*.java", "**/*.groovy");
+            tree.exclude("**/module-info.java");
+        }).getFiles());
+        sources.forEach(source -> {
+            Matcher matcher = PACKAGE.matcher(read(source));
+            if (matcher.find())
+                packages.add(matcher.group(1));
+        });
+        return packages;
+    }
+
+    private static Map<String, Set<String>> requiredModules(String source) {
+        Map<String, Set<String>> modules = new LinkedHashMap<>();
+        Matcher matcher = REQUIRES.matcher(withoutComments(source));
+        while (matcher.find()) {
+            Set<String> modifiers = new LinkedHashSet<>();
+            String declaredModifiers = matcher.group(1);
+            if (declaredModifiers != null)
+                for (String modifier : declaredModifiers.trim().split("\\s+"))
+                    modifiers.add(modifier);
+            modules.put(matcher.group(2), modifiers);
+        }
+        return modules;
+    }
+
+    private static boolean isRequired(Map<String, Set<String>> modules, String module) {
+        Set<String> modifiers = modules.get(module);
+        return modifiers != null && (!"com.blackbuild.klum.ast.compiler".equals(module) || modifiers.contains("static"));
+    }
+
+    private static Map<String, Set<String>> openedPackages(String source) {
+        Map<String, Set<String>> packages = new LinkedHashMap<>();
+        Matcher matcher = OPENS.matcher(withoutComments(source));
+        while (matcher.find()) {
+            Set<String> targets = new LinkedHashSet<>();
+            for (String target : matcher.group(2).split(","))
+                targets.add(target.trim());
+            packages.put(matcher.group(1), targets);
+        }
+        return packages;
+    }
+
+    private static String withoutComments(String source) {
+        return source.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//.*", "");
+    }
+
+    private static String read(File file) {
+        try {
+            return Files.readString(file.toPath());
+        } catch (IOException exception) {
+            throw new GradleException("Cannot read " + file, exception);
+        }
+    }
+
+    private String remediation(List<String> problems, Set<String> targets, Set<String> adapterModules) {
+        String required = REQUIRED_MODULES.stream()
+                .map(module -> "    " + requiresDirective(module))
+                .sorted()
+                .reduce("", (left, right) -> left + "\n" + right);
+        String adapter = adapterModules.stream()
+                .sorted()
+                .map(module -> "    requires " + module + ";")
+                .reduce("", (left, right) -> left + "\n" + right);
+        String opens = schemaPackages().stream().sorted()
+                .map(schemaPackage -> "    opens " + schemaPackage + " to " + String.join(", ", targets) + ";")
+                .reduce("", (left, right) -> left + "\n" + right);
+        return "KlumAST schema module validation failed:\n - " + String.join("\n - ", problems) + "\n\n"
+                + "module-info.java remains user-owned; the Schema plugin will not edit it or add JVM workaround flags. "
+                + "For Groovy 4/5, add the applicable directives:\n" + required + adapter + opens;
+    }
+
+    private static String requiresDirective(String module) {
+        return "requires " + ("com.blackbuild.klum.ast.compiler".equals(module) ? "static " : "") + module + ";";
+    }
+}

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -52,16 +53,17 @@ import java.util.regex.Pattern;
  */
 public abstract class ValidateKlumSchemaModule extends DefaultTask {
 
+    private static final String COMPILER_MODULE = "com.blackbuild.klum.ast.compiler";
     private static final Set<String> REQUIRED_MODULES = Set.of(
             "com.blackbuild.klum.ast.annotations",
             "com.blackbuild.klum.ast.runtime",
-            "com.blackbuild.klum.ast.compiler",
+            COMPILER_MODULE,
             "org.apache.groovy");
     private static final Map<String, String> ADAPTER_OPEN_TARGETS = Map.of(
             "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
             "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
-    private static final Pattern REQUIRES = Pattern.compile("\\brequires\\s+((?:(?:static|transitive)\\s+)*)?([\\w.]+)\\s*;");
-    private static final Pattern OPENS = Pattern.compile("\\bopens\\s+([\\w.]+)\\s+to\\s+([^;]+);");
+    private static final Pattern REQUIRES = Pattern.compile("\\brequires\\s+((?:static\\s+transitive|transitive\\s+static|static|transitive)\\s+)?([\\w.]+)\\s*;");
+    private static final Pattern OPENS = Pattern.compile("\\bopens\\s+([\\w.]+)\\s+to\\s+((?:[\\w.]+\\s*,\\s*)*[\\w.]+)\\s*;");
     private static final Pattern PACKAGE = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*(?:;|$)", Pattern.MULTILINE);
 
     @InputFiles
@@ -150,8 +152,7 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
             Set<String> modifiers = new LinkedHashSet<>();
             String declaredModifiers = matcher.group(1);
             if (declaredModifiers != null)
-                for (String modifier : declaredModifiers.trim().split("\\s+"))
-                    modifiers.add(modifier);
+                Collections.addAll(modifiers, declaredModifiers.trim().split("\\s+"));
             modules.put(matcher.group(2), modifiers);
         }
         return modules;
@@ -159,7 +160,7 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
 
     private static boolean isRequired(Map<String, Set<String>> modules, String module) {
         Set<String> modifiers = modules.get(module);
-        return modifiers != null && (!"com.blackbuild.klum.ast.compiler".equals(module) || modifiers.contains("static"));
+        return modifiers != null && (!COMPILER_MODULE.equals(module) || modifiers.contains("static"));
     }
 
     private static Map<String, Set<String>> openedPackages(String source) {
@@ -204,6 +205,6 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
     }
 
     private static String requiresDirective(String module) {
-        return "requires " + ("com.blackbuild.klum.ast.compiler".equals(module) ? "static " : "") + module + ";";
+        return "requires " + (COMPILER_MODULE.equals(module) ? "static " : "") + module + ";";
     }
 }

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
@@ -63,7 +63,6 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
             "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
             "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
     private static final Pattern REQUIRES = Pattern.compile("\\brequires\\s+((?:static\\s+transitive|transitive\\s+static|static|transitive)\\s+)?([\\w.]+)\\s*;");
-    private static final Pattern OPENS = Pattern.compile("\\bopens\\s+([\\w.]+)\\s+to\\s+((?:[\\w.]+\\s*,\\s*)*[\\w.]+)\\s*;");
     private static final Pattern PACKAGE = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*(?:;|$)", Pattern.MULTILINE);
 
     @InputFiles
@@ -165,12 +164,17 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
 
     private static Map<String, Set<String>> openedPackages(String source) {
         Map<String, Set<String>> packages = new LinkedHashMap<>();
-        Matcher matcher = OPENS.matcher(withoutComments(source));
-        while (matcher.find()) {
+        for (String directive : withoutComments(source).split(";")) {
+            String trimmed = directive.trim();
+            if (!trimmed.startsWith("opens "))
+                continue;
+            int targetSeparator = trimmed.indexOf(" to ");
+            if (targetSeparator < 0)
+                continue;
             Set<String> targets = new LinkedHashSet<>();
-            for (String target : matcher.group(2).split(","))
+            for (String target : trimmed.substring(targetSeparator + " to ".length()).split(","))
                 targets.add(target.trim());
-            packages.put(matcher.group(1), targets);
+            packages.put(trimmed.substring("opens ".length(), targetSeparator).trim(), targets);
         }
         return packages;
     }

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModule.java
@@ -38,32 +38,14 @@ import org.gradle.api.tasks.TaskAction;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Validates the user-owned JPMS descriptor of a Schema project.
  */
 public abstract class ValidateKlumSchemaModule extends DefaultTask {
-
-    private static final String COMPILER_MODULE = "com.blackbuild.klum.ast.compiler";
-    private static final Set<String> REQUIRED_MODULES = Set.of(
-            "com.blackbuild.klum.ast.annotations",
-            "com.blackbuild.klum.ast.runtime",
-            COMPILER_MODULE,
-            "org.apache.groovy");
-    private static final Map<String, String> ADAPTER_OPEN_TARGETS = Map.of(
-            "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
-            "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
-    private static final Pattern REQUIRES = Pattern.compile("\\brequires\\s+((?:static\\s+transitive|transitive\\s+static|static|transitive)\\s+)?([\\w.]+)\\s*;");
-    private static final Pattern PACKAGE = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*(?:;|$)", Pattern.MULTILINE);
 
     @InputFiles
     @Optional
@@ -86,41 +68,15 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
         if (descriptors.isEmpty())
             return;
 
-        File descriptor = descriptors.iterator().next();
-        if (groovyMajorVersion() == 3) {
-            throw new GradleException("""
-                    KlumAST schema module '%s' cannot use module-info.java with Groovy 3.
-                    Groovy 3 is a supported classpath-only configuration. Remove module-info.java and compile/run this Schema on the ordinary classpath, or use Groovy 4 or 5 for a named module.
-                    The Schema plugin will not rewrite module-info.java or add JVM module-path workaround flags.
-                    """.formatted(getProject().getPath()).trim());
-        }
-
-        String source = read(descriptor);
-        Map<String, Set<String>> required = requiredModules(source);
-        Map<String, Set<String>> openedPackages = openedPackages(source);
-        Set<String> expectedModules = new LinkedHashSet<>(REQUIRED_MODULES);
-        Set<String> adapterModules = new LinkedHashSet<>(getOptionalAdapterModules().get());
-        required.keySet().stream().filter(ADAPTER_OPEN_TARGETS::containsKey).forEach(adapterModules::add);
-        expectedModules.addAll(adapterModules);
-
-        List<String> problems = new ArrayList<>();
-        expectedModules.stream()
-                .filter(module -> !isRequired(required, module))
-                .forEach(module -> problems.add("missing `" + requiresDirective(module) + "`"));
-
-        Set<String> targets = new LinkedHashSet<>();
-        targets.add("com.blackbuild.klum.ast.runtime");
-        adapterModules.stream()
-                .map(ADAPTER_OPEN_TARGETS::get)
-                .forEach(targets::add);
-        schemaPackages().forEach(schemaPackage -> {
-            Set<String> openedTo = openedPackages.getOrDefault(schemaPackage, Set.of());
-            targets.stream().filter(target -> !openedTo.contains(target)).forEach(target ->
-                    problems.add("missing `opens " + schemaPackage + " to " + target + ";`"));
+        SchemaModuleValidation.Input input = new SchemaModuleValidation.Input(
+                getProject().getPath(),
+                groovyMajorVersion(),
+                read(descriptors.iterator().next()),
+                schemaSourceTexts(),
+                getOptionalAdapterModules().get());
+        SchemaModuleValidation.diagnostic(input).ifPresent(diagnostic -> {
+            throw new GradleException(diagnostic);
         });
-
-        if (!problems.isEmpty())
-            throw new GradleException(remediation(problems, targets, adapterModules));
     }
 
     private int groovyMajorVersion() {
@@ -129,58 +85,13 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
         return Integer.parseInt(separator < 0 ? configured : configured.substring(0, separator));
     }
 
-    private Set<String> schemaPackages() {
-        Set<String> packages = new LinkedHashSet<>();
+    private List<String> schemaSourceTexts() {
         Set<File> sources = new LinkedHashSet<>(getSchemaSources().getFiles());
         sources.addAll(getProject().fileTree("src/main", tree -> {
             tree.include("**/*.java", "**/*.groovy");
             tree.exclude("**/module-info.java");
         }).getFiles());
-        sources.forEach(source -> {
-            Matcher matcher = PACKAGE.matcher(read(source));
-            if (matcher.find())
-                packages.add(matcher.group(1));
-        });
-        return packages;
-    }
-
-    private static Map<String, Set<String>> requiredModules(String source) {
-        Map<String, Set<String>> modules = new LinkedHashMap<>();
-        Matcher matcher = REQUIRES.matcher(withoutComments(source));
-        while (matcher.find()) {
-            Set<String> modifiers = new LinkedHashSet<>();
-            String declaredModifiers = matcher.group(1);
-            if (declaredModifiers != null)
-                Collections.addAll(modifiers, declaredModifiers.trim().split("\\s+"));
-            modules.put(matcher.group(2), modifiers);
-        }
-        return modules;
-    }
-
-    private static boolean isRequired(Map<String, Set<String>> modules, String module) {
-        Set<String> modifiers = modules.get(module);
-        return modifiers != null && (!COMPILER_MODULE.equals(module) || modifiers.contains("static"));
-    }
-
-    private static Map<String, Set<String>> openedPackages(String source) {
-        Map<String, Set<String>> packages = new LinkedHashMap<>();
-        for (String directive : withoutComments(source).split(";")) {
-            String trimmed = directive.trim();
-            if (!trimmed.startsWith("opens "))
-                continue;
-            int targetSeparator = trimmed.indexOf(" to ");
-            if (targetSeparator < 0)
-                continue;
-            Set<String> targets = new LinkedHashSet<>();
-            for (String target : trimmed.substring(targetSeparator + " to ".length()).split(","))
-                targets.add(target.trim());
-            packages.put(trimmed.substring("opens ".length(), targetSeparator).trim(), targets);
-        }
-        return packages;
-    }
-
-    private static String withoutComments(String source) {
-        return source.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//.*", "");
+        return sources.stream().map(ValidateKlumSchemaModule::read).toList();
     }
 
     private static String read(File file) {
@@ -189,26 +100,5 @@ public abstract class ValidateKlumSchemaModule extends DefaultTask {
         } catch (IOException exception) {
             throw new GradleException("Cannot read " + file, exception);
         }
-    }
-
-    private String remediation(List<String> problems, Set<String> targets, Set<String> adapterModules) {
-        String required = REQUIRED_MODULES.stream()
-                .map(module -> "    " + requiresDirective(module))
-                .sorted()
-                .reduce("", (left, right) -> left + "\n" + right);
-        String adapter = adapterModules.stream()
-                .sorted()
-                .map(module -> "    requires " + module + ";")
-                .reduce("", (left, right) -> left + "\n" + right);
-        String opens = schemaPackages().stream().sorted()
-                .map(schemaPackage -> "    opens " + schemaPackage + " to " + String.join(", ", targets) + ";")
-                .reduce("", (left, right) -> left + "\n" + right);
-        return "KlumAST schema module validation failed:\n - " + String.join("\n - ", problems) + "\n\n"
-                + "module-info.java remains user-owned; the Schema plugin will not edit it or add JVM workaround flags. "
-                + "For Groovy 4/5, add the applicable directives:\n" + required + adapter + opens;
-    }
-
-    private static String requiresDirective(String module) {
-        return "requires " + (COMPILER_MODULE.equals(module) ? "static " : "") + module + ";";
     }
 }

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/convention/GroovyDependenciesExtension.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/convention/GroovyDependenciesExtension.java
@@ -57,6 +57,15 @@ public abstract class GroovyDependenciesExtension {
         return getGroovyVersionInternal().map(Version::fromString).map(Version::getGroovyBom);
     }
 
+    /**
+     * Returns the configured Groovy version in the form supplied by the build.
+     *
+     * @return configured Groovy version
+     */
+    public Provider<String> getGroovyVersion() {
+        return getGroovyVersionInternal();
+    }
+
     @SuppressWarnings("java:S5411")
     public Provider<String> getSpockVersionDependency() {
         // if skipSpock is true, return null, otherwise return the spock dependency

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumSchemaModuleValidationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumSchemaModuleValidationTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('391')
+class KlumSchemaModuleValidationTest extends Specification {
+
+    File projectDir
+
+    def setup() {
+        projectDir = File.createTempDir('klum-schema-module-', '')
+        new File(projectDir, 'settings.gradle').text = "rootProject.name = 'schema-module-validation'\n"
+        new File(projectDir, 'build.gradle').text = '''
+            plugins {
+                id 'com.blackbuild.klum-ast-schema'
+            }
+
+            groovyDependencies {
+                groovyVersion = 4
+            }
+        '''.stripIndent()
+        File sources = new File(projectDir, 'src/main/groovy/example/schema')
+        sources.mkdirs()
+        new File(sources, 'Example.groovy').text = '''
+            package example.schema
+
+            class Example {}
+        '''.stripIndent()
+    }
+
+    def cleanup() {
+        projectDir?.deleteDir()
+    }
+
+    def "valid Groovy 4 Schema descriptor is accepted and validation is part of check and publication"() {
+        given:
+        new File(projectDir, 'build.gradle') << '''
+            apply plugin: 'maven-publish'
+            dependencies {
+                api 'com.blackbuild.klum.ast:klum-ast-jackson'
+            }
+        '''.stripIndent()
+        descriptor '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.runtime;
+                requires static com.blackbuild.klum.ast.compiler;
+                requires com.blackbuild.klum.ast.jackson;
+                requires org.apache.groovy;
+
+                opens example.schema to com.blackbuild.klum.ast.runtime, com.fasterxml.jackson.databind;
+            }
+        '''
+
+        when:
+        BuildResult validation = run('validateKlumSchemaModule')
+        BuildResult check = run('check', '--dry-run')
+        BuildResult publication = run('publishToMavenLocal', '--dry-run')
+
+        then:
+        validation.output.contains('BUILD SUCCESSFUL')
+        check.output.contains(':validateKlumSchemaModule SKIPPED')
+        publication.output.contains(':validateKlumSchemaModule SKIPPED')
+    }
+
+    def "invalid Groovy 5 Schema descriptor receives copyable required-module and opens remediation"() {
+        given:
+        new File(projectDir, 'build.gradle').text = new File(projectDir, 'build.gradle').text.replace('groovyVersion = 4', 'groovyVersion = 5')
+        new File(projectDir, 'build.gradle') << '''
+            dependencies {
+                api 'com.blackbuild.klum.ast:klum-ast-bean-validation'
+            }
+        '''.stripIndent()
+        descriptor '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.compiler;
+            }
+        '''
+
+        when:
+        BuildResult result = runAndFail('validateKlumSchemaModule')
+
+        then:
+        result.output.contains('missing `requires com.blackbuild.klum.ast.runtime;`')
+        result.output.contains('missing `requires static com.blackbuild.klum.ast.compiler;`')
+        result.output.contains('missing `requires org.apache.groovy;`')
+        result.output.contains('missing `opens example.schema to com.blackbuild.klum.ast.runtime;`')
+        result.output.contains('missing `requires com.blackbuild.klum.ast.validation.bean;`')
+        result.output.contains('missing `opens example.schema to org.hibernate.validator;`')
+        result.output.contains('module-info.java remains user-owned')
+    }
+
+    def "Groovy 3 named Schema receives classpath-only remediation"() {
+        given:
+        new File(projectDir, 'build.gradle').text = new File(projectDir, 'build.gradle').text.replace('groovyVersion = 4', 'groovyVersion = 3')
+        descriptor '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.runtime;
+            }
+        '''
+
+        when:
+        BuildResult result = runAndFail('validateKlumSchemaModule')
+
+        then:
+        result.output.contains('Groovy 3 is a supported classpath-only configuration')
+        result.output.contains('Remove module-info.java and compile/run this Schema on the ordinary classpath')
+        result.output.contains('will not rewrite module-info.java or add JVM module-path workaround flags')
+    }
+
+    private void descriptor(String contents) {
+        File descriptor = new File(projectDir, 'src/main/java/module-info.java')
+        descriptor.parentFile.mkdirs()
+        descriptor.text = contents.stripIndent()
+    }
+
+    private BuildResult run(String... arguments) {
+        GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(arguments.toList() + ['--stacktrace', '--console=plain'])
+                .withPluginClasspath()
+                .build()
+    }
+
+    private BuildResult runAndFail(String... arguments) {
+        GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(arguments.toList() + ['--stacktrace', '--console=plain'])
+                .withPluginClasspath()
+                .buildAndFail()
+    }
+}

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModuleTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/ValidateKlumSchemaModuleTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('391')
+class ValidateKlumSchemaModuleTest extends Specification {
+
+    File projectDir
+    ValidateKlumSchemaModule task
+
+    def setup() {
+        projectDir = File.createTempDir('validate-klum-schema-module-', '')
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        task = project.tasks.create('validateKlumSchemaModule', ValidateKlumSchemaModule)
+        task.optionalAdapterModules.set([])
+    }
+
+    def cleanup() {
+        projectDir?.deleteDir()
+    }
+
+    def "does nothing without a module descriptor"() {
+        when:
+        task.validateDescriptor()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "maps the Gradle inputs to a valid generation-aware validation request"() {
+        given:
+        File descriptor = source('src/main/java/module-info.java', '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.runtime;
+                requires static com.blackbuild.klum.ast.compiler;
+                requires com.blackbuild.klum.ast.jackson;
+                requires org.apache.groovy;
+
+                opens example.schema to com.blackbuild.klum.ast.runtime, com.fasterxml.jackson.databind;
+            }
+        ''')
+        File schema = source('src/main/groovy/example/schema/Example.groovy', '''
+            package example.schema
+
+            class Example {}
+        ''')
+        task.descriptorFiles.from(descriptor)
+        task.schemaSources.from(schema)
+        task.groovyVersion.set('4')
+        task.optionalAdapterModules.set(['com.blackbuild.klum.ast.jackson'])
+
+        when:
+        task.validateDescriptor()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "turns a validation diagnostic into a Gradle exception"() {
+        given:
+        task.descriptorFiles.from(source('src/main/java/module-info.java', '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.runtime;
+            }
+        '''))
+        task.schemaSources.from(source('src/main/groovy/example/schema/Example.groovy', '''
+            package example.schema
+        '''))
+        task.groovyVersion.set('5.0')
+
+        when:
+        task.validateDescriptor()
+
+        then:
+        GradleException exception = thrown()
+        exception.message.contains("KlumAST schema module validation failed for ':'")
+        exception.message.contains('missing')
+    }
+
+    private File source(String path, String contents) {
+        File file = new File(projectDir, path)
+        file.parentFile.mkdirs()
+        file.text = contents.stripIndent()
+        file
+    }
+}


### PR DESCRIPTION
## Summary

- validate user-owned Schema `module-info.java` for Groovy 4/5 requirements, adapter openings, and the Groovy 3 classpath-only boundary
- run validation from `check` and Maven publication tasks without editing descriptors or adding JPMS workaround flags
- document the Gradle, onboarding, migration, README, and changelog guidance

## Validation

- `./gradlew :klum-ast-gradle-plugin:test --tests com.blackbuild.klum.ast.gradle.KlumSchemaModuleValidationTest --stacktrace`
- `./gradlew check --no-daemon --max-workers=1 --stacktrace`

Related: #391

This partial JP-5 slice intentionally leaves #391 open and does not alter the established descriptors, JP-ABI bridge, or JP-1b fixture boundary.
