### PR TITLE
Project recursive unqualified static Builder converters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
   duplicates, and map keys. Opaque or precompiled model producers are omitted from generated APIs and matching dynamic calls
   fail with targeted migration guidance ([#437](https://github.com/klum-dsl/klum-ast/issues/437),
   [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md)).
+- Fixed Builder-producing projection for source-visible recursive unqualified static factory and converter calls, including
+  overload selection. The generated relationship APIs and IDE mirrors now expose the matching public Builder overloads for
+  single, List, and Map relationships without changing direct root-factory behavior ([#642](https://github.com/klum-dsl/klum-ast/issues/642)).
 - Added the Java-first `KlumObjectSupport.of(completedObject)` facade for a completed DSL Object root or subtree. Its
   construction-path getter and composition-only `Structure` helper expose paths, direct ownership, relative paths, and
   cycle-safe typed traversal. Its `Validation` helper exposes `getResult()` for the target and `getSubtreeResults()` for

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -30,7 +30,7 @@ use this guide for Builder-first diagnostics:
 | A `KlumBuilder` result is raw, wildcarded, or unresolved | KlumAST cannot determine which public Builder interface to expose. | Declare the concrete model type, for example `KlumBuilder<Child>` or `List<KlumBuilder<Child>>`. |
 | A polymorphic relationship closure cannot see members of the selected subtype under static compilation | A dynamic `ChildType` Class selector retains the declared base Builder delegate. | Pass the generated factory, for example `child(ConcreteChild.Create) { concreteProperty 'value' }`, to select the exact public `ConcreteChild_DSL.Builder<ConcreteChild>` delegate. |
 | A member beginning with `$klum$` is rejected | The namespace is reserved for generated implementation members. | Rename the source member. |
-| A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
+| A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. Source-visible recursive calls, including unqualified static calls to same-source converters, are projected. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
 
 ### 2. Compile and Run a Representative Model
 

--- a/docs/user/Factory-Classes.md
+++ b/docs/user/Factory-Classes.md
@@ -60,6 +60,21 @@ methods without an explicit `KlumBuilder<Foo>` contract are omitted from relatio
 when a matching dynamic call is attempted. See
 [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md).
 
+An unqualified static call to another source-visible converter is projected recursively, including overload selection. For
+example, a relationship can use `fromFile` without inlining the final factory call:
+
+(See: `BuilderProjectionDocumentaryTest#'uses an unqualified static converter chain in an owned relationship'`.)
+
+```groovy
+static Customer fromFile(File file) {
+    fromYaml(file)
+}
+
+static Customer fromYaml(File file) {
+    Customer.Create.With(file.name, source: file.name)
+}
+```
+
 
 ```groovy
 @DSL class Foo {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -48,6 +48,7 @@ import org.codehaus.groovy.ast.expr.ExpressionTransformer;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.MapExpression;
 import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.TupleExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.EmptyStatement;
@@ -495,6 +496,8 @@ final class BuilderMethodProjection {
                 result.copyNodeMetaData(source);
                 return result;
             }
+            if (expression instanceof StaticMethodCallExpression source)
+                return transformStaticMethodCall(source);
             if (!(expression instanceof MethodCallExpression source))
                 return expression.transformExpression(this);
 
@@ -534,6 +537,23 @@ final class BuilderMethodProjection {
             return result;
         }
 
+        private Expression transformStaticMethodCall(StaticMethodCallExpression source) {
+            StaticMethodCallExpression result = (StaticMethodCallExpression) source.transformExpression(this);
+
+            Candidate dependency = findDependency(source);
+            if (dependency == null) return result;
+
+            candidate.dependencies.add(dependency);
+            StaticMethodCallExpression projected = new StaticMethodCallExpression(
+                    source.getOwnerType(),
+                    dependency.twin.getName(),
+                    result.getArguments()
+            );
+            projected.setSourcePosition(source);
+            projected.copyNodeMetaData(source);
+            return projected;
+        }
+
         private Candidate findDependency(MethodCallExpression call) {
             MethodNode target = call.getMethodTarget();
             if (target != null) {
@@ -549,22 +569,32 @@ final class BuilderMethodProjection {
             return state.candidateFor(resolvedOriginal);
         }
 
+        private Candidate findDependency(StaticMethodCallExpression call) {
+            if (!call.getOwnerType().redirect().equals(candidate.original.getDeclaringClass().redirect())) return null;
+            MethodNode resolvedOriginal = resolveOriginalSourceTarget(call.getMethod(), call.getArguments());
+            return resolvedOriginal == null ? null : state.candidateFor(resolvedOriginal);
+        }
+
         /**
          * Dynamic Groovy source calls do not always have a MethodNode target yet. Resolve only the original
          * source overload here; the hidden twin is then obtained exclusively from that MethodNode's metadata.
          */
         private MethodNode resolveOriginalSourceTarget(MethodCallExpression call) {
             if (!call.isImplicitThis()) return null;
-            int argumentCount = argumentCount(call.getArguments());
+            return resolveOriginalSourceTarget(call.getMethodAsString(), call.getArguments());
+        }
+
+        private MethodNode resolveOriginalSourceTarget(String methodName, Expression arguments) {
+            int argumentCount = argumentCount(arguments);
             List<MethodNode> byArity = state.candidates.values().stream()
                     .map(value -> value.original)
-                    .filter(method -> method.getName().equals(call.getMethodAsString()))
+                    .filter(method -> method.getName().equals(methodName))
                     .filter(method -> acceptsArgumentCount(method, argumentCount))
                     .toList();
             if (byArity.size() == 1) return byArity.get(0);
 
             List<MethodNode> compatible = byArity.stream()
-                    .filter(method -> argumentsMatch(method.getParameters(), call.getArguments()))
+                    .filter(method -> argumentsMatch(method.getParameters(), arguments))
                     .toList();
             return compatible.size() == 1 ? compatible.get(0) : null;
         }
@@ -650,6 +680,11 @@ final class BuilderMethodProjection {
                     return false;
                 if (expression instanceof ClosureExpression
                         && !parameters[index].getType().equals(ClassHelper.CLOSURE_TYPE))
+                    return false;
+                ClassNode expressionType = expression.getType();
+                if (expressionType != null
+                        && !expressionType.equals(ClassHelper.OBJECT_TYPE)
+                        && !isAssignableTo(expressionType, parameters[index].getOriginType()))
                     return false;
             }
             return true;

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionDocumentaryTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Tag("documentary")
+@Issue("642")
+class BuilderProjectionDocumentaryTest extends AbstractDSLSpec {
+
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Factory-Classes.md#creator-methods-and-collection-factories")
+    def "uses an unqualified static converter chain in an owned relationship"() {
+        given:
+        createClass '''
+            import java.io.File
+
+            @DSL class Order {
+                Customer customer
+            }
+
+            @DSL class Customer {
+                @Key String name
+                String source
+
+                static Customer fromFile(File file) {
+                    return fromYaml(file)
+                }
+
+                static Customer fromYaml(File file) {
+                    return Customer.Create.With(file.name, source: file.name)
+                }
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            customer new File('customer.yaml')
+        }
+
+        then:
+        instance.customer.source == 'customer.yaml'
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -29,8 +29,82 @@ import com.blackbuild.annodocimal.generator.SourceProjector
 import com.blackbuild.klum.ast.runtime.internal.DslHelper
 import com.blackbuild.klum.ast.runtime.KlumModelException
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import spock.lang.Issue
 
 class BuilderProjectionSpec extends AbstractDSLSpec {
+
+    @Issue("642")
+    def "unqualified static recursive converters project relationship overloads"() {
+        given:
+        createClass '''
+            import java.io.File
+            import java.net.URL
+
+            @DSL class Root {
+                Customer singleCustomer
+                List<Customer> listCustomers
+                Map<String, Customer> mapCustomers
+            }
+
+            @DSL class Customer {
+                @Key String name
+                String source
+
+                static Customer fromFile(File file) {
+                    return fromYaml(file)
+                }
+
+                static Customer fromUrl(URL source) {
+                    return fromYaml(source)
+                }
+
+                static Customer fromYaml(URL source) {
+                    return Customer.Create.With(source.file, source: "url:${source.file}")
+                }
+
+                static Customer fromYaml(File file) {
+                    return Customer.Create.With(file.name, source: file.name)
+                }
+            }
+        '''
+
+        expect: 'the public Builder surface has the same source-visible converter on every relationship shape'
+        getClass('Root_DSL$Builder').getMethod('singleCustomer', File).returnType == getClass('Customer_DSL$Builder')
+        getClass('Root_DSL$Builder').getMethod('singleCustomer', URL).returnType == getClass('Customer_DSL$Builder')
+        getClass('Root_DSL$Builder').getMethod('listCustomer', File).returnType == getClass('Customer_DSL$Builder')
+        getClass('Root_DSL$Builder').getMethod('mapCustomer', File).returnType == getClass('Customer_DSL$Builder')
+
+        and: 'the IDE mirror exposes the projected overloads without synthetic twins'
+        File mirrorRoot = new File(tempFolder.root, 'mirrors')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(
+                new File(compilerConfiguration.targetDirectory, 'Root_DSL.class').toPath(), mirrorRoot.toPath())
+        String mirror = new File(mirrorRoot, 'Root_DSL.java').text
+        mirror.contains('singleCustomer(File file)')
+        mirror.contains('singleCustomer(URL source)')
+        mirror.contains('listCustomer(File file)')
+        mirror.contains('mapCustomer(File file)')
+        !mirror.contains('$klum$asBuilder$')
+
+        when:
+        instance = clazz.Create.With {
+            singleCustomer new File('single.yaml')
+            listCustomer new File('list.yaml')
+            mapCustomer new File('map.yaml')
+        }
+
+        then:
+        instance.singleCustomer.source == 'single.yaml'
+        instance.listCustomers*.source == ['list.yaml']
+        instance.mapCustomers['map.yaml'].source == 'map.yaml'
+
+        when: 'the later overload is selected for another recursive static call'
+        instance = clazz.Create.With {
+            singleCustomer new URL('file:/url.yaml')
+        }
+
+        then:
+        instance.singleCustomer.source == 'url:/url.yaml'
+    }
 
     def "declared KlumBuilder generic projects to the concrete public Builder interface"() {
         given:


### PR DESCRIPTION
## Summary

- Project unqualified static recursive same-source factory and converter calls onto Builder-producing twins.
- Preserve typed overload selection and expose public/IDE-mirror Builder relationship overloads for single, List, and Map relationships.
- Add documentary migration and factory guidance.

## Root cause

Groovy represents unqualified static calls as `StaticMethodCallExpression`; the projection transformer previously handled only `MethodCallExpression`.

## Validation

- `./gradlew --no-daemon :klum-ast:test --tests 'com.blackbuild.klum.ast.BuilderProjectionSpec' --tests 'com.blackbuild.klum.ast.BuilderProjectionDocumentaryTest'`
- Equivalent focused Groovy 4 and Groovy 5 lanes
- `./gradlew --no-daemon check --console=plain` — passed (54s, 106 tasks)

Related: #642