### PR TITLE
Expose same-session Builder sources through generated copyFrom APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,8 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 - Defined copy-source behavior: ordinary completed models and Maps are value-only; marked Templates add immutable recipe
   replay; same-session unsealed Builders add an ephemeral dehydrated snapshot of pending actions without identity
   conversion. Sealed and cross-session Builders are rejected.
+- Generated public Builder contracts now expose the same-model active-Builder `copyFrom` overload, so Builder lifecycle
+  merges are statically checked without exposing internal Builder implementations ([#644](https://github.com/klum-dsl/klum-ast/issues/644)).
 - `applyLater`/`scheduleApplyLater` now reject every phase at or after `INSTANTIATE` (40) immediately and direct
   completed-model work to `ModelVisitingPhaseAction`.
 

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -67,6 +67,10 @@ assert deployment.service.image == 'catalog:1.0'
 | A generated `apply` method is missing on a completed model | Move the changes into the original `Create.With` callback, a Template, or another factory input. |
 | Completed-model proxy access fails | Stop calling `KlumInstanceProxy.getProxyFor(model)`; use `KlumObjectSupport.of(model)` and its supported completed-object utilities. Use `getConstructionPath()` for the Builder/factory invocation path and `getModelPath()` for the object's structural location. |
 
+The generated `Foo_DSL.Builder<Foo>` interface now types `copyFrom` for an active Builder of the same model. In a
+`@Default`, `@AutoCreate`, or `Create.AsBuilder.With` callback, use that public Builder type instead of suppressing
+static checking. Runtime still rejects sealed and cross-session Builder sources.
+
 ### 3. Run the Full Model Test Suite
 
 Pay particular attention to lifecycle callbacks, validation, ownership and construction paths, sorted collection comparators,

--- a/docs/user/Copy-Strategies.md
+++ b/docs/user/Copy-Strategies.md
@@ -13,7 +13,9 @@ The donor's identity determines whether deferred recipe actions are replayed:
 - a marked Template contributes values plus its immutable recipe actions;
 - an unsealed Builder in the same active Construction session contributes current values plus an ephemeral, dehydrated
   snapshot of actions that have not run yet. Copying does not mark or convert the source Builder or either completed model
-  into a Template. Because this snapshot never leaves the active session, captured values do not need to be serializable;
+  into a Template. The generated `Foo_DSL.Builder<Foo>` contract accepts that same-model Builder source directly, so
+  `copyFrom source` remains statically checked in Builder lifecycle code and `Create.AsBuilder.With` callbacks. Because
+  this snapshot never leaves the active session, captured values do not need to be serializable;
 - a sealed Builder or a Builder from another Construction session is rejected. Use the sealed Builder's completed model
   for a value-only copy, or a marked Template when actions must replay;
 - Maps and other data sources remain value-only.

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
@@ -179,6 +179,11 @@ class TemplateMethods {
     private void copyFromMethods() {
         createProxyMethod(COPY_FROM, "copyFromRecipe")
                 .mod(ACC_PUBLIC)
+                .documentationTitle("Copies all non-null/non-empty recipe values from an active Builder of the same model.")
+                .param(GeneratedDslSupport.builderTypeFor(annotatedClass), "source", "the active Builder source to copy")
+                .addTo(rwClass);
+        createProxyMethod(COPY_FROM, "copyFromRecipe")
+                .mod(ACC_PUBLIC)
                 .documentationTitle("Copies all non-null/non-empty recipe values from the template to this Builder.")
                 .param(newClass(dslAncestor), "template", "the recipe to apply")
                 .addTo(rwClass);

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
@@ -24,6 +24,7 @@
 package com.blackbuild.klum.ast
 
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import spock.lang.Issue
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 class StaticTypingSpec extends AbstractDSLSpec {
@@ -103,5 +104,95 @@ class StaticTypingSpec extends AbstractDSLSpec {
 
         then:
         notThrown(MultipleCompilationErrorsException)
+    }
+
+    @Issue('644')
+    def "static type checking accepts same-session Builder copies in Builder lifecycle code"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class ProductSource {
+                String name
+            }
+        ''')
+
+        and:
+        createClass('''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL
+            class ProductCatalog {
+                @Default
+                void mergeDefaultSource() {
+                    ProductSource_DSL.Builder<ProductSource> source = ProductSource.Create.AsBuilder.With(name: 'default source')
+                    ProductSource.Create.AsBuilder.With {
+                        copyFrom source
+                        name 'default recipient'
+                    }
+                }
+
+                @AutoCreate
+                void mergeAutoCreatedSource() {
+                    ProductSource_DSL.Builder<ProductSource> source = ProductSource.Create.AsBuilder.With(name: 'auto-created source')
+                    ProductSource.Create.AsBuilder.With {
+                        copyFrom source
+                        name 'auto-created recipient'
+                    }
+                }
+            }
+        ''')
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
+
+        when:
+        clazz.Create.One()
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Issue('644')
+    def "static type checking rejects a Builder from another model as a copy source"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class ProductSource { }
+        ''')
+
+        and:
+        createClass('''
+            package pk
+
+            @DSL
+            class OtherSource { }
+        ''')
+
+        and:
+        createClass('''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL
+            class ProductCatalog {
+                @AutoCreate
+                void attemptsCrossModelCopy() {
+                    ProductSource_DSL.Builder<ProductSource> target = ProductSource.Create.AsBuilder.One()
+                    OtherSource_DSL.Builder<OtherSource> source = OtherSource.Create.AsBuilder.One()
+                    target.copyFrom(source)
+                }
+            }
+        ''')
+
+        then:
+        MultipleCompilationErrorsException error = thrown()
+        error.message.contains('copyFrom')
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -396,6 +396,34 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         noExceptionThrown()
     }
 
+    @Issue('644')
+    def "public Builder contracts expose typed same-model copy sources"() {
+        given:
+        Class<?> fooBuilder = getClass('sample.Foo_DSL$Builder')
+
+        expect:
+        fooBuilder.getMethod('copyFrom', fooBuilder).with {
+            parameterTypes == [fooBuilder]
+            getAnnotation(AnnoDoc).value().contains('active Builder of the same model')
+        }
+
+        when: 'Java consumes the generated public Builder type without an implementation leak'
+        compileJavaConsumer('''
+            package sample;
+
+            public final class JavaDslConsumer {
+                public static void copyFromSameModel(
+                        Foo_DSL.Builder<Foo> target,
+                        Foo_DSL.Builder<Foo> source) {
+                    target.copyFrom(source);
+                }
+            }
+        ''')
+
+        then:
+        noExceptionThrown()
+    }
+
     @Issue('620')
     def "typed relationship factories select the public Builder delegate without a root lifecycle"() {
         given:
@@ -532,6 +560,7 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         mirror.contains('interface Builder')
         mirror.contains('interface CollectionFactory_kids')
         mirror.contains('interface ClusterFactory_services')
+        mirror.contains('void copyFrom(Builder<Foo> source)')
         mirror.contains('The generated DSL support namespace for sample.Foo.')
         mirror.contains('Creates a new')
         getClass('sample.Foo_DSL$Builder').getAnnotation(AnnoDoc).value().contains('public Builder contract')


### PR DESCRIPTION
## Summary

Expose a typed `copyFrom` overload for the same model's generated public Builder interface.

The runtime already supports an active same-session Builder as a copy source, but generated APIs previously published only completed-model and `Map` overloads. That made valid Builder-first lifecycle merges fail static type checking.

The generated `Foo_DSL.Builder<Foo>` API and IDE source mirror now expose the typed overload without leaking internal Builder implementations. Static coverage exercises `@Default`, `@AutoCreate`, and `Create.AsBuilder.With`, while wrong-model sources remain static diagnostics and existing runtime protocol coverage retains sealed/cross-session guards.

## Documentation

- Builder-first migration guidance
- Copy-source protocol guidance
- 4.0 changelog

## Validation

- `./gradlew --no-daemon check --console=plain` — passed (106 actionable tasks; 24 executed)

Related: #644

Out of scope: `@BuilderQuery`, Builder-aware converter input, cross-model Builder copies, and converter/factory redesign.
