### PR TITLE
Configure protected release in-memory signing

### DIFF
--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -329,6 +329,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         String baseConventions = new File(project.rootDir, 'buildSrc/src/main/groovy/klum-ast.base-conventions.gradle').text
         assertContains(baseConventions, 'gradle.taskGraph.hasTask(":publishCompleteKlumAstProduct")',
                 'protected complete-product publication must require Maven signatures')
+        assertContains(baseConventions, 'useInMemoryPgpKeys(signingKey, signingPassword)',
+                'protected in-memory signing credentials must configure a Gradle signatory')
 
         def localEntryTask = project.tasks.named('renderLocalDocumentation').get()
         def localPreviewTask = project.tasks.named('previewLocalDocumentation').get()

--- a/buildSrc/src/main/groovy/klum-ast.base-conventions.gradle
+++ b/buildSrc/src/main/groovy/klum-ast.base-conventions.gradle
@@ -43,6 +43,10 @@ publishing.publications.configureEach {
 
 afterEvaluate {
     signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        if (signingKey)
+            useInMemoryPgpKeys(signingKey, signingPassword)
         required = {
             gradle.taskGraph.hasTask("publish") ||
                     gradle.taskGraph.hasTask("publishToMavenLocal") ||


### PR DESCRIPTION
## Summary

Configure Gradle's in-memory PGP signatory whenever the protected release workflow supplies `signingKey` and `signingPassword`.

## Root cause

The protected workflow provided non-empty OpenPGP credentials, but the Gradle Signing plugin was never told to use them. Its signing tasks therefore had no hosted-runner signatory and failed before artifact upload.

Local developer builds without those properties continue to use their existing signatory configuration.

## Validation

- `./gradlew verifyVersionedDocumentationRenderer --no-daemon --console=plain`
- Safe negative signing probe with a deliberately invalid, non-secret key reaches Gradle's PGP parser (`Could not read PGP secret key`) instead of the former `no configured signatory` path; publication, staging, release, Plugin Portal, and checks were excluded.
- `./gradlew check --no-daemon --console=plain`

Related: #512
