### PR TITLE
Keep protected release tagging manual

### DIFF
--- a/.github/workflows/publish-pending-documentation.yml
+++ b/.github/workflows/publish-pending-documentation.yml
@@ -151,7 +151,9 @@ jobs:
           if [[ "$RELEASE_STAGE" == final ]]; then
             arguments+=('-PdocumentationFinalBrandingApproval=docs/branding/final-approval.json')
           fi
-          ./gradlew "$RELEASE_STAGE" preparePendingDocumentationStage "${arguments[@]}"
+          ./gradlew preparePendingDocumentationStage "${arguments[@]}" \
+            "-Prelease.stage=$RELEASE_STAGE" \
+            "-Prelease.version=$RELEASE_VERSION"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,6 @@ jobs:
           [[ "$DOCUMENTATION_PAGE_URL" =~ ^https:// ]]
       - name: Verify, sign, stage, and publish the complete product
         run: >-
-          ./gradlew ${{ inputs.stage }} publishCompleteKlumAstProduct
-          -PreleaseExpectedVersion=${{ inputs.version }}
-          -PreleaseStage=${{ inputs.stage }}
+          ./gradlew publishCompleteKlumAstProduct
+          -Prelease.version=${{ inputs.version }}
+          -Prelease.stage=${{ inputs.stage }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,10 +39,10 @@ versioned documentation/Javadoc source, hosting, URL, preview, retention, and pr
 stage. The delivered tracer and protected Pages stage are the documentation release gates; the
 mutable wiki remains migration-stub material only and is not a release destination.
 
-The repository currently uses major action tags in its workflows. Maintainers must review
-the resolved action revisions and their update policy before authorizing the first use of the
-new release workflow; this is a release gate, not permission to substitute an arbitrary
-action revision during an incident.
+The protected release, pending-Pages, and public-proof workflows pin every external action to
+a reviewed full commit SHA. Maintainers must review any pin update before authorizing its first
+use; this is a release gate, not permission to substitute an arbitrary action revision during
+an incident.
 
 ## Before approving an RC or final
 
@@ -58,7 +58,7 @@ action revision during an incident.
    may date the exact final heading; any substantive source, dependency, signing, publication,
    or workflow change requires the next RC.
 5. Ensure all 4.0 blockers, documentation/Javadocs, and the normal Java 17 Groovy 3/4/5
-   `check` gate are ready. The workflow runs `check` and requires the computed Nebula version
+   `check` gate are ready. The workflow runs `check` and requires the protected Gradle version
    to equal the approved input before any publication task starts.
 6. Confirm #456 has delivered the ADR 0013 versioned documentation/Javadoc destination and
    that its protected Pages stage has produced the exact unlisted pending snapshot and manifest
@@ -115,8 +115,8 @@ directory indexes, and heading fragments. Neither task contacts GitHub or publis
 
 The release workflow calls the separately permissioned **Publish pending documentation** workflow
 before its credential-bearing publication job. It receives the exact `candidate` or `final` stage,
-version, and full source SHA and independently recomputes the Nebula version, proves the clean
-SHA is on `master`, and rejects malformed identity or an existing `v<version>` tag. It renders
+version, and full source SHA; it configures and verifies that exact protected Gradle version,
+proves the clean SHA is on `master`, and rejects malformed identity or an existing `v<version>` tag. It renders
 only that revision with status `pending`; pending chrome and the `pending/<version>/<sha>/` path
 state that this is unlisted release-gate evidence, never a public RC, stable page, or alias.
 
@@ -152,14 +152,14 @@ shapes before it selects either protected environment. The workflow then checks 
 with no persisted GitHub credential, proves it is on `master`, and executes in its protected job:
 
 ```text
-./gradlew <candidate|final> publishCompleteKlumAstProduct \
-  -PreleaseExpectedVersion=<exact version> \
-  -PreleaseStage=<candidate|final>
+./gradlew publishCompleteKlumAstProduct \
+  -Prelease.version=<exact version> \
+  -Prelease.stage=<candidate|final>
 ```
 
-Nebula selects the candidate/final version during configuration. `verifyReleaseVersion` rejects
-a version/stage mismatch or an absent matching protected authorization before any publication
-task executes. Once #456 delivers it, its protected Pages stage independently validates the same
+The protected inputs configure the exact Gradle publication version without invoking Nebula's
+tag-producing `candidate` or `final` tasks. `verifyReleaseVersion` rejects a version/stage
+mismatch or an absent matching protected authorization before any publication task executes. Once #456 delivers it, its protected Pages stage independently validates the same
 stage/version/master SHA and deploys an immutable unlisted documentation/Javadoc snapshot plus
 manifest before `publishCompleteKlumAstProduct`. That task remains the sole permitted public
 artifact publication entry: it publishes every Maven coordinate to one Sonatype staging

--- a/build.gradle
+++ b/build.gradle
@@ -212,21 +212,26 @@ tasks.named('verifyVersionedDocumentationRenderer', VerifyVersionedDocumentation
     dependsOn(versionedDocumentationJavadocTasks)
 }
 
-def releaseExpectedVersion = providers.gradleProperty("releaseExpectedVersion")
-def releaseStage = providers.gradleProperty("releaseStage")
+def releaseVersion = providers.gradleProperty("release.version")
+def releaseStage = providers.gradleProperty("release.stage")
 def releaseAuthorization = providers.environmentVariable("KLUM_AST_RELEASE_AUTHORIZED")
+
+allprojects {
+    if (releaseVersion.present)
+        version = releaseVersion.get()
+}
 
 tasks.register("verifyReleaseVersion") {
     group = "verification"
     description = "Verifies the protected release path received the authorized stage and exact version."
 
     doLast {
-        if (!releaseExpectedVersion.present)
-            throw new GradleException("A release requires -PreleaseExpectedVersion=<exact version>.")
+        if (!releaseVersion.present)
+            throw new GradleException("A release requires -Prelease.version=<exact version>.")
         if (!releaseStage.present)
-            throw new GradleException("A release requires -PreleaseStage=candidate|final.")
+            throw new GradleException("A release requires -Prelease.stage=candidate|final.")
 
-        def expected = releaseExpectedVersion.get()
+        def expected = releaseVersion.get()
         def stage = releaseStage.get()
         if (!(stage in ["candidate", "final"]))
             throw new GradleException("Release stage must be candidate or final: $stage")
@@ -235,15 +240,9 @@ tasks.register("verifyReleaseVersion") {
         if (stage == "final" && !(expected ==~ /\d+\.\d+\.\d+/))
             throw new GradleException("Final versions must match X.Y.Z: $expected")
         if (version.toString() != expected)
-            throw new GradleException("Release version $version does not match authorized version $expected.")
+            throw new GradleException("Configured release version $version does not match authorized version $expected.")
         if (releaseAuthorization.orNull != stage)
             throw new GradleException("Protected $stage authorization is required.")
-    }
-}
-
-["candidate", "final"].each { releaseTask ->
-    tasks.named(releaseTask) {
-        dependsOn tasks.named("check"), tasks.named("verifyReleaseVersion")
     }
 }
 
@@ -265,6 +264,7 @@ def publishGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("publi
 def publishCompleteKlumAstProduct = tasks.register("publishCompleteKlumAstProduct") {
     group = "publishing"
     description = "Publishes the complete protected KlumAST Maven and Gradle Plugin Portal product."
+    dependsOn tasks.named("check")
     dependsOn closeSonatypeStagingRepository
     dependsOn publishGradlePlugins
 }

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -358,6 +358,9 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(pagesWorkflow, 'actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547', 'gh-pages writes must use the dedicated Pages writer App')
         assertContains(pagesWorkflow, 'PAGES_WRITER_TOKEN', 'the dedicated App token must be used only for gh-pages writes')
         assertTrue(!pagesWorkflow.contains('git push origin HEAD:gh-pages'), 'the workflow token must not write the Pages ledger directly')
+        assertContains(pagesWorkflow, '"-Prelease.stage=$RELEASE_STAGE"', 'pending documentation must configure its exact protected release stage without Nebula tagging')
+        assertContains(pagesWorkflow, '"-Prelease.version=$RELEASE_VERSION"', 'pending documentation must configure its exact protected release version without Nebula tagging')
+        assertTrue(!pagesWorkflow.contains('./gradlew "$RELEASE_STAGE"'), 'pending documentation must not invoke Nebula tag-producing lifecycle tasks')
         String stagedCopy = 'cp -a "build/pending-documentation/$RELEASE_VERSION/." "pages/$EXACT_PATH"'
         String stagedManifest = 'staged_manifest="build/pending-documentation/$RELEASE_VERSION/site-manifest.json"'
         String fetchedManifest = 'git -C pages show "FETCH_HEAD:${EXACT_PATH}site-manifest.json" > "$written_manifest"'
@@ -381,6 +384,10 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(releaseWorkflow, 'pages: write', 'reusable Pages workflow caller must grant Pages deployment authority')
         assertContains(releaseWorkflow, 'id-token: write', 'reusable Pages workflow caller must grant OIDC authority')
         assertContains(releaseWorkflow, 'DOCUMENTATION_MANIFEST_SHA256', 'artifact workflow must recheck the pending manifest handoff')
+        assertContains(releaseWorkflow, './gradlew publishCompleteKlumAstProduct', 'artifact publication must use the guarded complete-product task without Nebula tagging')
+        assertContains(releaseWorkflow, '-Prelease.version=${{ inputs.version }}', 'artifact publication must configure the exact protected release version')
+        assertContains(releaseWorkflow, '-Prelease.stage=${{ inputs.stage }}', 'artifact publication must configure the exact protected release stage')
+        assertTrue(!releaseWorkflow.contains('./gradlew ${{ inputs.stage }}'), 'artifact publication must not invoke Nebula tag-producing lifecycle tasks')
         assertTrue(releaseWorkflow.indexOf('needs: [validate-release-input, stage-pending-documentation]') <
                 releaseWorkflow.indexOf('publishCompleteKlumAstProduct'), 'artifact publication must remain unreachable before pending documentation success')
     }


### PR DESCRIPTION
## Summary

Correct the protected 4.0.0-rc.1 workflow after its pending-documentation stage failed because the GitHub runner has no Git identity for Nebula’s tag-producing lifecycle tasks.

- configure the approved exact version and stage with `-Prelease.version` / `-Prelease.stage` instead of invoking Nebula `candidate` or `final`;
- preserve the separate reusable pending-documentation workflow and all full-SHA action pins;
- retain the mandatory root `check` gate in the guarded product-publication task;
- keep tag and GitHub Release creation manual, after public resolve-back proof, as stated by `RELEASING.md`.

No artifact publication, tag, Pages deployment, or release is performed by this change.

Related: #488

## Validation

- `env KLUM_AST_RELEASE_AUTHORIZED=candidate ./gradlew check -Prelease.version=4.0.0-rc.1 -Prelease.stage=candidate --no-daemon --console=plain`
- guarded product-publication `--dry-run` confirms `check` precedes all publication tasks
- `./gradlew verifyVersionedDocumentationRenderer --no-daemon --console=plain`
- `git diff --check`
- Standards and Spec reviews: no remaining findings.