### PR TITLE
Diagnose nested root factories in Builder code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Statically checked Builder-phase code now identifies source-visible `Child.Create.With`, `One`, and `From` root
+  factories, explains that they return a completed model, and directs nested composition to `Child.Create.AsBuilder.*`
+  attached to an owned relationship. Completed-model validation, ordinary static source factories, non-DSL `Create`, and
+  valid Builder composition remain valid ([#656](https://github.com/klum-dsl/klum-ast/issues/656)).
 - Statically checked Builder-phase code now rejects `instanceof SomeDslModel` when a relationship value is known to be a
   Builder before materialization. The diagnostic reports the inferred Builder type and points to the Builder-first
   migration guide; completed-model validation, ordinary non-model checks, and operands known only as `Object` remain

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -31,6 +31,7 @@ use this guide for Builder-first diagnostics:
 | A statically checked Builder lifecycle method sees an ordinary collection or map value as `Object` | An earlier 4.0 release candidate emitted a raw Builder accessor for simple collection and map fields. | Recompile the Schema with the correction. Declared element and map value types are preserved, so a compensating local generic cast is no longer needed. |
 | A polymorphic relationship closure cannot see members of the selected subtype under static compilation | A dynamic `ChildType` Class selector retains the declared base Builder delegate. | Pass the generated factory, for example `child(ConcreteChild.Create) { concreteProperty 'value' }`, to select the exact public `ConcreteChild_DSL.Builder<ConcreteChild>` delegate. |
 | `instanceof SomeDslModel` is rejected in a Builder-phase callback | The relationship value is a Builder before materialization, not the completed DSL Object. The diagnostic names the inferred Builder type when available. | Do not use a completed-model type check in a mutator, mutating lifecycle method, or Builder-retargeted annotation closure. Move a completed-model invariant to `@Validate`; ordinary checks and operands known only as `Object` remain valid. |
+| `Child.Create.With`, `One`, or `From` is rejected in Builder-phase code | That call starts an independent root lifecycle and returns a completed model, which cannot become owned composition in the active Builder graph. | Use `Child.Create.AsBuilder.With`, `One`, or `From`, then attach the returned Builder to an owned relationship. Root factories remain valid in `@Validate` and ordinary static source factory methods. |
 | A member beginning with `$klum$` is rejected | The namespace is reserved for generated implementation members. | Rename the source member. |
 | A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. Source-visible recursive calls, including unqualified static calls to same-source converters, are projected. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
 
@@ -46,6 +47,22 @@ void validateCompletedService() {
     assert service instanceof Service
 }
 ```
+
+### Builder-phase Factories
+
+`Create.With`, `Create.One`, and `Create.From` are root factories: they return a completed model and own a complete
+Construction session. In a mutator, mutating lifecycle method, or Builder-retargeted annotation closure, create the
+owned child in the active session instead:
+
+```groovy
+@Mutator
+void supplySource() {
+    source = ProductSource.Create.AsBuilder.With(name: 'default source')
+}
+```
+
+The returned Builder must be attached to an owned relationship. Do not use `Create.AsBuilder` for an independent root
+model; use the ordinary root factory outside Builder-phase code instead.
 
 ### 2. Compile and Run a Representative Model
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ConverterBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ConverterBuilder.java
@@ -138,6 +138,7 @@ class ConverterBuilder {
     }
 
     private void closureToStaticConverterMethod(ClassNode converterClass, ClosureExpression converter) {
+        converter.putNodeMetaData(DSLASTTransformation.MODEL_RESULT_ANNOTATION_CLOSURE_METADATA_KEY, Boolean.TRUE);
         Parameter[] parameters = rescopeParameters(converter.getParameters());
         String name = stream(parameters)
                 .map(Parameter::getOriginType)

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -136,6 +136,8 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     public static final String RWCLASS_METADATA_KEY = DSLASTTransformation.class.getName() + ".rwclass";
     public static final String BUILDER_ANNOTATION_CLOSURE_METADATA_KEY =
             DSLASTTransformation.class.getName() + ".builderAnnotationClosure";
+    public static final String MODEL_RESULT_ANNOTATION_CLOSURE_METADATA_KEY =
+            DSLASTTransformation.class.getName() + ".modelResultAnnotationClosure";
     public static final ClassNode INVOKER_HELPER_CLASS = ClassHelper.make(InvokerHelper.class);
     public static final String FACTORY_FIELD_NAME = "Create";
     private static final String RESERVED_KLUM_NAMESPACE = "$klum$";

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModelVerificationVisitor.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/ModelVerificationVisitor.java
@@ -35,6 +35,7 @@ import org.codehaus.groovy.transform.stc.StaticTypeCheckingVisitor;
 import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.codehaus.groovy.syntax.Types.*;
 import static org.codehaus.groovy.ast.ClassHelper.make;
@@ -46,7 +47,9 @@ import static com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper.i
 public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
 
     private static final ClassNode KLUM_BUILDER = make(KlumBuilder.class);
+    private static final Set<String> ROOT_FACTORY_METHODS = Set.of("With", "One", "From");
     private int builderAnnotationClosureDepth;
+    private int modelResultAnnotationClosureDepth;
 
     public ModelVerificationVisitor(SourceUnit unit, ClassNode node) {
         super(unit, node);
@@ -57,12 +60,18 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
     public void visitClosureExpression(ClosureExpression expression) {
         boolean builderAnnotationClosure = Boolean.TRUE.equals(expression.getNodeMetaData(
                 DSLASTTransformation.BUILDER_ANNOTATION_CLOSURE_METADATA_KEY));
+        boolean modelResultAnnotationClosure = Boolean.TRUE.equals(expression.getNodeMetaData(
+                DSLASTTransformation.MODEL_RESULT_ANNOTATION_CLOSURE_METADATA_KEY));
         if (builderAnnotationClosure)
             builderAnnotationClosureDepth++;
+        if (modelResultAnnotationClosure)
+            modelResultAnnotationClosureDepth++;
 
         try {
             super.visitClosureExpression(expression);
         } finally {
+            if (modelResultAnnotationClosure)
+                modelResultAnnotationClosureDepth--;
             if (builderAnnotationClosure)
                 builderAnnotationClosureDepth--;
         }
@@ -106,6 +115,31 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
         checkForCompletedModelInstanceofOnBuilder(expression);
     }
 
+    @Override
+    public void visitMethodCallExpression(MethodCallExpression expression) {
+        super.visitMethodCallExpression(expression);
+        checkForNestedRootFactory(expression);
+    }
+
+    private void checkForNestedRootFactory(MethodCallExpression expression) {
+        String factoryMethod = expression.getMethodAsString();
+        if (!isBuilderPhaseCode() || isInModelResultAnnotationClosure() || isInStaticMethod()
+                || factoryMethod == null || !ROOT_FACTORY_METHODS.contains(factoryMethod))
+            return;
+
+        if (!(expression.getObjectExpression() instanceof PropertyExpression factoryExpression)
+                || !DSLASTTransformation.FACTORY_FIELD_NAME.equals(factoryExpression.getPropertyAsString())
+                || !(factoryExpression.getObjectExpression() instanceof ClassExpression modelExpression)
+                || !DslAstHelper.isDSLObject(modelExpression.getType()))
+            return;
+
+        String modelName = modelExpression.getType().getNameWithoutPackage();
+        addError(String.format(
+                "%1$s.Create.%2$s starts a completed-model root factory. In Builder-phase code use %1$s.Create.AsBuilder.%2$s and attach the returned Builder to an owned relationship.",
+                modelName,
+                factoryMethod), expression);
+    }
+
     private void checkForCompletedModelInstanceofOnBuilder(BinaryExpression expression) {
         if (!isBuilderPhaseCode() || expression.getOperation().getType() != KEYWORD_INSTANCEOF)
             return;
@@ -126,6 +160,15 @@ public class ModelVerificationVisitor extends StaticTypeCheckingVisitor {
 
     private boolean isBuilderPhaseCode() {
         return inRwClass() || builderAnnotationClosureDepth > 0;
+    }
+
+    private boolean isInStaticMethod() {
+        MethodNode currentMethod = typeCheckingContext.getEnclosingMethod();
+        return currentMethod != null && currentMethod.isStatic();
+    }
+
+    private boolean isInModelResultAnnotationClosure() {
+        return modelResultAnnotationClosureDepth > 0;
     }
 
     private void checkForIllegalAssignment(BinaryExpression expression) {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConverterSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConverterSpec.groovy
@@ -105,6 +105,7 @@ class ConverterSpec extends AbstractDSLSpec {
         TimeCategory.minus(instance.date, new Date()).days == 0
     }
 
+    @Issue('656')
     def "generated converter for dsl field"() {
         when:
         createClass '''
@@ -131,6 +132,7 @@ class ConverterSpec extends AbstractDSLSpec {
         instance.bar.value.time == 123L
     }
 
+    @Issue('656')
     def "generated converter for keyed dsl field"() {
         when:
         createClass '''

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/StaticTypingSpec.groovy
@@ -209,6 +209,152 @@ class StaticTypingSpec extends AbstractDSLSpec {
         notThrown(MultipleCompilationErrorsException)
     }
 
+    @Issue('656')
+    def "static type checking identifies nested root factories in Builder-phase methods"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class Parent {
+                Child child
+
+                @Mutator
+                void configureChild() {
+                    child = Child.Create.With()
+                }
+            }
+        ''')
+
+        then:
+        MultipleCompilationErrorsException error = thrown()
+        error.message.contains('Child.Create.With starts a completed-model root factory')
+        error.message.contains('Child.Create.AsBuilder.With')
+        error.message.contains('attach the returned Builder to an owned relationship')
+    }
+
+    @Issue('656')
+    def "static type checking identifies nested root factories in Builder lifecycle and annotation closures"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class LifecycleParent {
+                Child child
+
+                @PostTree
+                void configureChild() {
+                    child = Child.Create.One()
+                }
+            }
+        ''')
+
+        then:
+        MultipleCompilationErrorsException lifecycleError = thrown()
+        lifecycleError.message.contains('Child.Create.One starts a completed-model root factory')
+
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class AnnotationParent {
+                @Default(code = { Child.Create.With() })
+                Child child
+            }
+        ''')
+
+        then:
+        MultipleCompilationErrorsException annotationError = thrown()
+        annotationError.message.contains('Child.Create.With starts a completed-model root factory')
+    }
+
+    @Issue('656')
+    def "static type checking identifies nested From root factories in Builder-phase code"() {
+        when:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child { }
+
+            @DSL
+            class Parent {
+                Child child
+
+                @Mutator
+                void configureChild() {
+                    child = Child.Create.From('')
+                }
+            }
+        ''')
+
+        then:
+        MultipleCompilationErrorsException error = thrown()
+        error.message.contains('Child.Create.From starts a completed-model root factory')
+        error.message.contains('Child.Create.AsBuilder.From')
+    }
+
+    @Issue('656')
+    def "static type checking permits Builder composition, validation root factories, static factories, and non-DSL Create"() {
+        when:
+        createSecondaryClass('''
+            package pk
+
+            class External {
+                static final Creator Create = new Creator()
+
+                static class Creator {
+                    String One() { 'external' }
+                }
+            }
+        ''')
+
+        and:
+        createClass('''
+            package pk
+
+            @DSL
+            class Child {
+                String name
+            }
+
+            @DSL
+            class Parent {
+                Child child
+
+                @Mutator
+                void configureChild() {
+                    child = Child.Create.AsBuilder.With(name: 'child')
+                    assert External.Create.One() == 'external'
+                }
+
+                @Validate
+                void validateCompletedChild() {
+                    Child completedChild = Child.Create.One()
+                    assert completedChild instanceof Child
+                }
+
+                static Child createStandaloneChild() {
+                    Child.Create.With()
+                }
+            }
+        ''')
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
+    }
+
     @Issue('644')
     def "static type checking accepts same-session Builder copies in Builder lifecycle code"() {
         when:


### PR DESCRIPTION
## Summary

Adds a bounded compile-time diagnostic for source-visible `Create.With`, `Create.One`, and `Create.From` calls in Builder-phase code when the call lacks `AsBuilder`.

## Why

A nested root factory returns a completed model and starts an independent Construction session, so it cannot provide an owned child to the active Builder graph. The diagnostic guides migration to `Create.AsBuilder.*` and an owned relationship.

Completed-model validation, ordinary static factory methods, non-DSL `Create` properties, valid Builder composition, and model-producing converter closures remain valid. No factory API or runtime behavior changes.

## Validation

- `./gradlew -q :klum-ast:test :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- Local standards/spec review: no findings

Related: #656

The shared Builder-phase diagnostic seam from #654 is included in the merged base.
