### PR TITLE
docs: clarify advanced and static-model concepts

### DIFF
--- a/docs/user/Advanced-Techniques.md
+++ b/docs/user/Advanced-Techniques.md
@@ -2,14 +2,14 @@
 
 ## Delegation Hints for Builder Closures
 
-Generated methods accepting configuration closures receive the appropriate `@DelegatesTo` metadata automatically, so
-modern IDEs can infer the available Builder methods.
+Generated DSL methods that accept configuration closures automatically receive the appropriate `@DelegatesTo` metadata,
+so modern IDEs can infer the available Builder methods.
 
-Schema-defined Mutators sometimes accept and forward their own configuration closures. The generated Builder type does
-not exist when that source method is parsed. Use `@DelegatesToBuilder` in that case. It tells the IDE and static type
-checker about the generated Builder, not a mutable completed DSL Object.
+Schema-defined Mutators can also accept and forward configuration closures. Because the generated Builder type does not
+exist when that source method is parsed, use `@DelegatesToBuilder` for those parameters. It tells the IDE and static type
+checker about the generated Builder; it does not make the completed DSL Object mutable.
 
-The optional annotation value selects the DSL Object whose Builder receives the closure:
+The optional annotation value names the DSL Object whose Builder receives the closure:
 
 ```groovy
 @DSL
@@ -25,7 +25,6 @@ class Container {
     def square(@DelegatesToBuilder(Element) Closure body) {
         element(type: 'square', body)
     }
-// ...
 }
 ```
 
@@ -35,8 +34,8 @@ participate in factory/Builder construction; see [[Builder First Migration]] for
 
 ## Behavior Models and Parameter Hints
 
-Fields can hold dynamic behavior as a closure or interface value. This lets a Model choose behavior without creating a
-new Schema type.
+Fields can hold behavior as a closure or interface value. This lets a Model choose an algorithm without creating a new
+Schema type.
 
 Consider the following example:
 
@@ -50,10 +49,11 @@ class ValueProvider {
 }
 ```
 
-If the description must contain another value, a subclass of `ValueProvider` would be required. That is inconvenient when
-the behavior varies by Model rather than by Schema.
+If different Models need different descriptions, this design could require a subclass of `ValueProvider` for each
+algorithm. That is inconvenient when the behavior varies by Model rather than by Schema.
 
-Make the description configurable instead (the Strategy pattern). Use either an interface/abstract class or a closure.
+Make the description algorithm configurable instead (the Strategy pattern). Use either an interface or abstract class,
+or a closure.
 
 ### Interface
 
@@ -74,8 +74,8 @@ interface DescriptionProvider {
 }
 ```
 
-The Model can now supply the description algorithm. In Groovy, a single-abstract-method (SAM) interface can be supplied
-as a closure:
+The Model can now supply the description algorithm. In Groovy, a closure can implement a single-abstract-method (SAM)
+interface:
 
 ```groovy
 ValueProvider.Create.With {
@@ -84,7 +84,7 @@ ValueProvider.Create.With {
 }
 ```
 
-The closure has one `Map` parameter and returns `String`, which the compiler can check.
+The closure has one `Map` parameter and returns `String`, so the compiler can check both parts of the contract.
 
 `DescriptionProvider` could instead be an abstract class, for example to add [[Converters#factory-method-converters]].
 
@@ -111,11 +111,11 @@ ValueProvider.Create.With {
 ```
 
 The Model call looks the same as the SAM-interface form. With an unannotated Closure field, however, the IDE and type
-checker do not know the parameter type, so they cannot offer parameter completion.
+checker do not know the parameter type. `Closure<String>` describes the return type, not the parameter type, so they
+cannot offer parameter completion.
 
-In normal Groovy, a method parameter can carry `@ClosureParams`. Because this setter is generated, use
-`@ParameterAnnotation.ClosureHint` instead. For this closure field, the supplied hint carries the required parameter
-annotation:
+In normal Groovy, a method parameter can carry `@ClosureParams`. Because KlumAST generates this setter, use
+`@ParameterAnnotation.ClosureHint` on the field instead. The hint supplies the required parameter annotation:
 
 ```groovy
 @DSL class ValueProvider {

--- a/docs/user/Static-Models.md
+++ b/docs/user/Static-Models.md
@@ -1,34 +1,33 @@
-# Static models
+# Static Models
 
-The idea of KlumDSL is centered around static data models.
+KlumAST is centered around static data models.
 
 ## What are static data models?
 
-A static model is a collection of classes that fulfills a couple of constraints:
+A static data model is a group of classes with these characteristics:
 
-- Its completed instances are structurally immutable: they expose no generated mutation path after creation
-- Its methods are side effect free, and mainly consist of getters, quasi getters and converters
-- Static data models are usually rather tightly coupled, allowing to traverse in both directions
-- additional functionality is provided using Decorators and Adapters (which is the aim of another KlumDSL project: KlumWrap)
-- To be useful, static data models should be strongly typed
+- Completed instances are structurally immutable: they expose no generated mutation path after creation.
+- Methods are side-effect free and mainly consist of getters, quasi-getters, and converters.
+- Classes are usually tightly coupled, so relationships can be traversed in both directions.
+- Decorators and Adapters provide additional functionality. This is the aim of another KlumDSL project, KlumWrap.
+- Models should be strongly typed.
 
 ## How does KlumAST implement the static data model paradigm?
 
-KlumAST aspires to create SDMs by using the following techniques:
+KlumAST supports this style with the following techniques:
 
-- setters, generated DSL methods, and mutating lifecycle methods are moved to a generated Builder. Builders own all
-  mutable construction state through `POST_TREE`; `INSTANTIATE` then creates the completed DSL Object graph before
-  validation. See [[Model Phases]] for the lifecycle boundary. DSL features are available during construction without
-  polluting the completed model interface
-- Other methods changing the state of the model (for instance, pseudo setters) must be marked using an annotation 
-  with the meta annotation `@WriteAccess`. These methods are moved to the Builder as well. Core annotations with
-  write access are `@Mutator` for manual write access methods and the lifecycle methods `@PostCreate`, `@PostApply`,
-  `@PostTree` and `@AutoCreate`.
-- all non-relationship, non-transient fields are final in the completed model; relationship fields are assigned only by
-  internal graph materialization so cyclic links remain possible
-- supported Collections are published as independent read-only snapshots; `EnumSet` is exposed through defensive copies
+- Setters, generated DSL methods, and mutating lifecycle methods move to a generated Builder. Builders own mutable
+  construction state through `POST_TREE`; `INSTANTIATE` then creates the completed DSL Object graph before validation.
+  See [[Model Phases]] for the lifecycle boundary. DSL features remain available during construction without polluting
+  the completed-model interface.
+- Other state-changing methods, such as pseudo-setters, must be marked with an annotation meta-annotated with
+  `@WriteAccess`. Those methods also move to the Builder. Built-in write-access annotations include `@Mutator` for
+  manual write-access methods and the lifecycle annotations `@PostCreate`, `@PostApply`, `@PostTree`, and `@AutoCreate`.
+- All non-relationship, non-transient fields are final in the completed model. Internal graph materialization assigns
+  relationship fields so cyclic links remain possible.
+- Supported Collections are published as independent read-only snapshots; `EnumSet` is exposed through defensive copies.
 
 ## Transient fields
 
-Fields marked with `@Field(FieldType.TRANSIENT)` allow to add transient data to a model. This data
-can be changed at will and will not participate in checks for equality.
+Fields marked with `@Field(FieldType.TRANSIENT)` are the explicit exception: they add transient data to a model. This
+data can be changed at will and does not participate in equality checks.


### PR DESCRIPTION
## Summary

Clarifies the two #544 pre-release concept pages:

- makes Builder-closure delegation and closure-parameter hints easier to follow
- improves the static-model definition, Builder lifecycle explanation, and transient-field context

## Scope

Documentation-only correction. It does not change public or generated behavior, add documentary tests, or reopen #491's finalized audit.

Related: #544

## Validation

- `./gradlew renderLocalDocumentation verifyVersionedDocumentationRenderer`
- `git diff --check`
