### PR TITLE
Document 3.x-to-4.0 migration starter script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Added a deliberately incomplete, best-effort 3.x-to-4.0 migration starter script for known annotation,
+  `KlumModelException`, and copy-annotation import moves plus current-target validation-reporter edits. It runs from a
+  schema module in a clean disposable Git worktree and requires diff review, normal compilation, and the Builder-first
+  migration checklist; it is not an automatic migration tool ([#652](https://github.com/klum-dsl/klum-ast/issues/652)).
 - Added the portable `build-domain-first-schema` skill, task-oriented domain-first guidance, and an executable Layer 3 smart-home journey. The fixture separates generic API, fixed floorplan Schema, registered Model script, and API-only `client-demo`; it covers Cluster projection, provider-polymorphic Builder calls, `@DefaultValues` labels, and a bounded field-test artifact ([#471](https://github.com/klum-dsl/klum-ast/issues/471)).
 
 - Added a task-oriented Gradle onboarding preview, portable `start-klum-project`, `author-klum-model`, and `feature-advisor` Agent Skills, plus an executable minimal fixture. `feature-advisor` also assesses whether KlumAST or its skill distribution needs an update ([#470](https://github.com/klum-dsl/klum-ast/issues/470)).

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -78,6 +78,95 @@ Pay particular attention to lifecycle callbacks, validation, ownership and const
 Templates, serialization, and Jackson inputs. These areas intentionally distinguish between the construction-time Builder
 graph and the completed model graph.
 
+## Optional Mechanical Starting Point
+
+The following **best-effort convenience script** performs only a small set of mechanical 3.x-to-4.0 edits. It is not a
+KlumAST migration tool: it does not promise a compiling project, understand application semantics, or replace the
+checklist below. Run it only from the **schema module directory**—the Gradle subproject containing the Schema's
+`src/main` and `src/test` sources—not from a multi-module project's top-level directory. That module must be in a
+**clean, disposable Git worktree**. Review its diff immediately, then compile, run a representative model, and fix the
+remaining compiler errors with this guide.
+
+It rewrites public schema-annotation imports, changes the deprecated `@DelegatesToRW` spelling to
+`@DelegatesToBuilder`, migrates Layer 3 annotation imports such as `@AutoCreate`, copy annotations such as `@Overwrite`,
+and `KlumModelException` imports. It also converts only current-target Groovy `Validator` reporting/suppression calls. It
+intentionally does **not** rewrite internal packages, `ValidatorBase`, validation result readers, explicit-target
+`Validator` calls, fully qualified type references, Builders, factories, relationships, lifecycle structure, or any other
+semantic migration.
+
+```bash
+#!/usr/bin/env bash
+# Run from a schema module directory in a clean, disposable Git worktree.
+# Do not run this from a multi-module project's top-level directory. Requires Bash and Perl.
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Refusing to edit a non-clean worktree; commit, stash, or create a fresh worktree first." >&2
+  exit 1
+fi
+command -v perl >/dev/null || {
+  echo "This convenience script requires Perl." >&2
+  exit 1
+}
+
+roots=()
+for candidate in src/main/groovy src/test/groovy src/main/java src/test/java; do
+  [[ -d "$candidate" ]] && roots+=("$candidate")
+done
+(( ${#roots[@]} )) || {
+  echo "No conventional Groovy or Java source roots found." >&2
+  exit 1
+}
+
+# Known public annotation moves, exception import, and canonical deprecated annotation spelling.
+while IFS= read -r -d '' file; do
+  perl -0pi -e '
+    s{^(\s*import\s+(?:static\s+)?)(com\.blackbuild\.groovy\.configdsl\.transform\.)}{$1com.blackbuild.klum.ast.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.layer3\.annotations\.)}{$1com.blackbuild.klum.ast.layer3.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.copy\.)}{$1com.blackbuild.klum.ast.copy.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.KlumModelException\b)}{$1com.blackbuild.klum.ast.runtime.KlumModelException}mg;
+    s{\bDelegatesToRW\b}{DelegatesToBuilder}g;
+  ' "$file"
+done < <(find "${roots[@]}" -type f \( -name '*.groovy' -o -name '*.java' \) -print0)
+
+# Current-target Groovy Validator calls only. Explicit-target calls, ValidatorBase,
+# and validation-result readers deliberately remain for manual migration.
+groovy_roots=()
+for candidate in src/main/groovy src/test/groovy; do
+  [[ -d "$candidate" ]] && groovy_roots+=("$candidate")
+done
+
+if (( ${#groovy_roots[@]} )); then
+  while IFS= read -r -d '' file; do
+    if grep -qE 'Validator\.(addError|addErrorToMember|addIssue|addIssueToMember|suppressFurtherIssues)' "$file"; then
+    perl -0pi -e '
+      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*,\s*([^\)]+)\)}{klumValidation.suppressAll($1)}g;
+      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*\)}{klumValidation.suppressAll()}g;
+      s{\bValidator\.addErrorToMember\b}{klumValidation.errorAt}g;
+      s{\bValidator\.addError\b}{klumValidation.error}g;
+      s{\bValidator\.addIssueToMember\b}{klumValidation.issueAt}g;
+      s{\bValidator\.addIssue\b}{klumValidation.issue}g;
+      s{\bValidator\.suppressFurtherIssues\b}{klumValidation.suppressOn}g;
+      if (!/Validator\./) {
+        s{^\s*import\s+com\.blackbuild\.klum\.ast\.validation\.Validator\s*\n}{}mg;
+      }
+      if (/\bklumValidation\./ && !/import\s+static\s+com\.blackbuild\.klum\.ast\.runtime\.KlumSchemaSupport\.klumValidation/) {
+        if (!s{^(package[^\n]*\n)}{$1\nimport static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n}m) {
+          s{\A}{import static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n\n};
+        }
+      }
+    ' "$file"
+    fi
+  done < <(find "${groovy_roots[@]}" -type f -name '*.groovy' -print0)
+fi
+
+echo "Starter edits applied. Review 'git diff', then compile, run a representative model, and follow Builder-First-Migration.md."
+```
+
+Do not broaden this script by guessing package destinations or rewriting unresolved compiler errors. The compilation and
+model checks are the handoff from mechanical edits to the actual migration.
+
 ## Builder Lifecycle Field Types
 
 Builder lifecycle code preserves ordinary declared collection and map element types. A statically checked `@Default` or


### PR DESCRIPTION
## Summary

Adds a deliberately incomplete migration convenience script to the Builder-first migration guide.

It is designed to run from a clean, disposable schema-module worktree and performs only reviewable mechanical edits:

- known annotation, Layer 3, copy-annotation, and `KlumModelException` import moves;
- the `@DelegatesToRW` to `@DelegatesToBuilder` spelling update; and
- qualified current-target `Validator` reporting and suppression calls.

The guide explicitly requires reviewing the diff, compiling, and following the remaining migration checklist; it is not an automatic migration tool.

## Validation

- Bash syntax check of the documented script
- Clean Git schema-module fixtures for the import and `Validator` transformations
- `git diff --check`

Related: #652
