### PR TITLE
Fix named-schema relationship materialization access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 ## Java modules
 
 - Named schema modules are supported with Groovy 4 and 5; Groovy 3 remains supported on the ordinary classpath. The Schema plugin validates the user-owned descriptor as part of `check` and Maven publication, reporting copyable missing directives without editing it. A named schema requires the documented `org.apache.groovy` dependency and a qualified `opens` directive to KlumAST runtime, Jackson when used, and Hibernate Validator when Bean Validation is used. No JVM module-path workaround flags are required ([#391](https://github.com/klum-dsl/klum-ast/issues/391)).
+- Fixed Groovy 4/5 named-schema materialization for owned direct, collection, and keyed relationships without changing the approved module descriptors or requiring consumer flags ([#622](https://github.com/klum-dsl/klum-ast/issues/622)).
 
 ## Builder-first construction
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder.java
@@ -25,7 +25,10 @@ package com.blackbuild.klum.ast.runtime.generated;
 
 import com.blackbuild.klum.ast.runtime.internal.InternalKlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumPhase;
+import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactoryProvider;
 import groovy.lang.Closure;
+
+import java.util.Map;
 
 /**
  * Generated-code linkage base for Builder implementations emitted by the DSL transformation.
@@ -54,6 +57,44 @@ public abstract class GeneratedKlumBuilder<M> extends InternalKlumBuilder<M> {
 
     protected final <T> T $setSingleField(String fieldOrMethodName, T value) {
         return super.setSingleField(fieldOrMethodName, value);
+    }
+
+    protected final <T> T $createSingleChild(Map<String, Object> namedParams, String fieldOrMethodName,
+                                              Class<T> type, Boolean explicitType, String key, Closure<T> body) {
+        return super.createSingleChild(namedParams, fieldOrMethodName, type, explicitType, key, body);
+    }
+
+    protected final Object $createSingleChild(Map<String, Object> namedParams, String fieldOrMethodName,
+                                              BuilderFactoryProvider<?, ?> factory, String key, Closure<?> body) {
+        return super.createSingleChild(namedParams, fieldOrMethodName, factory, key, body);
+    }
+
+    protected final <T> T $addNewDslElementToCollection(Map<String, Object> namedParams, String collectionName,
+                                                         Class<? extends T> type, Boolean explicitType, String key,
+                                                         Closure<T> body) {
+        return super.addNewDslElementToCollection(namedParams, collectionName, type, explicitType, key, body);
+    }
+
+    protected final Object $addNewDslElementToCollection(Map<String, Object> namedParams, String collectionName,
+                                                          BuilderFactoryProvider<?, ?> factory, String key,
+                                                          Closure<?> body) {
+        return super.addNewDslElementToCollection(namedParams, collectionName, factory, key, body);
+    }
+
+    protected final <T> T $addNewDslElementToMap(Map<String, Object> namedParams, String mapName,
+                                                  Class<? extends T> type, Boolean explicitType, String key,
+                                                  Closure<T> body) {
+        return super.addNewDslElementToMap(namedParams, mapName, type, explicitType, key, body);
+    }
+
+    protected final Object $addNewDslElementToMap(Map<String, Object> namedParams, String mapName,
+                                                   BuilderFactoryProvider<?, ?> factory, String key,
+                                                   Closure<?> body) {
+        return super.addNewDslElementToMap(namedParams, mapName, factory, key, body);
+    }
+
+    protected final void $assignMaterializedRelationship(String fieldName) {
+        super.$assignMaterializedRelationship(fieldName);
     }
 
     protected final void $scheduleApplyLater(Closure<?> closure) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/InternalKlumBuilder.java
@@ -195,7 +195,7 @@ public abstract class InternalKlumBuilder<M> extends GroovyObjectSupport impleme
     }
 
     /** Internal Builder hook that assigns one completed relationship without exposing a model mutator. */
-    protected final void $assignMaterializedRelationship(String fieldName) {
+    protected void $assignMaterializedRelationship(String fieldName) {
         Field target = DslHelper.getField(completedModel.getClass(), fieldName)
                 .orElseThrow(() -> new MissingPropertyException(fieldName, completedModel.getClass()));
         setFieldValue(completedModel, target, $materializeRelationship(fieldName));

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -606,17 +606,24 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     private void createRelationshipAssignmentHook() {
         MethodBuilder method = createProtectedMethod("$assignRelationships")
                 .returning(VOID_TYPE);
-        if (dslParent != null)
-            method.statement(stmt(callSuperX("$assignRelationships")));
+        if (dslParent != null) {
+            MethodCallExpression parentAssignment = callSuperX("$assignRelationships");
+            parentAssignment.setMethodTarget(MethodAstHelper.findMatchingMethod(
+                    getRwClassOfDslParent(), "$assignRelationships", List.of()));
+            method.statement(stmt(parentAssignment));
+        }
 
         builderFields.forEach((modelField, builderField) -> {
             if (getFieldType(modelField) == FieldType.BUILDER || !isRelationshipField(modelField))
                 return;
-            method.statement(stmt(callX(
+            MethodCallExpression relationshipAssignment = callX(
                     varX("this"),
                     "$assignMaterializedRelationship",
                     args(constX(modelField.getName()))
-            )));
+            );
+            relationshipAssignment.setMethodTarget(MethodAstHelper.findMatchingMethod(
+                    GENERATED_KLUM_BUILDER, "$assignMaterializedRelationship", List.of(STRING_TYPE)));
+            method.statement(stmt(relationshipAssignment));
         });
         method.addTo(rwClass);
     }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
@@ -84,6 +84,9 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
         return switch (methodName) {
             case "copyFromRecipe" -> "$copyFromRecipe";
             case "setSingleField" -> "$setSingleField";
+            case "createSingleChild" -> "$createSingleChild";
+            case "addNewDslElementToCollection" -> "$addNewDslElementToCollection";
+            case "addNewDslElementToMap" -> "$addNewDslElementToMap";
             case "scheduleApplyLater" -> "$scheduleApplyLater";
             default -> methodName;
         };
@@ -120,7 +123,8 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
 
     private boolean isGeneratedBuilderHook() {
         return targetType.equals(KLUM_BUILDER_TYPE) && switch (proxyMethodName) {
-            case "$copyFromRecipe", "$setSingleField", "$scheduleApplyLater" -> true;
+            case "$copyFromRecipe", "$setSingleField", "$createSingleChild",
+                    "$addNewDslElementToCollection", "$addNewDslElementToMap", "$scheduleApplyLater" -> true;
             default -> false;
         };
     }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/JpmsPackageBoundaryTest.groovy
@@ -252,6 +252,45 @@ class JpmsPackageBoundaryTest extends Specification {
                 "Generated setter must directly link \$setSingleField: $directlyLinkedSetters"
     }
 
+    private static void assertGeneratedRelationshipHooksDirectlyInvokeRuntimeHooks(Path classes) {
+        Set<String> relationshipHooks = [
+                '$createSingleChild',
+                '$addNewDslElementToCollection',
+                '$addNewDslElementToMap',
+                '$assignMaterializedRelationship'
+        ] as Set
+        Set<String> unresolvedHooks = [] as Set
+        Set<String> directlyLinkedHooks = [] as Set
+        Path builderClass = classes.resolve('fixture/schema/Deployment$Builder.class')
+
+        Files.newInputStream(builderClass).withCloseable { input ->
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM7) {
+                @Override
+                MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                    new MethodVisitor(Opcodes.ASM7) {
+                        @Override
+                        void visitInvokeDynamicInsn(String methodName, String methodDescriptor, Handle bootstrapMethodHandle,
+                                                    Object... bootstrapMethodArguments) {
+                            unresolvedHooks.addAll(relationshipHooks.findAll { bootstrapMethodArguments.contains(it) })
+                        }
+
+                        @Override
+                        void visitMethodInsn(int opcode, String owner, String methodName, String methodDescriptor,
+                                             boolean isInterface) {
+                            if (owner == 'com/blackbuild/klum/ast/runtime/generated/GeneratedKlumBuilder' &&
+                                    relationshipHooks.contains(methodName))
+                                directlyLinkedHooks << methodName
+                        }
+                    }
+                }
+            }, 0)
+        }
+
+        assert unresolvedHooks.empty: "Generated relationship hooks must not use invokedynamic: $unresolvedHooks"
+        assert directlyLinkedHooks.containsAll(relationshipHooks):
+                "Generated relationship hooks must directly link the generated runtime bridge: $directlyLinkedHooks"
+    }
+
     private static boolean hasRuntimeInternalReference(Path classFile) {
         classFileConstants(classFile).any { constant ->
             constant.contains('com/blackbuild/klum/ast/runtime/internal')
@@ -308,7 +347,7 @@ class JpmsPackageBoundaryTest extends Specification {
         }
     }
 
-    @Issue("620")
+    @Issue(["620", "622"])
     def "a real schema and consumer prove the classpath and named-module contracts"() {
         given:
         boolean namedGroovy = GroovySystem.version.startsWith('4.') || GroovySystem.version.startsWith('5.')
@@ -426,6 +465,8 @@ class JpmsPackageBoundaryTest extends Specification {
             assertProtectedLifecycleContract(schemaClasses)
         if (named)
             assertGeneratedSetterDirectlyInvokesRuntimeHook(schemaClasses)
+        if (named)
+            assertGeneratedRelationshipHooksDirectlyInvokeRuntimeHooks(schemaClasses)
 
         Path schemaArtifact = named ? compileAndPackageNamedSchema(schemaSources, schemaClasses) : schemaClasses
 
@@ -580,6 +621,7 @@ class JpmsPackageBoundaryTest extends Specification {
             package fixture.schema
 
             import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Key
             import com.blackbuild.klum.ast.PostCreate
             import com.blackbuild.klum.ast.PostTree
             import com.blackbuild.klum.ast.Validate
@@ -622,7 +664,34 @@ class JpmsPackageBoundaryTest extends Specification {
 
             @DSL
             class Deployment {
-                Endpoint endpoint
+                HttpEndpoint endpoint
+                List<HttpEndpoint> routes
+                Map<String, KeyedEndpoint> keyedEndpoints
+                Endpoint classEndpoint
+                List<Endpoint> classRoutes
+                Map<String, KeyedEndpoint> classKeyedEndpoints
+
+                @PostCreate
+                void addOwnedRelationships() {
+                    endpoint(HttpEndpoint.Create) {
+                        url 'https://direct.example.test'
+                    }
+                    routes {
+                        route(HttpEndpoint.Create) {
+                            url 'https://list.example.test'
+                        }
+                    }
+                    keyedEndpoints {
+                        keyedEndpoint(NamedHttpEndpoint.Create, 'named') {
+                            url 'https://map.example.test'
+                        }
+                    }
+                }
+            }
+
+            @DSL
+            class HttpEndpoint {
+                String url
             }
 
             @DSL
@@ -630,8 +699,38 @@ class JpmsPackageBoundaryTest extends Specification {
             }
 
             @DSL
-            class HttpEndpoint extends Endpoint {
+            class DynamicHttpEndpoint extends Endpoint {
                 String url
+            }
+
+            @DSL
+            abstract class KeyedEndpoint {
+                @Key String name
+            }
+
+            @DSL
+            class NamedHttpEndpoint extends KeyedEndpoint {
+                String url
+            }
+
+            class DynamicSchemaConsumer {
+                static Deployment create() {
+                    Deployment.Create.With {
+                        classEndpoint(DynamicHttpEndpoint) {
+                            url 'https://class-direct.example.test'
+                        }
+                        classRoutes {
+                            classRoute(DynamicHttpEndpoint) {
+                                url 'https://class-list.example.test'
+                            }
+                        }
+                        classKeyedEndpoints {
+                            classKeyedEndpoint(NamedHttpEndpoint, 'class-named') {
+                                url 'https://class-map.example.test'
+                            }
+                        }
+                    }
+                }
             }
         '''.stripIndent()
     }
@@ -676,6 +775,9 @@ class JpmsPackageBoundaryTest extends Specification {
             import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactoryProvider;
             import com.blackbuild.klum.ast.runtime.validation.InstanceValidator;
             import com.fasterxml.jackson.databind.ObjectMapper;
+            import fixture.schema.Deployment;
+            import fixture.schema.DynamicHttpEndpoint;
+            import fixture.schema.DynamicSchemaConsumer;
             import fixture.schema.HttpEndpoint;
             import fixture.schema.HttpEndpoint_DSL;
             import fixture.schema.Station;
@@ -699,6 +801,16 @@ class JpmsPackageBoundaryTest extends Specification {
                         throw new AssertionError("Bean Validation schema value was not materialized");
                     if (!Station.eventLog().equals(List.of("create", "tree", "validate")))
                         throw new AssertionError("Builder lifecycle and model validation did not run in order");
+                    Deployment deployment = Deployment.Create.One();
+                    if (!"https://direct.example.test".equals(deployment.getEndpoint().getUrl()) ||
+                            !"https://list.example.test".equals(deployment.getRoutes().get(0).getUrl()) ||
+                            !"named".equals(deployment.getKeyedEndpoints().get("named").getName()))
+                        throw new AssertionError("Owned relationships did not materialize");
+                    Deployment dynamicDeployment = DynamicSchemaConsumer.create();
+                    if (!"https://class-direct.example.test".equals(((DynamicHttpEndpoint) dynamicDeployment.getClassEndpoint()).getUrl()) ||
+                            !"https://class-list.example.test".equals(((DynamicHttpEndpoint) dynamicDeployment.getClassRoutes().get(0)).getUrl()) ||
+                            !"class-named".equals(dynamicDeployment.getClassKeyedEndpoints().get("class-named").getName()))
+                        throw new AssertionError("Dynamic Class relationship selection did not materialize");
                     boolean phaseActionLoaded = ServiceLoader.load(PhaseAction.class).stream()
                             .anyMatch(provider -> provider.type().getName()
                                     .equals("com.blackbuild.klum.ast.runtime.internal.validation.ValidationPhase"));


### PR DESCRIPTION
## Summary

- Directly link generated relationship materialization to narrow generated-runtime bridges.
- Restore direct, list, and keyed relationship assignment for Groovy 4 and 5 named schemas.
- Cover both typed Factory and legacy dynamic Class relationship selectors.

## Root cause

Generated relationship assignment crossed the named-module boundary through an inaccessible runtime hook during Materialization. Compilation and classpath execution were unaffected, so the gap surfaced only when a relationship-bearing named schema executed.

## Compatibility

No module-descriptor change, consumer portability flag, export/open, or broad public runtime-hook ABI was added. Builder-first current-session ownership and Materialization semantics are preserved.

## Validation

- Focused G3/G4/G5 and runtime suites
- G4/G5 named-schema runtime execution for typed Factory and dynamic Class selectors
- ./gradlew check
- git diff --check
- Standards and spec review

Related: #622