### PR TITLE
Preflight protected release identity remotely

### DIFF
--- a/.github/workflows/publish-pending-documentation.yml
+++ b/.github/workflows/publish-pending-documentation.yml
@@ -87,16 +87,47 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit }}
       - id: master
-        name: Prove the requested source is clean, unused, and on master
+        name: Prove the requested source is clean and on master
         env:
+          GH_TOKEN: ${{ github.token }}
           EXPECTED_COMMIT: ${{ inputs.commit }}
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
           git merge-base --is-ancestor "$EXPECTED_COMMIT" origin/master
           test -z "$(git status --porcelain=v1)"
-          ! git show-ref --verify --quiet "refs/tags/v${{ inputs.version }}"
+
+          assert_remote_identity_absent() {
+            local identity="$1"
+            local endpoint="$2"
+            local status
+
+            if ! status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/$endpoint")"; then
+              echo "Could not query the remote $identity state." >&2
+              exit 1
+            fi
+
+            case "$status" in
+              404) ;;
+              200)
+                echo "The remote $identity already exists; published versions are never retried in place." >&2
+                exit 1
+                ;;
+              *)
+                echo "Remote $identity query returned unexpected HTTP status $status." >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          assert_remote_identity_absent 'release tag' "git/ref/tags/v$RELEASE_VERSION"
+          assert_remote_identity_absent 'GitHub release' "releases/tags/v$RELEASE_VERSION"
           echo 'valid=true' >> "$GITHUB_OUTPUT"
 
   publish-pending:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,55 @@ jobs:
             exit 1
           fi
 
+  verify-release-identity-available:
+    name: Verify remote release identity availability
+    needs: validate-release-input
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Reject an already used remote version or tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          assert_remote_identity_absent() {
+            local identity="$1"
+            local endpoint="$2"
+            local status
+
+            if ! status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/$endpoint")"; then
+              echo "Could not query the remote $identity state." >&2
+              exit 1
+            fi
+
+            case "$status" in
+              404) ;;
+              200)
+                echo "The remote $identity already exists; published versions are never retried in place." >&2
+                exit 1
+                ;;
+              *)
+                echo "Remote $identity query returned unexpected HTTP status $status." >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          assert_remote_identity_absent 'release tag' "git/ref/tags/v$RELEASE_VERSION"
+          assert_remote_identity_absent 'GitHub release' "releases/tags/v$RELEASE_VERSION"
+
   stage-pending-documentation:
     name: Stage pending documentation for ${{ inputs.version }}
-    needs: validate-release-input
+    needs: [validate-release-input, verify-release-identity-available]
     permissions:
       contents: read
       pages: write
@@ -66,7 +112,7 @@ jobs:
 
   publish:
     name: Publish ${{ inputs.stage }} ${{ inputs.version }}
-    needs: [validate-release-input, stage-pending-documentation]
+    needs: [validate-release-input, verify-release-identity-available, stage-pending-documentation]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment:
@@ -101,20 +147,43 @@ jobs:
           distribution: temurin
           java-version: "17"
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
-      - name: Reject an already used version or tag
+      - name: Recheck remote release identity availability
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
-          git show-ref --verify --quiet "refs/tags/v${{ inputs.version }}" && {
-            echo "The release tag already exists; published versions are never retried in place." >&2
-            exit 1
+
+          assert_remote_identity_absent() {
+            local identity="$1"
+            local endpoint="$2"
+            local status
+
+            if ! status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/$endpoint")"; then
+              echo "Could not query the remote $identity state." >&2
+              exit 1
+            fi
+
+            case "$status" in
+              404) ;;
+              200)
+                echo "The remote $identity already exists; published versions are never retried in place." >&2
+                exit 1
+                ;;
+              *)
+                echo "Remote $identity query returned unexpected HTTP status $status." >&2
+                exit 1
+                ;;
+            esac
           }
-          gh release view "v${{ inputs.version }}" >/dev/null 2>&1 && {
-            echo "The GitHub release already exists; published versions are never retried in place." >&2
-            exit 1
-          }
+
+          assert_remote_identity_absent 'release tag' "git/ref/tags/v$RELEASE_VERSION"
+          assert_remote_identity_absent 'GitHub release' "releases/tags/v$RELEASE_VERSION"
       - name: Require every protected credential before publication
         shell: bash
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,11 +113,14 @@ the printed `http://127.0.0.1:<port>/klum-ast/` URL, and stop the task with Ctrl
 use the same defaults and safe cleanup. The automated check crawls internal pages, assets,
 directory indexes, and heading fragments. Neither task contacts GitHub or publishes anything.
 
-The release workflow calls the separately permissioned **Publish pending documentation** workflow
-before its credential-bearing publication job. It receives the exact `candidate` or `final` stage,
-version, and full source SHA; it configures and verifies that exact protected Gradle version,
-proves the clean SHA is on `master`, and rejects malformed identity or an existing `v<version>` tag. It renders
-only that revision with status `pending`; pending chrome and the `pending/<version>/<sha>/` path
+After validating the stage/version shape, the release workflow queries GitHub's authoritative remote
+tag and release state before it calls the separately permissioned **Publish pending documentation**
+workflow. The reusable workflow repeats that remote check at its own staging boundary, and the
+credential-bearing publication job checks it once more immediately before it receives publication
+credentials. No release decision relies on runner-local Git refs. The workflow receives the exact
+`candidate` or `final` stage, version, and full source SHA; it configures and verifies that exact
+protected Gradle version and proves the clean SHA is on `master`. It renders only that revision with
+status `pending`; pending chrome and the `pending/<version>/<sha>/` path
 state that this is unlisted release-gate evidence, never a public RC, stable page, or alias.
 
 The caller uses `secrets: inherit` to forward its available secret set into the reusable workflow.
@@ -164,7 +167,10 @@ with no persisted GitHub credential, proves it is on `master`, and executes in i
 
 The protected inputs configure the exact Gradle publication version without invoking Nebula's
 tag-producing `candidate` or `final` tasks. `verifyReleaseVersion` rejects a version/stage
-mismatch or an absent matching protected authorization before any publication task executes. Once #456 delivers it, its protected Pages stage independently validates the same
+mismatch or an absent matching protected authorization before any publication task executes. Before
+the Pages stage can create an immutable snapshot, the workflow has already rejected a remotely
+existing tag or GitHub release for that version; the stage and publication job repeat this check to
+fail closed across queue-time races. Once #456 delivers it, its protected Pages stage independently validates the same
 stage/version/master SHA and deploys an immutable unlisted documentation/Javadoc snapshot plus
 manifest before `publishCompleteKlumAstProduct`. That task remains the sole permitted public
 artifact publication entry: it publishes every Maven coordinate to one Sonatype staging

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -386,14 +386,31 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertTrue(pagesWorkflow.indexOf(stagedManifest) < pagesWorkflow.indexOf(manifestComparison),
                 'the staged manifest must remain available until post-push byte comparison completes')
         assertTrue(!pagesWorkflow.contains('publishCompleteKlumAstProduct'), 'Pages workflow must not publish artifacts')
+        assertContains(pagesWorkflow, 'git/ref/tags/v$RELEASE_VERSION',
+                'the pending Pages workflow must check release tags through the authoritative remote API')
+        assertContains(pagesWorkflow, 'releases/tags/v$RELEASE_VERSION',
+                'the pending Pages workflow must check GitHub releases through the authoritative remote API')
+        assertTrue(!pagesWorkflow.contains('git show-ref --verify'),
+                'the pending Pages workflow must not decide release identity from runner-local Git refs')
         String releaseWorkflow = new File(project.rootDir, '.github/workflows/release.yml').text
+        int identityPreflightStart = releaseWorkflow.indexOf('  verify-release-identity-available:\n')
         int pendingStageStart = releaseWorkflow.indexOf('  stage-pending-documentation:\n')
         int publishStageStart = releaseWorkflow.indexOf('  publish:\n', pendingStageStart)
-        assertTrue(pendingStageStart >= 0 && publishStageStart > pendingStageStart,
-                'artifact workflow must declare a pending documentation stage before publication')
+        assertTrue(identityPreflightStart >= 0 && pendingStageStart > identityPreflightStart && publishStageStart > pendingStageStart,
+                'artifact workflow must preflight remote release identity before pending documentation and publication')
+        String identityPreflight = releaseWorkflow.substring(identityPreflightStart, pendingStageStart)
         String pendingDocumentationStage = releaseWorkflow.substring(pendingStageStart, publishStageStart)
+        String publicationStage = releaseWorkflow.substring(publishStageStart)
+        assertContains(identityPreflight, 'git/ref/tags/v$RELEASE_VERSION',
+                'the preflight must check release tags through the authoritative remote API')
+        assertContains(identityPreflight, 'releases/tags/v$RELEASE_VERSION',
+                'the preflight must check GitHub releases through the authoritative remote API')
+        assertTrue(!identityPreflight.contains('git show-ref --verify'),
+                'the preflight must not decide release identity from runner-local Git refs')
         assertContains(pendingDocumentationStage, 'uses: ./.github/workflows/publish-pending-documentation.yml',
                 'the pending documentation stage must call the reusable Pages workflow')
+        assertContains(pendingDocumentationStage, 'needs: [validate-release-input, verify-release-identity-available]',
+                'the pending documentation stage must remain unreachable before remote identity preflight succeeds')
         assertContains(pendingDocumentationStage, 'secrets: inherit',
                 'the pending documentation stage must forward the reusable Pages workflow secret contract')
         assertContains(releaseWorkflow, 'contents: read', 'the reusable Pages workflow caller must not receive ledger-write authority')
@@ -404,7 +421,13 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(releaseWorkflow, '-Prelease.version=${{ inputs.version }}', 'artifact publication must configure the exact protected release version')
         assertContains(releaseWorkflow, '-Prelease.stage=${{ inputs.stage }}', 'artifact publication must configure the exact protected release stage')
         assertTrue(!releaseWorkflow.contains('./gradlew ${{ inputs.stage }}'), 'artifact publication must not invoke Nebula tag-producing lifecycle tasks')
-        assertTrue(releaseWorkflow.indexOf('needs: [validate-release-input, stage-pending-documentation]') <
+        assertContains(publicationStage, 'git/ref/tags/v$RELEASE_VERSION',
+                'publication must recheck release tags through the authoritative remote API')
+        assertContains(publicationStage, 'releases/tags/v$RELEASE_VERSION',
+                'publication must recheck GitHub releases through the authoritative remote API')
+        assertTrue(!publicationStage.contains('git show-ref --verify'),
+                'publication must not decide release identity from runner-local Git refs')
+        assertTrue(releaseWorkflow.indexOf('needs: [validate-release-input, verify-release-identity-available, stage-pending-documentation]') <
                 releaseWorkflow.indexOf('publishCompleteKlumAstProduct'), 'artifact publication must remain unreachable before pending documentation success')
     }
 


### PR DESCRIPTION
## Summary

- check remote tag and GitHub-release identity before the immutable pending Pages stage
- repeat the check at the reusable staging boundary and immediately before publication credentials
- verify the workflow ordering and document the fail-closed recovery rule

Related: #488

Issue #488 remains open.

## Validation

- `./gradlew verifyVersionedDocumentationRenderer --no-daemon --console=plain`
- `KLUM_AST_RELEASE_AUTHORIZED=candidate ./gradlew check -Prelease.version=4.0.0-rc.2 -Prelease.stage=candidate --no-daemon --console=plain`
- `KLUM_AST_RELEASE_AUTHORIZED=candidate ./gradlew publishCompleteKlumAstProduct -Prelease.version=4.0.0-rc.2 -Prelease.stage=candidate --dry-run --no-daemon --console=plain`
- workflow YAML and embedded Bash syntax checks
- authoritative GitHub API endpoints return `404` for unused `4.0.0-rc.2` tag and release identities