### PR TITLE
Initialize sorted collection defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Uninitialized `SortedSet`/`NavigableSet` and `SortedMap`/`NavigableMap` fields now receive their
+  natural-order sorted defaults before Builder-first materialization. Their completed views remain
+  sorted and immutable, while explicit `TreeSet`/`TreeMap` comparators continue to be preserved
+  ([#664](https://github.com/klum-dsl/klum-ast/issues/664)).
 - Factory maps continue to prefer an explicit same-named Builder mutator over direct field storage. KlumAST now warns
   when an exact single-argument `@Mutator` override returns the field value or compatible Builder, points direct
   assignment to `setX`, and rejects other non-void return types as likely helper-method collisions. `void` overrides and

--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -203,7 +203,10 @@ Config.Create.With {
 }
 ```
 
-If the collection has no initial value, it is automatically initialized.
+If the collection has no initial value, it is automatically initialized. `SortedSet` and `NavigableSet`
+use natural-order sorted storage by default, as do `SortedMap` and `NavigableMap`. Supply an explicit
+`TreeSet` or `TreeMap` initializer when the Schema needs a custom comparator; the completed model keeps
+that ordering in its read-only collection view.
 
 ### `keyMapping` for Simple Maps
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/common/CommonAstHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/common/CommonAstHelper.java
@@ -57,7 +57,10 @@ public class CommonAstHelper {
     public static final ClassNode[] NO_EXCEPTIONS = ClassNode.EMPTY_ARRAY;
     public static final FieldNode NO_SUCH_FIELD = new FieldNode(null, 0, null, null, null);
     public static final ClassNode COLLECTION_TYPE = makeWithoutCaching(Collection.class);
+    public static final ClassNode SORTED_SET_TYPE = makeWithoutCaching(SortedSet.class);
+    public static final ClassNode NAVIGABLE_SET_TYPE = makeWithoutCaching(NavigableSet.class);
     public static final ClassNode SORTED_MAP_TYPE = makeWithoutCaching(SortedMap.class);
+    public static final ClassNode NAVIGABLE_MAP_TYPE = makeWithoutCaching(NavigableMap.class);
     public static final ClassNode ENUM_SET_TYPE = makeWithoutCaching(EnumSet.class);
 
     public static AnnotationNode getAnnotation(AnnotatedNode target, ClassNode type) {
@@ -379,9 +382,11 @@ public class CommonAstHelper {
         ClassNode fieldType = fieldNode.getType();
         if (fieldType.equals(ENUM_SET_TYPE))
             initializeField(fieldNode, callX(ENUM_SET_TYPE, "noneOf", classX(getElementTypeForCollection(fieldType))));
+        else if (fieldType.equals(SORTED_SET_TYPE) || fieldType.equals(NAVIGABLE_SET_TYPE))
+            initializeField(fieldNode, ctorX(makeClassSafe(TreeSet.class)));
         else if (isCollection(fieldType))
             initializeField(fieldNode, asExpression(fieldType, new ListExpression()));
-        else if (fieldType.equals(SORTED_MAP_TYPE))
+        else if (fieldType.equals(SORTED_MAP_TYPE) || fieldType.equals(NAVIGABLE_MAP_TYPE))
             initializeField(fieldNode, ctorX(makeClassSafe(TreeMap.class)));
         else if (isMap(fieldType))
             initializeField(fieldNode, asExpression(fieldType, new MapExpression()));

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFirstSpec.groovy
@@ -400,6 +400,7 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         childBuilder.completedModel.is(instance.child)
     }
 
+    @Issue('664')
     def "materialization publishes independent read only collection snapshots"() {
         given:
         createClass '''
@@ -442,7 +443,9 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         instance.sortedMap.keySet().toList() == ["second", "first"]
         instance.navigableMap.keySet().toList() == ["second", "first"]
         instance.sortedSet.comparator().compare("first", "second") > 0
+        instance.navigableSet.comparator().compare("first", "second") > 0
         instance.sortedMap.comparator().compare("first", "second") > 0
+        instance.navigableMap.comparator().compare("first", "second") > 0
 
         and: "the snapshot no longer shares storage with its Builder"
         builder.list.add("builder-only")
@@ -467,6 +470,60 @@ class BuilderFirstSpec extends AbstractDSLSpec {
         ["list", "set", "sortedSet", "navigableSet", "map", "sortedMap", "navigableMap", "tones"].every {
             Modifier.isFinal(clazz.getDeclaredField(it).modifiers)
         }
+    }
+
+    @Issue('664')
+    def "implicit sorted collection defaults materialize as natural-order immutable views"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class ReleaseCatalog {
+                NavigableSet<String> validReleases
+                SortedSet<String> retiredReleases
+                SortedMap<String, String> compatibility
+                NavigableMap<String, String> releaseNotes
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            validReleases "4.0", "3.0"
+            retiredReleases "2.0", "1.0"
+            compatibility "4.0", "current"
+            compatibility "3.0", "legacy"
+            releaseNote "4.0", "current"
+            releaseNote "3.0", "legacy"
+        }
+
+        then:
+        instance.validReleases instanceof NavigableSet
+        instance.retiredReleases instanceof SortedSet
+        instance.compatibility instanceof SortedMap
+        instance.releaseNotes instanceof NavigableMap
+
+        and: "the concrete defaults retain natural ordering through materialization"
+        instance.validReleases.toList() == ["3.0", "4.0"]
+        instance.retiredReleases.toList() == ["1.0", "2.0"]
+        instance.compatibility.keySet().toList() == ["3.0", "4.0"]
+        instance.releaseNotes.keySet().toList() == ["3.0", "4.0"]
+        instance.validReleases.comparator() == null
+        instance.retiredReleases.comparator() == null
+        instance.compatibility.comparator() == null
+        instance.releaseNotes.comparator() == null
+
+        when: "a completed sorted collection view is mutated"
+        instance.validReleases.add("5.0")
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when: "a completed sorted map view is mutated"
+        instance.releaseNotes.put("5.0", "future")
+
+        then:
+        thrown(UnsupportedOperationException)
     }
 
     def "unsupported concrete collection declarations fail schema compilation"() {


### PR DESCRIPTION
## Summary

- initialize uninitialized `SortedSet`/`NavigableSet` fields with `TreeSet` and `SortedMap`/`NavigableMap` fields with `TreeMap`
- retain natural ordering and explicit comparator behavior through Builder-first materialization
- add focused regression coverage and document the corrected default behavior

## Root cause

The generic collection initialization path supplied list-like storage to supported sorted collection declarations. Materialization then expected sorted collection semantics and could call `ArrayList.comparator()`.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests`
- `./gradlew :klum-ast:groovy5Tests`
- local standards and specification review

Related: #664

Issue #664 remains open for normal review and delivery reconciliation.