### PR TITLE
Extract Schema module validation policy for #391

### DIFF
--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/SchemaModuleValidation.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/SchemaModuleValidation.java
@@ -31,8 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.StringTokenizer;
 
 /**
  * Pure policy for validating a user-owned Schema module descriptor.
@@ -48,12 +47,7 @@ final class SchemaModuleValidation {
     private static final Map<String, String> ADAPTER_OPEN_TARGETS = Map.of(
             "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
             "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
-    private static final Pattern REQUIRES = Pattern.compile(
-            "\\brequires\\s+((?:(?:static|transitive)\\s+)*)((?:[A-Za-z_$][\\w$]*\\.)*[A-Za-z_$][\\w$]*)\\s*;");
-    private static final Pattern OPENS = Pattern.compile(
-            "\\bopens\\s+((?:[A-Za-z_$][\\w$]*\\.)*[A-Za-z_$][\\w$]*)\\s+to\\s+([^;]+);");
-    private static final Pattern PACKAGE = Pattern.compile(
-            "(?m)^\\s*package\\s+([A-Za-z_$][\\w$]*(?:\\s*\\.\\s*[A-Za-z_$][\\w$]*)*)\\s*;?");
+    private static final String TOKEN_DELIMITERS = " \t\r\n{};,";
 
     private SchemaModuleValidation() {
         // Utility class
@@ -106,29 +100,53 @@ final class SchemaModuleValidation {
 
     private static Map<String, Set<String>> requiredModules(String descriptor) {
         Map<String, Set<String>> modules = new LinkedHashMap<>();
-        Matcher matcher = REQUIRES.matcher(descriptor);
-        while (matcher.find()) {
-            Set<String> modifiers = modules.computeIfAbsent(matcher.group(2), ignored -> new LinkedHashSet<>());
-            for (String modifier : matcher.group(1).trim().split("\\s+")) {
-                if (!modifier.isEmpty())
-                    modifiers.add(modifier);
-            }
-        }
+        statements(descriptor).forEach(statement -> addRequirement(modules, words(statement)));
         return modules;
     }
 
     private static Map<String, Set<String>> openedPackages(String descriptor) {
         Map<String, Set<String>> packages = new LinkedHashMap<>();
-        Matcher matcher = OPENS.matcher(descriptor);
-        while (matcher.find()) {
-            Set<String> targets = packages.computeIfAbsent(matcher.group(1), ignored -> new LinkedHashSet<>());
-            for (String target : matcher.group(2).split(",")) {
-                String trimmed = target.trim();
-                if (!trimmed.isEmpty())
-                    targets.add(trimmed);
-            }
-        }
+        statements(descriptor).forEach(statement -> addOpenedPackage(packages, words(statement)));
         return packages;
+    }
+
+    private static void addRequirement(Map<String, Set<String>> modules, List<String> words) {
+        int requiresIndex = words.indexOf("requires");
+        if (requiresIndex < 0 || requiresIndex + 1 >= words.size())
+            return;
+
+        int firstModifierIndex = requiresIndex + 1;
+        String firstModifier = words.get(firstModifierIndex);
+        int moduleIndex = isModifier(firstModifier) ? firstModifierIndex + 1 : firstModifierIndex;
+        String secondModifier = moduleIndex < words.size() ? words.get(moduleIndex) : "";
+        if (isModifier(firstModifier) && isModifier(secondModifier))
+            moduleIndex++;
+        if (moduleIndex >= words.size())
+            return;
+
+        Set<String> modifiers = modules.computeIfAbsent(words.get(moduleIndex), ignored -> new LinkedHashSet<>());
+        addModifier(modifiers, firstModifier);
+        addModifier(modifiers, secondModifier);
+    }
+
+    private static void addOpenedPackage(Map<String, Set<String>> packages, List<String> words) {
+        int opensIndex = words.indexOf("opens");
+        int targetIndex = words.indexOf("to");
+        if (opensIndex < 0 || targetIndex <= opensIndex + 1)
+            return;
+
+        Set<String> targets = packages.computeIfAbsent(words.get(opensIndex + 1), ignored -> new LinkedHashSet<>());
+        for (int index = targetIndex + 1; index < words.size(); index++)
+            targets.add(words.get(index));
+    }
+
+    private static boolean isModifier(String word) {
+        return "static".equals(word) || "transitive".equals(word);
+    }
+
+    private static void addModifier(Set<String> modifiers, String word) {
+        if (isModifier(word))
+            modifiers.add(word);
     }
 
     private static Set<String> adapterModules(Collection<String> configuredModules, Set<String> declaredModules) {
@@ -159,13 +177,45 @@ final class SchemaModuleValidation {
         if (sources == null)
             return packages;
         for (String source : sources) {
-            if (source == null)
-                continue;
-            Matcher matcher = PACKAGE.matcher(withoutComments(source));
-            if (matcher.find())
-                packages.add(matcher.group(1).replaceAll("\\s+", ""));
+            if (source != null)
+                schemaPackage(withoutComments(source)).ifPresent(packages::add);
         }
         return packages;
+    }
+
+    private static Optional<String> schemaPackage(String source) {
+        List<String> words = words(source);
+        int packageIndex = words.indexOf("package");
+        if (packageIndex < 0 || packageIndex + 1 >= words.size())
+            return Optional.empty();
+
+        StringBuilder packageName = new StringBuilder(words.get(packageIndex + 1));
+        for (int index = packageIndex + 2; index < words.size(); index++) {
+            String part = words.get(index);
+            if (part.equals(".") || part.startsWith(".") || packageName.charAt(packageName.length() - 1) == '.')
+                packageName.append(part);
+            else
+                break;
+        }
+        return packageName.charAt(packageName.length() - 1) == '.'
+                ? Optional.empty()
+                : Optional.of(packageName.toString());
+    }
+
+    private static List<String> statements(String source) {
+        List<String> statements = new ArrayList<>();
+        StringTokenizer tokenizer = new StringTokenizer(source, ";");
+        while (tokenizer.hasMoreTokens())
+            statements.add(tokenizer.nextToken());
+        return statements;
+    }
+
+    private static List<String> words(String source) {
+        List<String> words = new ArrayList<>();
+        StringTokenizer tokenizer = new StringTokenizer(source, TOKEN_DELIMITERS);
+        while (tokenizer.hasMoreTokens())
+            words.add(tokenizer.nextToken());
+        return words;
     }
 
     private static String remediation(Input input, List<String> problems, Set<String> adapterModules, Set<String> openTargets) {
@@ -194,38 +244,72 @@ final class SchemaModuleValidation {
 
     private static String withoutComments(String source) {
         StringBuilder result = new StringBuilder();
-        boolean lineComment = false;
-        boolean blockComment = false;
-        for (int index = 0; index < source.length(); index++) {
-            char current = source.charAt(index);
-            char next = index + 1 < source.length() ? source.charAt(index + 1) : '\0';
-            if (lineComment) {
-                if (current == '\n' || current == '\r') {
-                    lineComment = false;
-                    result.append(current);
-                }
-                continue;
-            }
-            if (blockComment) {
-                if (current == '*' && next == '/') {
-                    blockComment = false;
-                    index++;
-                } else if (current == '\n' || current == '\r') {
-                    result.append(current);
-                }
-                continue;
-            }
-            if (current == '/' && next == '/') {
-                lineComment = true;
-                index++;
-            } else if (current == '/' && next == '*') {
-                blockComment = true;
-                index++;
-            } else {
-                result.append(current);
-            }
+        CommentCursor cursor = new CommentCursor(source);
+        while (cursor.hasRemaining()) {
+            if (cursor.startsLineComment())
+                cursor.skipLineComment();
+            else if (cursor.startsBlockComment())
+                cursor.skipBlockComment(result);
+            else
+                cursor.copyCurrent(result);
         }
         return result.toString();
+    }
+
+    private static final class CommentCursor {
+
+        private final String source;
+        private int position;
+
+        private CommentCursor(String source) {
+            this.source = source;
+        }
+
+        private boolean hasRemaining() {
+            return position < source.length();
+        }
+
+        private boolean startsLineComment() {
+            return source.startsWith("//", position);
+        }
+
+        private boolean startsBlockComment() {
+            return source.startsWith("/*", position);
+        }
+
+        private void skipLineComment() {
+            position = nextLineBreak(position + 2);
+        }
+
+        private void skipBlockComment(StringBuilder result) {
+            int commentEnd = source.indexOf("*/", position + 2);
+            int contentEnd = commentEnd < 0 ? source.length() : commentEnd;
+            appendLineBreaks(result, position + 2, contentEnd);
+            position = commentEnd < 0 ? source.length() : commentEnd + 2;
+        }
+
+        private void copyCurrent(StringBuilder result) {
+            result.append(source.charAt(position));
+            position++;
+        }
+
+        private int nextLineBreak(int start) {
+            int carriageReturn = source.indexOf('\r', start);
+            int lineFeed = source.indexOf('\n', start);
+            if (carriageReturn < 0)
+                return lineFeed < 0 ? source.length() : lineFeed;
+            if (lineFeed < 0)
+                return carriageReturn;
+            return Math.min(carriageReturn, lineFeed);
+        }
+
+        private void appendLineBreaks(StringBuilder result, int start, int end) {
+            for (int index = start; index < end; index++) {
+                char character = source.charAt(index);
+                if (character == '\r' || character == '\n')
+                    result.append(character);
+            }
+        }
     }
 
     record Input(

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/SchemaModuleValidation.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/SchemaModuleValidation.java
@@ -1,0 +1,238 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Pure policy for validating a user-owned Schema module descriptor.
+ */
+final class SchemaModuleValidation {
+
+    private static final String COMPILER_MODULE = "com.blackbuild.klum.ast.compiler";
+    private static final List<String> CORE_MODULES = List.of(
+            "com.blackbuild.klum.ast.annotations",
+            "com.blackbuild.klum.ast.runtime",
+            COMPILER_MODULE,
+            "org.apache.groovy");
+    private static final Map<String, String> ADAPTER_OPEN_TARGETS = Map.of(
+            "com.blackbuild.klum.ast.jackson", "com.fasterxml.jackson.databind",
+            "com.blackbuild.klum.ast.validation.bean", "org.hibernate.validator");
+    private static final Pattern REQUIRES = Pattern.compile(
+            "\\brequires\\s+((?:(?:static|transitive)\\s+)*)((?:[A-Za-z_$][\\w$]*\\.)*[A-Za-z_$][\\w$]*)\\s*;");
+    private static final Pattern OPENS = Pattern.compile(
+            "\\bopens\\s+((?:[A-Za-z_$][\\w$]*\\.)*[A-Za-z_$][\\w$]*)\\s+to\\s+([^;]+);");
+    private static final Pattern PACKAGE = Pattern.compile(
+            "(?m)^\\s*package\\s+([A-Za-z_$][\\w$]*(?:\\s*\\.\\s*[A-Za-z_$][\\w$]*)*)\\s*;?");
+
+    private SchemaModuleValidation() {
+        // Utility class
+    }
+
+    static Optional<String> diagnostic(Input input) {
+        if (input == null || blank(input.descriptorSource()))
+            return Optional.empty();
+
+        if (input.groovyMajorVersion() == 3)
+            return Optional.of("""
+                    KlumAST schema module '%s' cannot use module-info.java with Groovy 3.
+                    Groovy 3 is a supported classpath-only configuration. Remove module-info.java and compile/run this Schema on the ordinary classpath, or use Groovy 4 or 5 for a named module.
+                    The Schema plugin will not rewrite module-info.java or add JVM module-path workaround flags.
+                    """.formatted(projectPath(input)).trim());
+
+        String descriptor = withoutComments(input.descriptorSource());
+        Map<String, Set<String>> requiredModules = requiredModules(descriptor);
+        Set<String> adapterModules = adapterModules(input.configuredAdapterModules(), requiredModules.keySet());
+        List<String> problems = missingRequirements(requiredModules, adapterModules);
+        Set<String> openTargets = openTargets(adapterModules);
+        Map<String, Set<String>> openedPackages = openedPackages(descriptor);
+        schemaPackages(input.schemaSourceTexts()).forEach(schemaPackage ->
+                openTargets.stream()
+                        .filter(target -> !openedPackages.getOrDefault(schemaPackage, Set.of()).contains(target))
+                        .forEach(target -> problems.add("missing `opens " + schemaPackage + " to " + target + ";`")));
+
+        if (problems.isEmpty())
+            return Optional.empty();
+        return Optional.of(remediation(input, problems, adapterModules, openTargets));
+    }
+
+    private static List<String> missingRequirements(Map<String, Set<String>> requiredModules, Set<String> adapterModules) {
+        List<String> problems = new ArrayList<>();
+        for (String module : CORE_MODULES) {
+            if (!isRequired(requiredModules, module))
+                problems.add("missing `" + requiresDirective(module) + "`");
+        }
+        for (String module : adapterModules) {
+            if (!isRequired(requiredModules, module))
+                problems.add("missing `" + requiresDirective(module) + "`");
+        }
+        return problems;
+    }
+
+    private static boolean isRequired(Map<String, Set<String>> requiredModules, String module) {
+        Set<String> modifiers = requiredModules.get(module);
+        return modifiers != null && (!COMPILER_MODULE.equals(module) || modifiers.contains("static"));
+    }
+
+    private static Map<String, Set<String>> requiredModules(String descriptor) {
+        Map<String, Set<String>> modules = new LinkedHashMap<>();
+        Matcher matcher = REQUIRES.matcher(descriptor);
+        while (matcher.find()) {
+            Set<String> modifiers = modules.computeIfAbsent(matcher.group(2), ignored -> new LinkedHashSet<>());
+            for (String modifier : matcher.group(1).trim().split("\\s+")) {
+                if (!modifier.isEmpty())
+                    modifiers.add(modifier);
+            }
+        }
+        return modules;
+    }
+
+    private static Map<String, Set<String>> openedPackages(String descriptor) {
+        Map<String, Set<String>> packages = new LinkedHashMap<>();
+        Matcher matcher = OPENS.matcher(descriptor);
+        while (matcher.find()) {
+            Set<String> targets = packages.computeIfAbsent(matcher.group(1), ignored -> new LinkedHashSet<>());
+            for (String target : matcher.group(2).split(",")) {
+                String trimmed = target.trim();
+                if (!trimmed.isEmpty())
+                    targets.add(trimmed);
+            }
+        }
+        return packages;
+    }
+
+    private static Set<String> adapterModules(Collection<String> configuredModules, Set<String> declaredModules) {
+        Set<String> modules = new LinkedHashSet<>();
+        addKnownAdapters(modules, configuredModules);
+        addKnownAdapters(modules, declaredModules);
+        return modules;
+    }
+
+    private static void addKnownAdapters(Set<String> target, Collection<String> candidates) {
+        if (candidates == null)
+            return;
+        for (String candidate : candidates) {
+            if (candidate != null && ADAPTER_OPEN_TARGETS.containsKey(candidate))
+                target.add(candidate);
+        }
+    }
+
+    private static Set<String> openTargets(Set<String> adapterModules) {
+        Set<String> targets = new LinkedHashSet<>();
+        targets.add("com.blackbuild.klum.ast.runtime");
+        adapterModules.stream().map(ADAPTER_OPEN_TARGETS::get).forEach(targets::add);
+        return targets;
+    }
+
+    private static Set<String> schemaPackages(Collection<String> sources) {
+        Set<String> packages = new LinkedHashSet<>();
+        if (sources == null)
+            return packages;
+        for (String source : sources) {
+            if (source == null)
+                continue;
+            Matcher matcher = PACKAGE.matcher(withoutComments(source));
+            if (matcher.find())
+                packages.add(matcher.group(1).replaceAll("\\s+", ""));
+        }
+        return packages;
+    }
+
+    private static String remediation(Input input, List<String> problems, Set<String> adapterModules, Set<String> openTargets) {
+        StringBuilder directives = new StringBuilder();
+        CORE_MODULES.forEach(module -> directives.append("\n    ").append(requiresDirective(module)));
+        adapterModules.forEach(module -> directives.append("\n    ").append(requiresDirective(module)));
+        schemaPackages(input.schemaSourceTexts()).forEach(schemaPackage -> directives.append("\n    opens ")
+                .append(schemaPackage).append(" to ").append(String.join(", ", openTargets)).append(";"));
+        return "KlumAST schema module validation failed for '" + projectPath(input) + "':\n - "
+                + String.join("\n - ", problems)
+                + "\n\nmodule-info.java remains user-owned; the Schema plugin will not edit it or add JVM workaround flags. "
+                + "For Groovy 4/5, add the applicable directives:" + directives;
+    }
+
+    private static String requiresDirective(String module) {
+        return "requires " + (COMPILER_MODULE.equals(module) ? "static " : "") + module + ";";
+    }
+
+    private static String projectPath(Input input) {
+        return blank(input.projectPath()) ? ":" : input.projectPath();
+    }
+
+    private static boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String withoutComments(String source) {
+        StringBuilder result = new StringBuilder();
+        boolean lineComment = false;
+        boolean blockComment = false;
+        for (int index = 0; index < source.length(); index++) {
+            char current = source.charAt(index);
+            char next = index + 1 < source.length() ? source.charAt(index + 1) : '\0';
+            if (lineComment) {
+                if (current == '\n' || current == '\r') {
+                    lineComment = false;
+                    result.append(current);
+                }
+                continue;
+            }
+            if (blockComment) {
+                if (current == '*' && next == '/') {
+                    blockComment = false;
+                    index++;
+                } else if (current == '\n' || current == '\r') {
+                    result.append(current);
+                }
+                continue;
+            }
+            if (current == '/' && next == '/') {
+                lineComment = true;
+                index++;
+            } else if (current == '/' && next == '*') {
+                blockComment = true;
+                index++;
+            } else {
+                result.append(current);
+            }
+        }
+        return result.toString();
+    }
+
+    record Input(
+            String projectPath,
+            int groovyMajorVersion,
+            String descriptorSource,
+            Collection<String> schemaSourceTexts,
+            Collection<String> configuredAdapterModules) {
+    }
+}

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/SchemaModuleValidationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/SchemaModuleValidationTest.groovy
@@ -32,12 +32,32 @@ import java.util.Optional
 @Issue('391')
 class SchemaModuleValidationTest extends Specification {
 
-    def "accepts valid Groovy 4 and 5 core-only Schema modules"(int groovyMajor) {
+    def "accepts a valid Groovy 4 core-only Schema module"() {
         expect:
-        !diagnostic(groovyMajor, coreDescriptor()).present
+        !SchemaModuleValidation.diagnostic(new SchemaModuleValidation.Input(
+                ':schema',
+                4,
+                '''
+                    module example.schema {
+                        requires com.blackbuild.klum.ast.annotations;
+                        requires com.blackbuild.klum.ast.runtime;
+                        requires static com.blackbuild.klum.ast.compiler;
+                        requires org.apache.groovy;
 
-        where:
-        groovyMajor << [4, 5]
+                        opens example.schema to com.blackbuild.klum.ast.runtime;
+                    }
+                ''',
+                ['''
+                    package example.schema
+
+                    class Example {}
+                '''],
+                [])).present
+    }
+
+    def "accepts a valid Groovy 5 core-only Schema module"() {
+        expect:
+        !diagnostic(5, coreDescriptor()).present
     }
 
     def "rejects a Groovy 3 named Schema module with classpath remediation"() {

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/SchemaModuleValidationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/SchemaModuleValidationTest.groovy
@@ -1,0 +1,216 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast.gradle
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.Collection
+import java.util.Optional
+
+@Issue('391')
+class SchemaModuleValidationTest extends Specification {
+
+    def "accepts valid Groovy 4 and 5 core-only Schema modules"(int groovyMajor) {
+        expect:
+        !diagnostic(groovyMajor, coreDescriptor()).present
+
+        where:
+        groovyMajor << [4, 5]
+    }
+
+    def "rejects a Groovy 3 named Schema module with classpath remediation"() {
+        when:
+        String diagnostic = diagnostic(3, coreDescriptor()).orElseThrow()
+
+        then:
+        diagnostic.contains("KlumAST schema module ':schema' cannot use module-info.java with Groovy 3.")
+        diagnostic.contains('Groovy 3 is a supported classpath-only configuration')
+        diagnostic.contains('Remove module-info.java and compile/run this Schema on the ordinary classpath')
+        diagnostic.contains('will not rewrite module-info.java or add JVM module-path workaround flags')
+    }
+
+    def "reports each missing core module and a non-static compiler requirement"(String descriptor, String expected) {
+        expect:
+        diagnostic(5, descriptor).orElseThrow().contains("missing `${expected}`")
+
+        where:
+        descriptor                                                                    | expected
+        descriptorWithout('com.blackbuild.klum.ast.annotations')                       | 'requires com.blackbuild.klum.ast.annotations;'
+        descriptorWithout('com.blackbuild.klum.ast.runtime')                           | 'requires com.blackbuild.klum.ast.runtime;'
+        descriptorWithout('com.blackbuild.klum.ast.compiler')                          | 'requires static com.blackbuild.klum.ast.compiler;'
+        descriptorWithout('org.apache.groovy')                                         | 'requires org.apache.groovy;'
+        coreDescriptor().replace('requires static com.blackbuild.klum.ast.compiler;',
+                'requires com.blackbuild.klum.ast.compiler;')                         | 'requires static com.blackbuild.klum.ast.compiler;'
+    }
+
+    def "requires and opens configured adapter modules"(String adapterModule, String target) {
+        when:
+        String diagnostic = diagnostic(4, coreDescriptor(), [adapterModule]).orElseThrow()
+
+        then:
+        diagnostic.contains("missing `requires ${adapterModule};`")
+        diagnostic.contains("missing `opens example.schema to ${target};`")
+        diagnostic.contains("requires ${adapterModule};")
+        diagnostic.contains("opens example.schema to com.blackbuild.klum.ast.runtime, ${target};")
+
+        where:
+        adapterModule                             | target
+        'com.blackbuild.klum.ast.jackson'         | 'com.fasterxml.jackson.databind'
+        'com.blackbuild.klum.ast.validation.bean' | 'org.hibernate.validator'
+    }
+
+    def "requires an adapter opening when the adapter is declared directly"(String adapterModule, String target) {
+        given:
+        String descriptor = coreDescriptor().replace('opens example.schema to com.blackbuild.klum.ast.runtime;', """
+            requires ${adapterModule};
+            opens example.schema to com.blackbuild.klum.ast.runtime;
+        """.stripIndent())
+
+        expect:
+        diagnostic(5, descriptor).orElseThrow().contains("missing `opens example.schema to ${target};`")
+
+        where:
+        adapterModule                             | target
+        'com.blackbuild.klum.ast.jackson'         | 'com.fasterxml.jackson.databind'
+        'com.blackbuild.klum.ast.validation.bean' | 'org.hibernate.validator'
+    }
+
+    def "aggregates missing runtime and adapter-qualified openings"() {
+        given:
+        String descriptor = coreDescriptor().replace('opens example.schema to com.blackbuild.klum.ast.runtime;', '')
+
+        when:
+        String diagnostic = diagnostic(5, descriptor, [
+                'com.blackbuild.klum.ast.jackson',
+                'com.blackbuild.klum.ast.validation.bean']).orElseThrow()
+
+        then:
+        diagnostic.contains('missing `opens example.schema to com.blackbuild.klum.ast.runtime;`')
+        diagnostic.contains('missing `opens example.schema to com.fasterxml.jackson.databind;`')
+        diagnostic.contains('missing `opens example.schema to org.hibernate.validator;`')
+    }
+
+    def "finds Java and Groovy Schema packages through comments and multiline declarations"() {
+        given:
+        String descriptor = coreRequirements() + '''
+            opens alpha.java to com.blackbuild.klum.ast.runtime;
+        '''
+        Collection<String> sources = [
+                '''/* package ignored.block; */
+                   package alpha.java;
+                   class JavaSchema {}''',
+                '''// package ignored.line
+                   package beta
+                       .groovy
+                   class GroovySchema {}''',
+                '''package gamma /* comment */ . mixed
+                   class MixedSchema {}'''
+        ]
+
+        when:
+        String diagnostic = diagnostic(5, descriptor, [], sources).orElseThrow()
+
+        then:
+        diagnostic.contains('missing `opens beta.groovy to com.blackbuild.klum.ast.runtime;`')
+        diagnostic.contains('missing `opens gamma.mixed to com.blackbuild.klum.ast.runtime;`')
+        !diagnostic.contains('ignored.block')
+        !diagnostic.contains('ignored.line')
+    }
+
+    def "returns one copyable aggregate remediation and accepts the complete descriptor"() {
+        given:
+        String incomplete = '''
+            /* requires com.blackbuild.klum.ast.runtime; */
+            module example.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.compiler;
+                // requires org.apache.groovy;
+            }
+        '''
+
+        when:
+        String validationMessage = diagnostic(5, incomplete, ['com.blackbuild.klum.ast.jackson']).orElseThrow()
+
+        then:
+        validationMessage.contains("KlumAST schema module validation failed for ':schema':")
+        validationMessage.contains('missing `requires com.blackbuild.klum.ast.runtime;`')
+        validationMessage.contains('missing `requires static com.blackbuild.klum.ast.compiler;`')
+        validationMessage.contains('missing `requires org.apache.groovy;`')
+        validationMessage.contains('missing `requires com.blackbuild.klum.ast.jackson;`')
+        validationMessage.contains('module-info.java remains user-owned')
+        validationMessage.contains('requires static com.blackbuild.klum.ast.compiler;')
+        validationMessage.contains('opens example.schema to com.blackbuild.klum.ast.runtime, com.fasterxml.jackson.databind;')
+
+        and:
+        !diagnostic(5, fullDescriptor(), [
+                'com.blackbuild.klum.ast.jackson',
+                'com.blackbuild.klum.ast.validation.bean']).present
+    }
+
+    def "ignores an absent descriptor and malformed optional input without throwing"() {
+        expect:
+        !SchemaModuleValidation.diagnostic(null).present
+        !diagnostic(3, null).present
+        !diagnostic(5, coreDescriptor(), [null]).present
+    }
+
+    private static Optional<String> diagnostic(int groovyMajor, String descriptor, Collection<String> adapters = [], Collection<String> sources = defaultSources()) {
+        SchemaModuleValidation.diagnostic(new SchemaModuleValidation.Input(':schema', groovyMajor, descriptor, sources, adapters))
+    }
+
+    private static Collection<String> defaultSources() {
+        ['package example.schema\nclass Example {}']
+    }
+
+    private static String coreDescriptor() {
+        coreRequirements() + '''
+            opens example.schema to com.blackbuild.klum.ast.runtime;
+            }
+        '''
+    }
+
+    private static String coreRequirements() {
+        '''
+            module example.schema {
+                requires com.blackbuild.klum.ast.annotations;
+                requires com.blackbuild.klum.ast.runtime;
+                requires static com.blackbuild.klum.ast.compiler;
+                requires org.apache.groovy;
+        '''
+    }
+
+    private static String descriptorWithout(String module) {
+        coreDescriptor().readLines().findAll { !it.contains("requires ${module};") && !it.contains("requires static ${module};") }.join('\n')
+    }
+
+    private static String fullDescriptor() {
+        coreRequirements() + '''
+                requires com.blackbuild.klum.ast.jackson;
+                requires com.blackbuild.klum.ast.validation.bean;
+                opens example.schema to com.blackbuild.klum.ast.runtime, com.fasterxml.jackson.databind, org.hibernate.validator;
+            }
+        '''
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the package-private, Gradle-independent Schema module-validation policy needed by the blocked JP-5 implementation.

- Adds `SchemaModuleValidation` with null-safe, generation-aware descriptor parsing and aggregate copyable remediation.
- Covers Groovy 3 rejection, G4/G5 core requirements, adapters, qualified opens, and Java/Groovy package parsing directly in-process.
- Leaves JP-5 task wiring, TestKit, descriptors, and public APIs unchanged.

## Why

JP-5 needs a pure validation seam before the Gradle task can delegate policy without coupling its parsing and diagnostics to Gradle APIs.

## Validation

- `./gradlew :klum-ast-gradle-plugin:test --tests com.blackbuild.klum.ast.gradle.SchemaModuleValidationTest`
- `./gradlew :klum-ast-gradle-plugin:test`
- `./gradlew groovy4Tests groovy5Tests`
- `./gradlew check`

Related: #391
