### PR TITLE
Fix public verifier evidence filename

### DIFF
--- a/release/consumer/build.gradle
+++ b/release/consumer/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 tasks.register("verifyPublicProduct") {
     group = "verification"
     description = "Resolves every published Maven module and all declared Gradle plugin markers from public repositories."
-    def evidenceFile = layout.buildDirectory.file("verification/public-product-$releaseVersion.txt")
+    def evidenceFile = layout.buildDirectory.file("verification/public-product-${releaseVersion}.txt")
     dependsOn subprojects.collect { it.tasks.named("verifyPluginMarker") }
     outputs.file(evidenceFile)
 


### PR DESCRIPTION
## Summary

Fix the Groovy interpolation used for the public-consumer evidence filename.

## Root cause

`$releaseVersion.txt` is parsed as property access on `releaseVersion`, so the verifier failed during task configuration before it queried Maven Central or the Gradle Plugin Portal. Bracing the interpolation produces the intended versioned filename.

## Validation

- `env GRADLE_USER_HOME=/private/tmp/klum-ast-public-verifier-rc7 ./gradlew --refresh-dependencies -p release/consumer verifyPublicProduct -PreleaseVersion=4.0.0-rc.7 --no-build-cache --no-daemon`
- `git diff --check origin/master...HEAD`

Related: #512

This repairs only the public-consumer verifier. It does not establish public proof, complete #521's manual IntelliJ validation, or advance #456 aliases.
