### PR TITLE
Reject completed-model instanceof checks on Builders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Statically checked Builder-phase code now rejects `instanceof SomeDslModel` when a relationship value is known to be a
+  Builder before materialization. The diagnostic reports the inferred Builder type and points to the Builder-first
+  migration guide; completed-model validation, ordinary non-model checks, and operands known only as `Object` remain
+  valid ([#654](https://github.com/klum-dsl/klum-ast/issues/654)).
 - Added a deliberately incomplete, best-effort 3.x-to-4.0 migration starter script for known annotation,
   `KlumModelException`, and copy-annotation import moves plus current-target validation-reporter edits. It runs from a
   schema module in a clean disposable Git worktree and requires diff review, normal compilation, and the Builder-first

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -30,8 +30,22 @@ use this guide for Builder-first diagnostics:
 | A `KlumBuilder` result is raw, wildcarded, or unresolved | KlumAST cannot determine which public Builder interface to expose. | Declare the concrete model type, for example `KlumBuilder<Child>` or `List<KlumBuilder<Child>>`. |
 | A statically checked Builder lifecycle method sees an ordinary collection or map value as `Object` | An earlier 4.0 release candidate emitted a raw Builder accessor for simple collection and map fields. | Recompile the Schema with the correction. Declared element and map value types are preserved, so a compensating local generic cast is no longer needed. |
 | A polymorphic relationship closure cannot see members of the selected subtype under static compilation | A dynamic `ChildType` Class selector retains the declared base Builder delegate. | Pass the generated factory, for example `child(ConcreteChild.Create) { concreteProperty 'value' }`, to select the exact public `ConcreteChild_DSL.Builder<ConcreteChild>` delegate. |
+| `instanceof SomeDslModel` is rejected in a Builder-phase callback | The relationship value is a Builder before materialization, not the completed DSL Object. The diagnostic names the inferred Builder type when available. | Do not use a completed-model type check in a mutator, mutating lifecycle method, or Builder-retargeted annotation closure. Move a completed-model invariant to `@Validate`; ordinary checks and operands known only as `Object` remain valid. |
 | A member beginning with `$klum$` is rejected | The namespace is reserved for generated implementation members. | Rename the source member. |
 | A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. Source-visible recursive calls, including unqualified static calls to same-source converters, are projected. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
+
+### Builder-phase Type Checks
+
+Relationships are Builders until the graph materializes. A completed-model `instanceof` check therefore belongs in a
+completed-model validation callback rather than in construction-time code. (See:
+`BuilderFirstMigrationDocumentaryTest#'keeps completed-model type checks in validation'`.)
+
+```groovy
+@Validate
+void validateCompletedService() {
+    assert service instanceof Service
+}
+```
 
 ### 2. Compile and Run a Representative Model
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModelVerificationVisitor.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModelVerificationVisitor.java
@@ -26,6 +26,7 @@ package com.blackbuild.klum.ast.compiler.internal.ast.mutators;
 import com.blackbuild.klum.ast.FieldType;
 import com.blackbuild.klum.ast.compiler.internal.ast.DSLASTTransformation;
 import com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper;
+import com.blackbuild.klum.ast.runtime.KlumBuilder;
 import groovyjarjarasm.asm.Opcodes;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.*;
@@ -36,11 +37,16 @@ import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 import java.util.List;
 
 import static org.codehaus.groovy.syntax.Types.*;
+import static org.codehaus.groovy.ast.ClassHelper.make;
+import static com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper.isAssignableTo;
 
 /**
  * Created by stephan on 12.04.2017.
  */
 public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
+
+    private static final ClassNode KLUM_BUILDER = make(KlumBuilder.class);
+    private int builderAnnotationClosureDepth;
 
     public ModelVerificationVisitor(SourceUnit unit, ClassNode node) {
         super(unit, node);
@@ -49,10 +55,19 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
 
     @Override
     public void visitClosureExpression(ClosureExpression expression) {
-        super.visitClosureExpression(expression);
+        boolean builderAnnotationClosure = Boolean.TRUE.equals(expression.getNodeMetaData(
+                DSLASTTransformation.BUILDER_ANNOTATION_CLOSURE_METADATA_KEY));
+        if (builderAnnotationClosure)
+            builderAnnotationClosureDepth++;
 
-        if (!Boolean.TRUE.equals(expression.getNodeMetaData(
-                DSLASTTransformation.BUILDER_ANNOTATION_CLOSURE_METADATA_KEY)))
+        try {
+            super.visitClosureExpression(expression);
+        } finally {
+            if (builderAnnotationClosure)
+                builderAnnotationClosureDepth--;
+        }
+
+        if (!builderAnnotationClosure)
             return;
 
         ClassNode inferredReturnType = expression.getNodeMetaData(StaticTypesMarker.INFERRED_RETURN_TYPE);
@@ -88,6 +103,29 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
     public void visitBinaryExpression(BinaryExpression expression) {
         super.visitBinaryExpression(expression);
         checkForIllegalAssignment(expression);
+        checkForCompletedModelInstanceofOnBuilder(expression);
+    }
+
+    private void checkForCompletedModelInstanceofOnBuilder(BinaryExpression expression) {
+        if (!isBuilderPhaseCode() || expression.getOperation().getType() != KEYWORD_INSTANCEOF)
+            return;
+        if (!(expression.getRightExpression() instanceof ClassExpression modelTypeExpression)
+                || !DslAstHelper.isDSLObject(modelTypeExpression.getType()))
+            return;
+
+        ClassNode inferredType = getType(expression.getLeftExpression());
+        if (!isAssignableTo(inferredType, KLUM_BUILDER))
+            return;
+
+        addError(String.format(
+                "Cannot use 'instanceof %s' on '%s' in Builder-phase code: the relationship value is a Builder before materialization (inferred Builder type: %s), not a completed DSL Object. See the Builder-first migration guidance: docs/user/Builder-First-Migration.md.",
+                modelTypeExpression.getType().getNameWithoutPackage(),
+                expression.getLeftExpression().getText(),
+                inferredType.getName()), expression);
+    }
+
+    private boolean isBuilderPhaseCode() {
+        return inRwClass() || builderAnnotationClosureDepth > 0;
     }
 
     private void checkForIllegalAssignment(BinaryExpression expression) {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
@@ -88,6 +88,109 @@ class StaticTypingSpec extends AbstractDSLSpec {
         notThrown(MultipleCompilationErrorsException)
     }
 
+    @Issue('654')
+    def "static type checking rejects completed-model instanceof checks on Builder relationship values"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class Parent {
+                Child child
+
+                @Mutator
+                void classifyChild() {
+                    assert child instanceof Child
+                }
+            }
+        ''')
+
+        then:
+        def failure = thrown(MultipleCompilationErrorsException)
+        failure.message.contains('relationship value is a Builder before materialization')
+        failure.message.contains('Child_DSL$Builder')
+        failure.message.contains('Builder-First-Migration.md')
+    }
+
+    @Issue('654')
+    def "static type checking rejects completed-model instanceof checks in Builder lifecycle and annotation closures"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class LifecycleParent {
+                Child child
+
+                @PostTree
+                void classifyChild() {
+                    assert child instanceof Child
+                }
+            }
+        ''')
+
+        then:
+        def lifecycleFailure = thrown(MultipleCompilationErrorsException)
+        lifecycleFailure.message.contains('relationship value is a Builder before materialization')
+
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class AnnotationParent {
+                Child child
+
+                @Default(code = { child instanceof Child ? 'builder' : 'model' })
+                String lifecycleState
+            }
+        ''')
+
+        then:
+        def annotationFailure = thrown(MultipleCompilationErrorsException)
+        annotationFailure.message.contains('relationship value is a Builder before materialization')
+    }
+
+    @Issue('654')
+    def "static type checking permits completed-model, ordinary, and Object instanceof checks"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class Parent {
+                Child child
+                String name
+
+                @Mutator
+                void classifySafely(Object unknown) {
+                    assert unknown instanceof Child
+                    assert name instanceof String
+                }
+
+                @Validate
+                void validateCompletedChild() {
+                    assert child instanceof Child
+                }
+            }
+        ''')
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
+    }
+
     def "def typed methods are allowed"() {
         when:
         createClass('''

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
@@ -61,4 +61,34 @@ class BuilderFirstMigrationDocumentaryTest extends AbstractDSLSpec {
         deployment.environment == 'production'
         deployment.service.image == 'catalog:1.0'
     }
+
+    @Issue("654")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Builder-First-Migration.md#builder-phase-type-checks")
+    def "keeps completed-model type checks in validation"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Service { }
+
+            @DSL
+            class Deployment {
+                Service service
+
+                @Validate
+                void validateCompletedService() {
+                    assert service instanceof Service
+                }
+            }
+        '''
+
+        when:
+        def deployment = getClass("Deployment").Create.With {
+            service {}
+        }
+
+        then:
+        deployment.service.class == getClass("Service")
+    }
 }


### PR DESCRIPTION
## Summary

- reject `instanceof SomeDslModel` only when a Builder-phase operand is statically known to be a Klum Builder
- explain the Builder-before-materialization boundary, inferred Builder type, and migration path
- add focused and documentary coverage plus migration and changelog updates

## Why

Relationship values remain Builders until materialization, so a completed-model type check in Builder-phase code is misleading. Completed-model validation and non-model/Object checks remain valid.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- focused `StaticTypingSpec` on Groovy 3, 4, and 5
- local standards and specification review

Related: #654