### PR TITLE
docs: finalize #544 pre-RC content review

### DIFF
--- a/docs/implementation/issue-544-content-freeze.md
+++ b/docs/implementation/issue-544-content-freeze.md
@@ -1,0 +1,43 @@
+# Issue 544 — 4.0 user-documentation content-freeze inventory
+
+Tracking issue: [#544 — Finalize KlumAST 4.0 user-documentation content before the first RC](https://github.com/klum-dsl/klum-ast/issues/544)
+
+Review basis: `origin/master` at `45f2167e` (2026-07-29), including the merged #491 inventory
+([PR #610](https://github.com/klum-dsl/klum-ast/pull/610)) and the closed #391 JPMS/module work
+([PR #614](https://github.com/klum-dsl/klum-ast/pull/614)). This is a content review of current `docs/user/`; #456
+continues to own rendered form, versioning, hosting, aliases, and publication.
+
+## Accepted content inventory
+
+| Adopter path | Reviewed current pages | Result |
+| --- | --- | --- |
+| Entry and setup | `Home`, `Terms`, `Usage`, `Getting-Started`, `Gradle-Plugins`, `Javadoc`, `Roadmap`, `Why-aC-is-not-enough` | The 4.0 preview, Builder-first construction, Groovy/JPMS boundary, generated-mirror scope, and versioned-documentation status agree with current artifacts. The remaining plugin examples now use a matching 4.x version placeholder rather than a 3.0 version. |
+| Core authoring and migration | `Basics`, `Static-Models`, `Model-Phases`, `Validation`, `Exception-Handling`, `Builder-First-Migration`, `Migration` | Builder-first materialization, validation, collection snapshots, transient-state exception, path terminology, and named-module migration guidance agree with the shipped 4.0 sources. `TRANSIENT` now explicitly distinguishes KlumAST's mutable/serialized model state from Java/Groovy `transient`. |
+| Construction and advanced use | `Convenience-Factories`, `Factory-Classes`, `Templates`, `Copy-Strategies`, `Default-Values`, `Inheritance`, `Converters`, `Alternatives-Syntax`, `Advanced-Techniques`, `Behind-the-Curtain`, `Completed-Object-Support` | #491 supplies the accepted documentary mapping or a deliberate reference/API-boundary exception. `Advanced-Techniques` remains a concept page, not a manufactured tutorial; its `@ParameterAnnotation` source link now follows #391's final package. |
+| Modeling shapes and integrations | `Domain-First-Modeling`, `Target-Contract-Modeling`, `Layer3`, `Jackson-Integration`, `FAQ` | Direct-schema versus Layer 3 and domain-first versus target-contract stay separate; the #469 journeys and #491 mappings remain consistent. Jackson remains asymmetric external-format integration, not persistence or source composition. |
+| Navigation and release context | `_Sidebar`, `CHANGES.md`, `Migration`, `Builder-First-Migration` | Current navigation exposes entry, migration, and release notes. `CHANGES.md` and migration pages state the same Builder-first and JPMS contract. The renderer owns final rendered-link verification. |
+
+## Evidence-backed corrections in this review
+
+- Updated the `@ParameterAnnotation` source link to its final `com.blackbuild.klum.ast` package.
+- Removed an unsupported dependency on a separate project from the static-model definition and clarified the supported adapter/decorator boundary.
+- Clarified that `FieldType.TRANSIENT` remains mutable and is serialized by default; it is not the Java/Groovy `transient` modifier.
+- Replaced 3.0 plugin-version literals in current 4.0 Gradle examples with the matching-version placeholder, while
+  retaining version inheritance in the multi-module child-project example.
+- Corrected the rendered named-module migration links to their generated heading anchor.
+
+## Deliberate residual ownership
+
+| Remaining substantive gap or acceptance | Existing owner | #544 disposition |
+| --- | --- | --- |
+| Confirm Layer 3 variants, examples, and broader terminology beyond the accepted API–Schema–Model baseline. | [#454](https://github.com/klum-dsl/klum-ast/issues/454) | Do not define it through this content review. |
+| Publish/version/stage the reviewed source and verify the rendered exact-version site. | [#456](https://github.com/klum-dsl/klum-ast/issues/456) | Renderer and publication work remain separate. |
+| Field-test the portable onboarding routes and refine them from adoption evidence. | [#469](https://github.com/klum-dsl/klum-ast/issues/469) | The current routes are consistent; this review does not extend them. |
+| State and prove the supported Gradle-version range. | [#389](https://github.com/klum-dsl/klum-ast/issues/389) | No range is claimed here. |
+| Reconcile the merged #491 documentary audit's tracker acceptance/closure. | [#491](https://github.com/klum-dsl/klum-ast/issues/491) | Its merged inventory is accepted evidence for #544; this review does not reopen the audit. |
+| Accept this content freeze before the first public RC. | [#544](https://github.com/klum-dsl/klum-ast/issues/544) maintainer | Pending explicit maintainer acceptance. |
+
+## Maintainer acceptance request
+
+Please confirm that this inventory is accepted as the pre-RC 4.0 user-documentation content freeze. Subsequent changes
+should be limited to the accepted RC-promotion correction policy or to the separately owned issues above.

--- a/docs/user/Advanced-Techniques.md
+++ b/docs/user/Advanced-Techniques.md
@@ -132,7 +132,7 @@ In normal Groovy, a method parameter can carry `@ClosureParams`. Because KlumAST
 
 This provides parameter completion and type checking for the generated methods. `@ParameterAnnotation` copies annotations
 from a Schema field to the generated setter or single-element adder; see the
-[`@ParameterAnnotation` API source and Javadoc](https://github.com/klum-dsl/klum-ast/blob/master/klum-ast-annotations/src/main/java/com/blackbuild/groovy/configdsl/transform/ParameterAnnotation.java)
+[`@ParameterAnnotation` API source and Javadoc](https://github.com/klum-dsl/klum-ast/blob/master/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/ParameterAnnotation.java)
 for the advanced annotation-mapping rules.
 
 ## Choosing a SAM Interface or Closure

--- a/docs/user/Getting-Started.md
+++ b/docs/user/Getting-Started.md
@@ -36,8 +36,8 @@ klumSchema {
 For a new project, Groovy 3 is the justified default: it is KlumAST's baseline and keeps the first build small. Keep an existing supported Groovy line instead. Groovy 3 uses `org.codehaus.groovy`; Groovy 4 and 5 use `org.apache.groovy`. The plugin selects matching Groovy and Spock dependencies.
 
 If this Schema must be a Java named module, use Groovy 4 or 5 and add the
-user-owned `src/main/java/module-info.java` described in [[Migration#Named
-modules and Groovy]]. The Schema plugin validates that descriptor as part of
+user-owned `src/main/java/module-info.java` described in [[Migration#named-modules-and-groovy]].
+The Schema plugin validates that descriptor as part of
 `check` (and Maven publication) but never writes it. Groovy 3 remains an
 ordinary-classpath setup; do not create a descriptor or add JPMS workaround
 flags for it.

--- a/docs/user/Gradle-Plugins.md
+++ b/docs/user/Gradle-Plugins.md
@@ -60,7 +60,7 @@ Groovy 4 and 5 may use a named Schema module. Its descriptor requires the
 annotations and runtime modules, `requires static com.blackbuild.klum.ast.compiler`,
 and `org.apache.groovy`; when the project declares the Jackson or Bean Validation
 adapter, it must also require that adapter and open each Schema package to its
-reflection target. See [[Migration#Named modules and Groovy]] for a complete
+reflection target. See [[Migration#named-modules-and-groovy]] for a complete
 descriptor example.
 
 Groovy 3 is classpath-only for KlumAST Schema projects. If it finds a descriptor,
@@ -73,7 +73,7 @@ This means that a fully working schema project can be set up with the following 
 
 ```groovy
 plugins {
-    id 'com.blackbuild.klum-ast-schema'
+    id 'com.blackbuild.klum-ast-schema' version '<matching-klum-version>'
     id "maven-publish"
 }
 
@@ -96,7 +96,7 @@ A simple model project can look like:
 
 ```groovy
 plugins {
-    id 'com.blackbuild.klum-ast-model' version "3.0.0"
+    id 'com.blackbuild.klum-ast-model' version '<matching-klum-version>'
     id "maven-publish"
 }
 
@@ -113,12 +113,14 @@ klumModel {
 ## Multi module
 
 Schema and model can be combined in a multimodule project (with the pre mentioned problem of missing IDE support):
+Because the root project applies the shared convention plugin at the matching KlumAST version, its child Schema and
+Model projects can use the packaged plugin IDs without repeating that version.
 
 Root:
 
 ```groovy
 plugins {
-    id 'com.blackbuild.convention.groovy' version '3.0.0'
+    id 'com.blackbuild.convention.groovy' version '<matching-klum-version>'
 }
 
 groovyDependencies {

--- a/docs/user/Home.md
+++ b/docs/user/Home.md
@@ -1,6 +1,6 @@
 KlumAST
 =======
-Turn your models into supermodels!
+> **Turn your models into supermodels!**
 
 ## What is KlumAST?
 
@@ -8,7 +8,8 @@ KlumAST turns annotated model classes into concise, statically checked Groovy DS
 Schema Developer to describe a model once, a Model Writer to configure it through a readable DSL, and client code to
 consume the completed model without generated mutation methods.
 
-The [[Terms|role guide]] defines these responsibilities and the value kinds used throughout the documentation.
+The [[Terms|Terms and role guide]] defines the core terms — especially Schema and Model — along with these responsibilities
+and the value kinds used throughout the documentation.
 
 ## Why models as code?
 

--- a/docs/user/Static-Models.md
+++ b/docs/user/Static-Models.md
@@ -9,7 +9,7 @@ A static data model is a group of classes with these characteristics:
 - Completed instances are structurally immutable: they expose no generated mutation path after creation.
 - Methods are side-effect free and mainly consist of getters, quasi-getters, and converters.
 - Classes are usually tightly coupled, so relationships can be traversed in both directions.
-- Decorators and Adapters provide additional functionality. This is the aim of another KlumDSL project, KlumWrap.
+- Put consumer-specific behavior in adapters or decorators rather than reopening a completed model for mutation.
 - Models should be strongly typed.
 
 ## How does KlumAST implement the static data model paradigm?
@@ -30,4 +30,5 @@ KlumAST supports this style with the following techniques:
 ## Transient fields
 
 Fields marked with `@Field(FieldType.TRANSIENT)` are the explicit exception: they add transient data to a model. This
-data can be changed at will and does not participate in equality checks.
+data can be changed at will and does not participate in equality checks. `FieldType.TRANSIENT` is a KlumAST model
+classification, not the Java/Groovy `transient` modifier: it is serialized by default.


### PR DESCRIPTION
## Summary

Completes the evidence-backed pre-RC content review for current 4.0 user documentation.

- Corrects stale package and rendered-fragment links.
- Clarifies static-model and `FieldType.TRANSIENT` guidance.
- Aligns 4.0 Gradle examples, preserving root-inherited plugin versions in multi-module builds.
- Improves the Home entry-point signpost.
- Adds the #544 content-freeze inventory with accepted scope and exact owners for residual gaps.

Related: #544

## Validation

- `./gradlew renderLocalDocumentation`
- `./gradlew check`

## Scope

This PR does not implement or reopen Layer 3 terminology (#454), versioned-documentation rendering/publication (#456), onboarding field testing (#469), or the documentary-test audit (#491). Maintainer content acceptance for #544 remains pending.
