### PR TITLE
Keep Pages writer secrets environment-owned

### DIFF
--- a/.github/workflows/publish-pending-documentation.yml
+++ b/.github/workflows/publish-pending-documentation.yml
@@ -2,13 +2,6 @@ name: Publish pending documentation
 
 on:
   workflow_call:
-    secrets:
-      PAGES_WRITER_APP_ID:
-        description: Protected GitHub App identifier for immutable gh-pages ledger writes.
-        required: true
-      PAGES_WRITER_APP_PRIVATE_KEY:
-        description: Protected GitHub App private key for immutable gh-pages ledger writes.
-        required: true
     inputs:
       stage:
         description: Exact protected release stage.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -120,10 +120,10 @@ proves the clean SHA is on `master`, and rejects malformed identity or an existi
 only that revision with status `pending`; pending chrome and the `pending/<version>/<sha>/` path
 state that this is unlisted release-gate evidence, never a public RC, stable page, or alias.
 
-The caller uses `secrets: inherit` to forward caller-available secrets into the reusable workflow.
-The called writer job still resolves its Pages-writer credentials only in the protected
-`documentation-pages-writer` environment; it neither targets a release environment nor receives
-publication credentials.
+The caller uses `secrets: inherit` to forward its available secret set into the reusable workflow.
+The called writer job resolves the Pages-writer credentials from the protected
+`documentation-pages-writer` environment instead of requiring them as caller inputs; it neither
+targets a release environment nor receives publication credentials.
 
 The Pages job writes the rendered static HTML, local assets, exact Javadocs, `site-manifest.json`,
 and a small handoff below the protected `gh-pages` branch. It refuses an existing pending path,

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -350,7 +350,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         int workflowCallInputs = pagesWorkflow.indexOf('    inputs:\n', workflowCallStart)
         assertTrue(workflowCallStart >= 0 && workflowCallInputs > workflowCallStart,
                 'the reusable Pages workflow must declare a workflow_call input contract')
-        String pagesWorkflowSecretContract = pagesWorkflow.substring(workflowCallStart, workflowCallInputs)
+        String pagesWorkflowCallContract = pagesWorkflow.substring(workflowCallStart, workflowCallInputs)
         assertContains(pagesWorkflow, 'pending/$RELEASE_VERSION/$EXPECTED_COMMIT/', 'pending Pages path must be version and SHA scoped')
         assertContains(pagesWorkflow, 'test ! -e "pages/$expected_path"', 'existing immutable pending Pages paths must be rejected')
         assertContains(pagesWorkflow, 'DOCUMENTATION_PAGES_READY', 'pending Pages must fail closed before the rehearsal/configuration gate')
@@ -360,14 +360,9 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(pagesWorkflow, 'deployment_commit', 'gh-pages commit identity must remain separate from Pages deployment identity')
         assertContains(pagesWorkflow, 'name: documentation-pages-writer', 'only the protected Pages writer environment may receive writer credentials')
         assertContains(pagesWorkflow, 'name: documentation-pages', 'the Pages deployment environment must remain separate from the writer')
-        assertContains(pagesWorkflowSecretContract, '''    secrets:
-      PAGES_WRITER_APP_ID:
-        description: Protected GitHub App identifier for immutable gh-pages ledger writes.
-        required: true
-      PAGES_WRITER_APP_PRIVATE_KEY:
-        description: Protected GitHub App private key for immutable gh-pages ledger writes.
-        required: true
-''', 'the reusable Pages workflow must declare both required writer secrets')
+        assertTrue(!pagesWorkflowCallContract.contains('PAGES_WRITER_APP_ID') &&
+                !pagesWorkflowCallContract.contains('PAGES_WRITER_APP_PRIVATE_KEY'),
+                'environment-owned writer secrets must not be required from the reusable workflow caller')
         assertContains(pagesWorkflow, 'actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547', 'gh-pages writes must use the dedicated Pages writer App')
         assertContains(pagesWorkflow, 'PAGES_WRITER_TOKEN', 'the dedicated App token must be used only for gh-pages writes')
         assertTrue(!pagesWorkflow.contains('git push origin HEAD:gh-pages'), 'the workflow token must not write the Pages ledger directly')


### PR DESCRIPTION
## Summary

Corrects the second RC secret-handling repair.

The protected `documentation-pages-writer` environment owns the Pages writer credentials. Declaring those credentials as required `workflow_call` secrets made GitHub reject the reusable-workflow call before the protected job could resolve its environment secrets.

- remove the invalid required caller-secret declarations
- retain `secrets: inherit` at the release caller
- make the local verifier reject a regression to caller-owned required declarations
- clarify the environment-owned boundary in the release runbook

Related: #488

## Evidence

The publication-disabled probe successfully exercised the exact caller → reusable workflow → `documentation-pages-writer` environment path after approval: [run 30752454701](https://github.com/klum-dsl/klum-ast/actions/runs/30752454701).

## Validation

- `./gradlew verifyVersionedDocumentationRenderer --no-daemon --console=plain`
- `KLUM_AST_RELEASE_AUTHORIZED=candidate ./gradlew check -Prelease.version=4.0.0-rc.1 -Prelease.stage=candidate --no-daemon --console=plain`
- `KLUM_AST_RELEASE_AUTHORIZED=candidate ./gradlew publishCompleteKlumAstProduct -Prelease.version=4.0.0-rc.1 -Prelease.stage=candidate --dry-run --no-daemon --console=plain`
- `git diff --check`

No tag, artifact publication, Pages write, or deployment is performed by this PR.
