### PR TITLE
Fix polymorphic Owner Builder types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,8 +36,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
-- Fixed polymorphic `@Owner` fields on types with `defaultImpl` to retain their declared public Builder type for ownership
-  matching, while ordinary relationship creation continues to select the default implementation ([#666](https://github.com/klum-dsl/klum-ast/issues/666)).
+- Fixed declared DSL relationship fields, including direct, collection, map, and `@Owner` fields, to retain their declared
+  public Builder type when a `defaultImpl` exists; ordinary relationship creation continues to select the default
+  implementation ([#666](https://github.com/klum-dsl/klum-ast/issues/666)).
 - Uninitialized `SortedSet`/`NavigableSet` and `SortedMap`/`NavigableMap` fields now receive their
   natural-order sorted defaults before Builder-first materialization. Their completed views remain
   sorted and immutable, while explicit `TreeSet`/`TreeMap` comparators continue to be preserved

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Fixed polymorphic `@Owner` fields on types with `defaultImpl` to retain their declared public Builder type for ownership
+  matching, while ordinary relationship creation continues to select the default implementation ([#666](https://github.com/klum-dsl/klum-ast/issues/666)).
 - Uninitialized `SortedSet`/`NavigableSet` and `SortedMap`/`NavigableMap` fields now receive their
   natural-order sorted defaults before Builder-first materialization. Their completed views remain
   sorted and immutable, while explicit `TreeSet`/`TreeMap` comparators continue to be preserved

--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -453,6 +453,9 @@ might be some corner cases where it is useful.
 
 `defaultImpl` can also be used on collections, maps and virtual fields.
 
+It selects the concrete type used for creation, but does not narrow `@Owner` matching: an owner declared with a polymorphic
+base type accepts matching subtype Builders.
+
 
 ### Collections of DSL Objects
 

--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -453,8 +453,9 @@ might be some corner cases where it is useful.
 
 `defaultImpl` can also be used on collections, maps and virtual fields.
 
-It selects the concrete type used for creation, but does not narrow `@Owner` matching: an owner declared with a polymorphic
-base type accepts matching subtype Builders.
+It selects the concrete type used for creation, but does not narrow Builder storage for a field declared as a DSL Object.
+Such a field, including collection and map values, retains its declared polymorphic Builder type for ownership and other
+Builder-time relationship handling.
 
 
 ### Collections of DSL Objects

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -478,7 +478,9 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
     private ClassNode getBuilderFieldType(FieldNode field) {
         ClassNode type = field.getType();
-        ClassNode effectiveValueType = getEffectiveFieldValueType(field);
+        ClassNode effectiveValueType = isOwnerField(field)
+                ? getDeclaredFieldValueType(field)
+                : getEffectiveFieldValueType(field);
         if (!isCollection(type) && !isMap(type) && isDSLObject(effectiveValueType))
             return getRwClassOf(effectiveValueType).getPlainNodeReference();
         if (isCollection(type) && isDSLObject(effectiveValueType))
@@ -493,6 +495,10 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     }
 
     private ClassNode getEffectiveFieldValueType(FieldNode field) {
+        return getDefaultImplOfFieldOrMethod(field, getDeclaredFieldValueType(field));
+    }
+
+    private ClassNode getDeclaredFieldValueType(FieldNode field) {
         ClassNode declaredValueType;
         if (isCollection(field.getType()))
             declaredValueType = getElementTypeForCollection(field.getType());
@@ -500,7 +506,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             declaredValueType = getElementTypeForMap(field.getType());
         else
             declaredValueType = field.getType();
-        return getDefaultImplOfFieldOrMethod(field, declaredValueType);
+        return declaredValueType;
     }
 
     FieldNode getBuilderField(FieldNode modelField) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -478,20 +478,23 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
     private ClassNode getBuilderFieldType(FieldNode field) {
         ClassNode type = field.getType();
-        ClassNode effectiveValueType = isOwnerField(field)
-                ? getDeclaredFieldValueType(field)
-                : getEffectiveFieldValueType(field);
-        if (!isCollection(type) && !isMap(type) && isDSLObject(effectiveValueType))
-            return getRwClassOf(effectiveValueType).getPlainNodeReference();
-        if (isCollection(type) && isDSLObject(effectiveValueType))
-            return makeClassSafeWithGenerics(type, new GenericsType(getRwClassOf(effectiveValueType).getPlainNodeReference()));
-        if (isMap(type) && isDSLObject(effectiveValueType))
+        ClassNode storageValueType = getBuilderStorageValueType(field);
+        if (!isCollection(type) && !isMap(type) && isDSLObject(storageValueType))
+            return getRwClassOf(storageValueType).getPlainNodeReference();
+        if (isCollection(type) && isDSLObject(storageValueType))
+            return makeClassSafeWithGenerics(type, new GenericsType(getRwClassOf(storageValueType).getPlainNodeReference()));
+        if (isMap(type) && isDSLObject(storageValueType))
                 return makeClassSafeWithGenerics(
                         type,
                         new GenericsType(getKeyTypeForMap(type)),
-                        new GenericsType(getRwClassOf(effectiveValueType).getPlainNodeReference())
+                        new GenericsType(getRwClassOf(storageValueType).getPlainNodeReference())
                 );
         return type;
+    }
+
+    private ClassNode getBuilderStorageValueType(FieldNode field) {
+        ClassNode declaredValueType = getDeclaredFieldValueType(field);
+        return isDSLObject(declaredValueType) ? declaredValueType : getEffectiveFieldValueType(field);
     }
 
     private ClassNode getEffectiveFieldValueType(FieldNode field) {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
@@ -45,10 +45,13 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
             @DSL
             class Catalog {
                 Product product
+                List<Product> products
+                Map<String, Product> productsByName
             }
 
             @DSL(defaultImpl = SingleProduct)
             abstract class Product {
+                @Key String name
             }
 
             @DSL
@@ -69,17 +72,22 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         def catalog = create("pk.Catalog") {
-            product {}
+            product("single") {}
         }
-        def subProduct = create("pk.SubProduct") {
+        def subProduct = create("pk.SubProduct", "sub") {
             mapping {}
         }
 
         then:
+        def productBuilder = getClass("pk.Product_DSL\$Builder")
+        def catalogBuilder = getClass("pk.Catalog\$Builder")
         catalog.product.class == getClass("pk.SingleProduct")
         subProduct.mapping.product.is(subProduct)
         subProduct.mapping.role == "mapping"
-        getClass("pk.Mapping\$Builder").getDeclaredField("product").type == getClass("pk.Product_DSL\$Builder")
+        getClass("pk.Mapping\$Builder").getDeclaredField("product").type == productBuilder
+        catalogBuilder.getDeclaredField("product").type == productBuilder
+        catalogBuilder.getDeclaredField("products").genericType.actualTypeArguments[0].rawType == productBuilder
+        catalogBuilder.getDeclaredField("productsByName").genericType.actualTypeArguments[1].rawType == productBuilder
     }
 
     @Issue("666")

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
@@ -36,6 +36,86 @@ import spock.lang.Issue
 @SuppressWarnings("GroovyAssignabilityCheck")
 class OwnerReferencesSpec extends AbstractDSLSpec {
 
+    @Issue("666")
+    def "polymorphic owner references retain their declared Builder type while creation uses defaultImpl"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Catalog {
+                Product product
+            }
+
+            @DSL(defaultImpl = SingleProduct)
+            abstract class Product {
+            }
+
+            @DSL
+            class SingleProduct extends Product {
+            }
+
+            @DSL
+            class SubProduct extends Product {
+                Mapping mapping
+            }
+
+            @DSL
+            class Mapping {
+                @Owner Product product
+                @Role(Product) String role
+            }
+        '''
+
+        when:
+        def catalog = create("pk.Catalog") {
+            product {}
+        }
+        def subProduct = create("pk.SubProduct") {
+            mapping {}
+        }
+
+        then:
+        catalog.product.class == getClass("pk.SingleProduct")
+        subProduct.mapping.product.is(subProduct)
+        subProduct.mapping.role == "mapping"
+        getClass("pk.Mapping\$Builder").getDeclaredField("product").type == getClass("pk.Product_DSL\$Builder")
+    }
+
+    @Issue("666")
+    def "inherited AutoCreate children receive their polymorphic subtype owner"() {
+        given:
+        createClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL(defaultImpl = SingleProduct)
+            abstract class Product {
+                @AutoCreate Mapping mapping
+            }
+
+            @DSL
+            class SingleProduct extends Product {
+            }
+
+            @DSL
+            class SubProduct extends Product {
+            }
+
+            @DSL
+            class Mapping {
+                @Owner Product product
+            }
+        '''
+
+        when:
+        def subProduct = create("pk.SubProduct")
+
+        then:
+        subProduct.mapping.product.is(subProduct)
+    }
+
     def "if owners is specified, no owner accessor is created"() {
         when:
         createClass('''

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/OwnerReferencesSpec.groovy
@@ -45,13 +45,10 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
             @DSL
             class Catalog {
                 Product product
-                List<Product> products
-                Map<String, Product> productsByName
             }
 
             @DSL(defaultImpl = SingleProduct)
             abstract class Product {
-                @Key String name
             }
 
             @DSL
@@ -72,19 +69,48 @@ class OwnerReferencesSpec extends AbstractDSLSpec {
 
         when:
         def catalog = create("pk.Catalog") {
-            product("single") {}
+            product {}
         }
-        def subProduct = create("pk.SubProduct", "sub") {
+        def subProduct = create("pk.SubProduct") {
             mapping {}
         }
 
         then:
         def productBuilder = getClass("pk.Product_DSL\$Builder")
-        def catalogBuilder = getClass("pk.Catalog\$Builder")
         catalog.product.class == getClass("pk.SingleProduct")
         subProduct.mapping.product.is(subProduct)
         subProduct.mapping.role == "mapping"
         getClass("pk.Mapping\$Builder").getDeclaredField("product").type == productBuilder
+    }
+
+    @Issue("666")
+    def "declared DSL relationship fields retain their public Builder type despite defaultImpl"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Catalog {
+                Product product
+                List<Product> products
+                Map<String, Product> productsByName
+            }
+
+            @DSL(defaultImpl = SingleProduct)
+            abstract class Product {
+                @Key String name
+            }
+
+            @DSL
+            class SingleProduct extends Product {
+            }
+        '''
+
+        when:
+        def catalogBuilder = getClass("pk.Catalog\$Builder")
+        def productBuilder = getClass("pk.Product_DSL\$Builder")
+
+        then:
         catalogBuilder.getDeclaredField("product").type == productBuilder
         catalogBuilder.getDeclaredField("products").genericType.actualTypeArguments[0].rawType == productBuilder
         catalogBuilder.getDeclaredField("productsByName").genericType.actualTypeArguments[1].rawType == productBuilder


### PR DESCRIPTION
## Summary

- Preserve declared public Builder storage types for direct, collection, map, and `@Owner` relationships whose declared value type is a DSL Object.
- Keep `defaultImpl` selection for generated factory creation.
- Add regression coverage for direct, collection, map, inherited AutoCreate, and `@Role` paths; update user and release documentation.

## Root cause

Builder-field generation used the effective `defaultImpl` type for storage. That narrowed a polymorphic declared DSL relationship to the default implementation Builder, even though creation selection and relationship identity have different type requirements.

## Scope

This does not define direct ordinary-value assignment for non-DSL interface implementations. That broader post-4.0 contract is tracked separately in #668.

## Validation

- Focused `OwnerReferencesSpec` in Groovy 3, 4, and 5
- Full `test groovy4Tests groovy5Tests`
- Local standards and specification reviews

Related: #666