### PR TITLE
Fix Sonatype release task ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,16 +246,10 @@ tasks.register("verifyReleaseVersion") {
     }
 }
 
-def sonatypePublicationTasks = subprojects.findAll { project ->
-    project.tasks.names.contains("publishToSonatype")
-}.collect { project ->
-    project.tasks.named("publishToSonatype")
-}
 def publishMavenProductToSonatype = tasks.register("publishMavenProductToSonatype") {
     group = "publishing"
     description = "Publishes every KlumAST Maven coordinate to one protected Sonatype staging repository."
     dependsOn tasks.named("verifyReleaseVersion")
-    dependsOn sonatypePublicationTasks
 }
 def closeSonatypeRepository = tasks.named("closeSonatypeStagingRepository")
 def releaseSonatypeRepository = tasks.named("releaseSonatypeStagingRepository")
@@ -269,12 +263,27 @@ def publishCompleteKlumAstProduct = tasks.register("publishCompleteKlumAstProduc
     dependsOn publishGradlePlugins
 }
 
-sonatypePublicationTasks.each { publicationTask ->
-    publicationTask.configure {
-        dependsOn tasks.named("verifyReleaseVersion")
-        doFirst {
-            if (!gradle.taskGraph.hasTask(publishMavenProductToSonatype.get()))
-                throw new GradleException("Use publishCompleteKlumAstProduct; individual Maven publication is forbidden.")
+gradle.projectsEvaluated {
+    def sonatypePublicationTasks = subprojects.findAll { project ->
+        project.tasks.names.contains("publishToSonatype")
+    }.collect { project ->
+        project.tasks.named("publishToSonatype")
+    }
+
+    if (sonatypePublicationTasks.empty)
+        throw new GradleException("No KlumAST Maven publications are configured for the Sonatype staging repository.")
+
+    publishMavenProductToSonatype.configure {
+        dependsOn sonatypePublicationTasks
+    }
+
+    sonatypePublicationTasks.each { publicationTask ->
+        publicationTask.configure {
+            dependsOn tasks.named("verifyReleaseVersion")
+            doFirst {
+                if (!gradle.taskGraph.hasTask(publishMavenProductToSonatype.get()))
+                    throw new GradleException("Use publishCompleteKlumAstProduct; individual Maven publication is forbidden.")
+            }
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -305,6 +305,22 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         if (!directDependencies.containsAll(expectedDependencies))
             throw new GradleException("Exact-version rendering must depend on every allowed module Javadoc task; actual direct dependencies: $directDependencies")
         assertTrue(!directDependencies.contains(':klum-ast-bom:javadoc'), 'BOM must not be wired into exact-version API rendering')
+
+        def mavenPublicationTask = project.tasks.named('publishMavenProductToSonatype').get()
+        Set<String> mavenPublicationDependencies = mavenPublicationTask.taskDependencies.getDependencies(mavenPublicationTask)*.path as Set
+        Set<String> expectedMavenPublicationDependencies = project.subprojects.findAll { subproject ->
+            subproject.tasks.findByName('publishToSonatype') != null
+        }.collect { subproject ->
+            ":${subproject.name}:publishToSonatype".toString()
+        } as Set
+        assertTrue(!expectedMavenPublicationDependencies.empty,
+                'the protected Maven publication aggregate must discover at least one Sonatype publication task')
+        assertTrue(mavenPublicationDependencies.containsAll(expectedMavenPublicationDependencies),
+                "the protected Maven publication aggregate must depend on every Sonatype publication task; actual direct dependencies: $mavenPublicationDependencies")
+        def closeStagingTask = project.tasks.named('closeSonatypeStagingRepository').get()
+        assertTrue(closeStagingTask.taskDependencies.getDependencies(closeStagingTask).contains(mavenPublicationTask),
+                'closing the protected Sonatype staging repository must require Maven publication first')
+
         def localEntryTask = project.tasks.named('renderLocalDocumentation').get()
         def localPreviewTask = project.tasks.named('previewLocalDocumentation').get()
         def localVerifyTask = project.tasks.named('verifyLocalDocumentationSite').get()


### PR DESCRIPTION
## Summary

Defers Sonatype publication-task discovery until all subprojects have been evaluated. The protected aggregate now depends on every module publishToSonatype task before staging can close.

## Root cause

The previous aggregate captured task names before subprojects registered their Sonatype tasks, so it was empty and closeSonatypeStagingRepository ran without a staging repository.

## Validation

- `./gradlew check --no-daemon --console=plain`
- release-configured `publishCompleteKlumAstProduct --dry-run`, confirming all module Sonatype publication tasks precede close/release
- `git diff --check`

No artifacts, tag, or GitHub Release were created by the failed rc.4 attempt. Its pending documentation snapshot remains immutable; the repaired workflow requires a newly authorized rc.5 identity.

Related: #512

Issue #512 remains open for the initial coordinated RC validation.