### PR TITLE
Fix protected release signing and plugin ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,7 @@ def publishMavenProductToSonatype = tasks.register("publishMavenProductToSonatyp
 def closeSonatypeRepository = tasks.named("closeSonatypeStagingRepository")
 def releaseSonatypeRepository = tasks.named("releaseSonatypeStagingRepository")
 def closeSonatypeStagingRepository = tasks.named("closeAndReleaseSonatypeStagingRepository")
+def assembleGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("assemble")
 def publishGradlePlugins = project(":klum-ast-gradle-plugin").tasks.named("publishPlugins")
 def publishCompleteKlumAstProduct = tasks.register("publishCompleteKlumAstProduct") {
     group = "publishing"
@@ -274,6 +275,7 @@ gradle.projectsEvaluated {
         throw new GradleException("No KlumAST Maven publications are configured for the Sonatype staging repository.")
 
     publishMavenProductToSonatype.configure {
+        dependsOn assembleGradlePlugins
         dependsOn sonatypePublicationTasks
     }
 

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -317,9 +317,15 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'the protected Maven publication aggregate must discover at least one Sonatype publication task')
         assertTrue(mavenPublicationDependencies.containsAll(expectedMavenPublicationDependencies),
                 "the protected Maven publication aggregate must depend on every Sonatype publication task; actual direct dependencies: $mavenPublicationDependencies")
+        def pluginAssemblyTask = project.project(':klum-ast-gradle-plugin').tasks.named('assemble').get()
+        assertTrue(mavenPublicationDependencies.contains(pluginAssemblyTask.path),
+                'the protected Maven publication aggregate must assemble Gradle plugins before staging')
         def closeStagingTask = project.tasks.named('closeSonatypeStagingRepository').get()
         assertTrue(closeStagingTask.taskDependencies.getDependencies(closeStagingTask).contains(mavenPublicationTask),
                 'closing the protected Sonatype staging repository must require Maven publication first')
+        String rootBuild = new File(project.rootDir, 'build.gradle').text
+        assertContains(rootBuild, 'mustRunAfter closeSonatypeStagingRepository',
+                'Gradle Plugin Portal publication must run after Sonatype release')
         String baseConventions = new File(project.rootDir, 'buildSrc/src/main/groovy/klum-ast.base-conventions.gradle').text
         assertContains(baseConventions, 'gradle.taskGraph.hasTask(":publishCompleteKlumAstProduct")',
                 'protected complete-product publication must require Maven signatures')

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -320,6 +320,9 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         def closeStagingTask = project.tasks.named('closeSonatypeStagingRepository').get()
         assertTrue(closeStagingTask.taskDependencies.getDependencies(closeStagingTask).contains(mavenPublicationTask),
                 'closing the protected Sonatype staging repository must require Maven publication first')
+        String baseConventions = new File(project.rootDir, 'buildSrc/src/main/groovy/klum-ast.base-conventions.gradle').text
+        assertContains(baseConventions, 'gradle.taskGraph.hasTask(":publishCompleteKlumAstProduct")',
+                'protected complete-product publication must require Maven signatures')
 
         def localEntryTask = project.tasks.named('renderLocalDocumentation').get()
         def localPreviewTask = project.tasks.named('previewLocalDocumentation').get()

--- a/buildSrc/src/main/groovy/klum-ast.base-conventions.gradle
+++ b/buildSrc/src/main/groovy/klum-ast.base-conventions.gradle
@@ -43,7 +43,11 @@ publishing.publications.configureEach {
 
 afterEvaluate {
     signing {
-        required = { gradle.taskGraph.hasTask("publish") || gradle.taskGraph.hasTask("publishToMavenLocal") }
+        required = {
+            gradle.taskGraph.hasTask("publish") ||
+                    gradle.taskGraph.hasTask("publishToMavenLocal") ||
+                    gradle.taskGraph.hasTask(":publishCompleteKlumAstProduct")
+        }
         publishing.publications.configureEach {
             sign it
         }
@@ -58,4 +62,3 @@ license {
     exclude("mockup/**")
     strictCheck = true
 }
-


### PR DESCRIPTION
## Summary

Fixes two protected-release task-graph defects exposed by the failed RC publication attempts:

- Require Maven signing when `publishCompleteKlumAstProduct` is the entry point, so Sonatype staging receives `.asc` signatures.
- Assemble the Gradle plugin before Maven/Sonatype staging, while retaining Gradle Plugin Portal publication after the Sonatype release succeeds.

The release-contract verifier now guards both relationships.

## Root cause

The signing convention recognized only generic `publish` and `publishToMavenLocal` task graphs. The protected aggregate did neither, leaving every signing task skipped. Separately, Plugin Portal publication was ordered after Sonatype release, but its `assemble` dependency was also deferred until after that release.

## Validation

- Safe signing-activation probe executed `:klum-ast:signMavenJavaPublication` with all publication, staging, release, plugin, and check dependencies excluded.
- Protected RC dry run confirms signed Maven publication tasks, plugin assembly before the Maven aggregate and Sonatype close/release, then Plugin Portal publication.
- `./gradlew verifyVersionedDocumentationRenderer --no-daemon --console=plain`
- `./gradlew check --no-daemon --console=plain`

No artifacts were published, no staging repository was created, and no tag or release was created.

Related: #512
