### PR TITLE
Project qualified static model converters in Builder code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Qualified same-source static model converters now project to active-session Builders in relocated lifecycle and
+  mutator code, while ordinary root converter calls retain their completed-model result ([#662](https://github.com/klum-dsl/klum-ast/issues/662)).
+
 - Fixed declared DSL relationship fields, including direct, collection, map, and `@Owner` fields, to retain their declared
   public Builder type when a `defaultImpl` exists; ordinary relationship creation continues to select the default
   implementation ([#666](https://github.com/klum-dsl/klum-ast/issues/666)).

--- a/docs/user/Converters.md
+++ b/docs/user/Converters.md
@@ -93,6 +93,13 @@ assert server.endpoint.port == 8443
 For the Builder-projection rules, source-visibility boundary, and diagnostics for opaque producers, see
 [[Behind the Curtain#builder-projection-for-custom-producers]].
 
+Source-visible same-compilation converters also work in Builder lifecycle methods and in nested converter bodies. For
+example, `storage('uri://bla/blub', 'uri://bli/blu')` can select `Storage.fromStrings`, whose implementation calls
+qualified `Registry.fromString(...)` converters for its owned children. Builder-phase calls use active-session Builder
+twins; the same `Registry.fromString(...)` call outside Builder construction remains a completed-model factory.
+
+(See: `ConvertersDocumentaryTest#'uses fluent scalar converter syntax for an owned relationship'`.)
+
 A factory method is named `from*`, `of*`, or `parse*`; a non-DSL factory may also be named `create*`. Alternatively,
 annotate the method with `@Converter`.
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -53,14 +53,22 @@ import org.codehaus.groovy.ast.expr.PropertyExpression;
 import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.TupleExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.AssertStatement;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.CaseStatement;
+import org.codehaus.groovy.ast.stmt.CatchStatement;
+import org.codehaus.groovy.ast.stmt.DoWhileStatement;
 import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.ast.stmt.IfStatement;
 import org.codehaus.groovy.ast.stmt.ReturnStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.ast.stmt.SwitchStatement;
+import org.codehaus.groovy.ast.stmt.SynchronizedStatement;
 import org.codehaus.groovy.ast.stmt.ThrowStatement;
+import org.codehaus.groovy.ast.stmt.TryCatchStatement;
+import org.codehaus.groovy.ast.stmt.WhileStatement;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -421,6 +429,45 @@ public final class BuilderMethodProjection {
                 );
                 copy.setVariableScope(forStatement.getVariableScope());
                 result = copy;
+            } else if (source instanceof WhileStatement whileStatement) {
+                result = new WhileStatement(
+                        (BooleanExpression) transform(whileStatement.getBooleanExpression()),
+                        cloneStatement(whileStatement.getLoopBlock())
+                );
+            } else if (source instanceof DoWhileStatement doWhileStatement) {
+                result = new DoWhileStatement(
+                        (BooleanExpression) transform(doWhileStatement.getBooleanExpression()),
+                        cloneStatement(doWhileStatement.getLoopBlock())
+                );
+            } else if (source instanceof TryCatchStatement tryCatchStatement) {
+                TryCatchStatement copy = new TryCatchStatement(
+                        cloneStatement(tryCatchStatement.getTryStatement()),
+                        cloneStatement(tryCatchStatement.getFinallyStatement())
+                );
+                tryCatchStatement.getResourceStatements().forEach(resource ->
+                        copy.addResource((ExpressionStatement) cloneStatement(resource)));
+                tryCatchStatement.getCatchStatements().forEach(catchStatement ->
+                        copy.addCatch(cloneCatchStatement(catchStatement)));
+                result = copy;
+            } else if (source instanceof SwitchStatement switchStatement) {
+                List<CaseStatement> cases = switchStatement.getCaseStatements().stream()
+                        .map(this::cloneCaseStatement)
+                        .toList();
+                result = new SwitchStatement(
+                        transform(switchStatement.getExpression()),
+                        cases,
+                        cloneStatement(switchStatement.getDefaultStatement())
+                );
+            } else if (source instanceof SynchronizedStatement synchronizedStatement) {
+                result = new SynchronizedStatement(
+                        transform(synchronizedStatement.getExpression()),
+                        cloneStatement(synchronizedStatement.getCode())
+                );
+            } else if (source instanceof AssertStatement assertStatement) {
+                result = new AssertStatement(
+                        (BooleanExpression) transform(assertStatement.getBooleanExpression()),
+                        transform(assertStatement.getMessageExpression())
+                );
             } else if (source instanceof ThrowStatement throwStatement) {
                 result = new ThrowStatement(transform(throwStatement.getExpression()));
             } else if (source instanceof EmptyStatement) {
@@ -434,9 +481,32 @@ public final class BuilderMethodProjection {
             return result;
         }
 
+        private CatchStatement cloneCatchStatement(CatchStatement source) {
+            CatchStatement result = new CatchStatement(source.getVariable(), cloneStatement(source.getCode()));
+            result.setSourcePosition(source);
+            result.copyNodeMetaData(source);
+            result.copyStatementLabels(source);
+            return result;
+        }
+
+        private CaseStatement cloneCaseStatement(CaseStatement source) {
+            CaseStatement result = new CaseStatement(transform(source.getExpression()), cloneStatement(source.getCode()));
+            result.setSourcePosition(source);
+            result.copyNodeMetaData(source);
+            result.copyStatementLabels(source);
+            return result;
+        }
+
         @Override
         public Expression transform(Expression expression) {
             if (expression == null) return null;
+            if (expression instanceof ClosureExpression source) {
+                ClosureExpression result = new ClosureExpression(source.getParameters(), cloneStatement(source.getCode()));
+                result.setVariableScope(source.getVariableScope());
+                result.setSourcePosition(source);
+                result.copyNodeMetaData(source);
+                return result;
+            }
             if (expression instanceof StaticMethodCallExpression source) {
                 Expression arguments = transform(source.getArguments());
                 MethodNode twin = builderTwinFor(null, sourceClassFor(source.getOwnerType(), context), source.getMethod(), source.getArguments());

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -338,11 +338,6 @@ public final class BuilderMethodProjection {
                 .orElse(null);
     }
 
-    private static MethodNode builderTwinFor(MethodCallExpression call) {
-        if (!(call.getObjectExpression() instanceof ClassExpression owner)) return null;
-        return builderTwinFor(call.getMethodTarget(), owner.getType(), call.getMethodAsString(), call.getArguments());
-    }
-
     private static MethodNode builderTwinFor(MethodNode target, ClassNode owner, String name, Expression arguments) {
         if (target != null) {
             MethodNode twin = target.getNodeMetaData(TWIN_METADATA_KEY);
@@ -876,11 +871,10 @@ public final class BuilderMethodProjection {
          * source overload here; the hidden twin is then obtained exclusively from that MethodNode's metadata.
          */
         private MethodNode resolveOriginalSourceTarget(MethodCallExpression call) {
-            if (!call.isImplicitThis()) {
-                if (!(call.getObjectExpression() instanceof ClassExpression owner)
-                        || !owner.getType().redirect().equals(candidate.original.getDeclaringClass().redirect()))
-                    return null;
-            }
+            if (!call.isImplicitThis()
+                    && (!(call.getObjectExpression() instanceof ClassExpression owner)
+                    || !owner.getType().redirect().equals(candidate.original.getDeclaringClass().redirect())))
+                return null;
             return resolveOriginalSourceTarget(call.getMethodAsString(), call.getArguments());
         }
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -397,14 +397,9 @@ public final class BuilderMethodProjection {
         return true;
     }
 
-    private static final class BuilderPhaseProjectionTransformer implements ExpressionTransformer {
-        private final ClassNode context;
+    private abstract static class StatementCloner implements ExpressionTransformer {
 
-        private BuilderPhaseProjectionTransformer(ClassNode context) {
-            this.context = context;
-        }
-
-        private Statement cloneStatement(Statement source) {
+        protected final Statement cloneStatement(Statement source) {
             if (source == null) return null;
             Statement result;
             if (source instanceof BlockStatement block) {
@@ -473,11 +468,21 @@ public final class BuilderMethodProjection {
             } else if (source instanceof EmptyStatement) {
                 return source;
             } else {
-                return source;
+                return handleUnsupportedStatement(source);
             }
             result.setSourcePosition(source);
             result.copyNodeMetaData(source);
             result.copyStatementLabels(source);
+            return result;
+        }
+
+        protected abstract Statement handleUnsupportedStatement(Statement source);
+
+        protected final ClosureExpression cloneClosure(ClosureExpression source) {
+            ClosureExpression result = new ClosureExpression(source.getParameters(), cloneStatement(source.getCode()));
+            result.setVariableScope(source.getVariableScope());
+            result.setSourcePosition(source);
+            result.copyNodeMetaData(source);
             return result;
         }
 
@@ -496,16 +501,25 @@ public final class BuilderMethodProjection {
             result.copyStatementLabels(source);
             return result;
         }
+    }
+
+    private static final class BuilderPhaseProjectionTransformer extends StatementCloner {
+        private final ClassNode context;
+
+        private BuilderPhaseProjectionTransformer(ClassNode context) {
+            this.context = context;
+        }
+
+        @Override
+        protected Statement handleUnsupportedStatement(Statement source) {
+            return source;
+        }
 
         @Override
         public Expression transform(Expression expression) {
             if (expression == null) return null;
             if (expression instanceof ClosureExpression source) {
-                ClosureExpression result = new ClosureExpression(source.getParameters(), cloneStatement(source.getCode()));
-                result.setVariableScope(source.getVariableScope());
-                result.setSourcePosition(source);
-                result.copyNodeMetaData(source);
-                return result;
+                return cloneClosure(source);
             }
             if (expression instanceof StaticMethodCallExpression source) {
                 Expression arguments = transform(source.getArguments());
@@ -727,7 +741,7 @@ public final class BuilderMethodProjection {
         }
     }
 
-    private static final class ProjectionTransformer implements ExpressionTransformer {
+    private static final class ProjectionTransformer extends StatementCloner {
         private final ProjectionState state;
         private final Candidate candidate;
 
@@ -736,54 +750,17 @@ public final class BuilderMethodProjection {
             this.candidate = candidate;
         }
 
-        private Statement cloneStatement(Statement source) {
-            if (source == null) return null;
-            Statement result;
-            if (source instanceof BlockStatement block) {
-                List<Statement> statements = new ArrayList<>();
-                block.getStatements().forEach(statement -> statements.add(cloneStatement(statement)));
-                result = new BlockStatement(statements, block.getVariableScope());
-            } else if (source instanceof ReturnStatement returnStatement) {
-                result = new ReturnStatement(transform(returnStatement.getExpression()));
-            } else if (source instanceof ExpressionStatement expressionStatement) {
-                result = new ExpressionStatement(transform(expressionStatement.getExpression()));
-            } else if (source instanceof IfStatement ifStatement) {
-                result = new IfStatement(
-                        (BooleanExpression) transform(ifStatement.getBooleanExpression()),
-                        cloneStatement(ifStatement.getIfBlock()),
-                        cloneStatement(ifStatement.getElseBlock())
-                );
-            } else if (source instanceof ForStatement forStatement) {
-                ForStatement copy = new ForStatement(
-                        forStatement.getVariable(),
-                        transform(forStatement.getCollectionExpression()),
-                        cloneStatement(forStatement.getLoopBlock())
-                );
-                copy.setVariableScope(forStatement.getVariableScope());
-                result = copy;
-            } else if (source instanceof ThrowStatement throwStatement) {
-                result = new ThrowStatement(transform(throwStatement.getExpression()));
-            } else if (source instanceof EmptyStatement) {
-                return source;
-            } else {
-                candidate.opaque = true;
-                return source;
-            }
-            result.setSourcePosition(source);
-            result.copyNodeMetaData(source);
-            result.copyStatementLabels(source);
-            return result;
+        @Override
+        protected Statement handleUnsupportedStatement(Statement source) {
+            candidate.opaque = true;
+            return source;
         }
 
         @Override
         public Expression transform(Expression expression) {
             if (expression == null) return null;
             if (expression instanceof ClosureExpression source) {
-                ClosureExpression result = new ClosureExpression(source.getParameters(), cloneStatement(source.getCode()));
-                result.setVariableScope(source.getVariableScope());
-                result.setSourcePosition(source);
-                result.copyNodeMetaData(source);
-                return result;
+                return cloneClosure(source);
             }
             if (expression instanceof StaticMethodCallExpression source)
                 return transformStaticMethodCall(source);

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -911,37 +911,6 @@ public final class BuilderMethodProjection {
             return true;
         }
 
-        private static boolean acceptsArgumentCount(MethodNode method, int argumentCount) {
-            int required = (int) Arrays.stream(method.getParameters())
-                    .filter(parameter -> !parameter.hasInitialExpression())
-                    .count();
-            return argumentCount >= required && argumentCount <= method.getParameters().length;
-        }
-
-        private static int argumentCount(Expression arguments) {
-            return arguments instanceof TupleExpression tupleExpression ? tupleExpression.getExpressions().size() : 1;
-        }
-
-        private static boolean argumentsMatch(Parameter[] parameters, Expression arguments) {
-            if (!(arguments instanceof TupleExpression tupleExpression)) return parameters.length == 1;
-            List<Expression> expressions = tupleExpression.getExpressions();
-            if (parameters.length != expressions.size()) return false;
-            for (int index = 0; index < parameters.length; index++) {
-                Expression expression = expressions.get(index);
-                if (expression instanceof MapExpression
-                        && !isAssignableTo(ClassHelper.MAP_TYPE, parameters[index].getType()))
-                    return false;
-                if (expression instanceof ClosureExpression
-                        && !parameters[index].getType().equals(ClassHelper.CLOSURE_TYPE))
-                    return false;
-                ClassNode expressionType = expression.getType();
-                if (expressionType != null
-                        && !expressionType.equals(ClassHelper.OBJECT_TYPE)
-                        && !isAssignableTo(expressionType, parameters[index].getOriginType()))
-                    return false;
-            }
-            return true;
-        }
     }
 
     private static final class RootFactoryCall {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/BuilderMethodProjection.java
@@ -35,6 +35,8 @@ import groovyjarjarasm.asm.Opcodes;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
@@ -50,6 +52,7 @@ import org.codehaus.groovy.ast.expr.MapExpression;
 import org.codehaus.groovy.ast.expr.PropertyExpression;
 import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.TupleExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
@@ -74,6 +77,7 @@ import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.createG
 import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.copyAnnotationsFromSourceToTarget;
 import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.getKeyField;
 import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.isDSLObject;
+import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.addDelayedAction;
 import static com.blackbuild.klum.ast.compiler.internal.reflect.AstReflectionBridge.cloneParamsWithAdjustedNames;
 import static com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper.getElementTypeForCollection;
 import static com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper.getElementTypeForMap;
@@ -86,7 +90,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
 
 /** Generates and links source-visible Builder-producing method twins for ADR 0004. */
-final class BuilderMethodProjection {
+public final class BuilderMethodProjection {
 
     static final String TWIN_METADATA_KEY = BuilderMethodProjection.class.getName() + ".twin";
     static final String ORIGINAL_METADATA_KEY = BuilderMethodProjection.class.getName() + ".original";
@@ -195,7 +199,7 @@ final class BuilderMethodProjection {
     }
 
     static void ensureProjectedMethods(ClassNode sourceClass, ClassNode expectedModel) {
-        if (sourceClass == null || sourceClass.isResolved()) return;
+        if (sourceClass == null || (sourceClass.isResolved() && sourceClass.getModule() == null)) return;
 
         ProjectionState existing = sourceClass.redirect().getNodeMetaData(PROJECTION_STATE_METADATA_KEY);
         if (existing != null) return;
@@ -248,6 +252,221 @@ final class BuilderMethodProjection {
                     candidate.original.removeNodeMetaData(TWIN_METADATA_KEY);
                     candidate.twin.removeNodeMetaData(ORIGINAL_METADATA_KEY);
                 });
+    }
+
+    /**
+     * Rewrites qualified calls to source-visible static model converters after a method has moved to Builder code.
+     * The original source method is no longer callable in that phase because its completed-model result cannot be
+     * attached as owned composition.
+     */
+    public static void projectQualifiedStaticCallsInBuilderMethod(MethodNode method) {
+        if (method.getCode() == null) return;
+        ensureQualifiedStaticCallOwners(method);
+        scheduleProjectionAfterSourceTypeTransformation(method);
+        method.setCode(new BuilderPhaseProjectionTransformer(method.getDeclaringClass()).cloneStatement(method.getCode()));
+    }
+
+    private static void ensureQualifiedStaticCallOwners(MethodNode method) {
+        method.getCode().visit(new CodeVisitorSupport() {
+            @Override
+            public void visitMethodCallExpression(MethodCallExpression call) {
+                super.visitMethodCallExpression(call);
+                ClassNode owner = sourceClassFor(call.getObjectExpression(), method.getDeclaringClass());
+                if (owner != null)
+                    ensureProjectedMethods(owner, owner);
+            }
+
+            @Override
+            public void visitStaticMethodCallExpression(StaticMethodCallExpression call) {
+                super.visitStaticMethodCallExpression(call);
+                ensureProjectedMethods(sourceClassFor(call.getOwnerType(), method.getDeclaringClass()), call.getOwnerType());
+            }
+        });
+    }
+
+    private static void scheduleProjectionAfterSourceTypeTransformation(MethodNode method) {
+        Set<ClassNode> pendingOwners = Collections.newSetFromMap(new IdentityHashMap<>());
+        method.getCode().visit(new CodeVisitorSupport() {
+            @Override
+            public void visitMethodCallExpression(MethodCallExpression call) {
+                super.visitMethodCallExpression(call);
+                ClassNode owner = sourceClassFor(call.getObjectExpression(), method.getDeclaringClass());
+                if (owner != null && builderTwinFor(call.getMethodTarget(), owner,
+                        call.getMethodAsString(), call.getArguments()) == null)
+                    pendingOwners.add(owner.redirect());
+            }
+
+            @Override
+            public void visitStaticMethodCallExpression(StaticMethodCallExpression call) {
+                super.visitStaticMethodCallExpression(call);
+                ClassNode owner = sourceClassFor(call.getOwnerType(), method.getDeclaringClass());
+                if (builderTwinFor(null, owner, call.getMethod(), call.getArguments()) == null)
+                    pendingOwners.add(owner.redirect());
+            }
+        });
+        pendingOwners.forEach(owner -> addDelayedAction(owner, () ->
+                method.setCode(new BuilderPhaseProjectionTransformer(method.getDeclaringClass()).cloneStatement(method.getCode()))));
+    }
+
+    private static ClassNode sourceClassFor(ClassNode owner, ClassNode context) {
+        if (owner == null || context == null || context.getModule() == null) return owner;
+        return context.getModule().getClasses().stream()
+                .filter(candidate -> candidate.getName().equals(owner.getName()))
+                .findFirst()
+                .orElse(owner);
+    }
+
+    private static ClassNode sourceClassFor(Expression receiver, ClassNode context) {
+        if (receiver instanceof ClassExpression owner)
+            return sourceClassFor(owner.getType(), context);
+        if (!(receiver instanceof VariableExpression variable)
+                || !(variable.getAccessedVariable() instanceof DynamicVariable)
+                || context == null
+                || context.getModule() == null)
+            return null;
+        return context.getModule().getClasses().stream()
+                .filter(candidate -> candidate.getNameWithoutPackage().equals(variable.getName()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static MethodNode builderTwinFor(MethodCallExpression call) {
+        if (!(call.getObjectExpression() instanceof ClassExpression owner)) return null;
+        return builderTwinFor(call.getMethodTarget(), owner.getType(), call.getMethodAsString(), call.getArguments());
+    }
+
+    private static MethodNode builderTwinFor(MethodNode target, ClassNode owner, String name, Expression arguments) {
+        if (target != null) {
+            MethodNode twin = target.getNodeMetaData(TWIN_METADATA_KEY);
+            if (twin != null) return twin;
+        }
+        if (owner == null) return null;
+
+        List<MethodNode> candidates = owner.getMethods(name).stream()
+                .filter(MethodNode::isStatic)
+                .filter(method -> method.getDeclaringClass().redirect().equals(owner.redirect()))
+                .filter(method -> method.getNodeMetaData(TWIN_METADATA_KEY) != null)
+                .filter(method -> acceptsArgumentCount(method, argumentCount(arguments)))
+                .toList();
+        if (candidates.size() == 1) return candidates.get(0).getNodeMetaData(TWIN_METADATA_KEY);
+
+        return candidates.stream()
+                .filter(method -> argumentsMatch(method.getParameters(), arguments))
+                .map(method -> (MethodNode) method.getNodeMetaData(TWIN_METADATA_KEY))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean acceptsArgumentCount(MethodNode method, int argumentCount) {
+        int required = (int) Arrays.stream(method.getParameters())
+                .filter(parameter -> !parameter.hasInitialExpression())
+                .count();
+        return argumentCount >= required && argumentCount <= method.getParameters().length;
+    }
+
+    private static int argumentCount(Expression arguments) {
+        return arguments instanceof TupleExpression tupleExpression ? tupleExpression.getExpressions().size() : 1;
+    }
+
+    private static boolean argumentsMatch(Parameter[] parameters, Expression arguments) {
+        if (!(arguments instanceof TupleExpression tupleExpression)) return parameters.length == 1;
+        List<Expression> expressions = tupleExpression.getExpressions();
+        if (parameters.length != expressions.size()) return false;
+        for (int index = 0; index < parameters.length; index++) {
+            Expression expression = expressions.get(index);
+            if (expression instanceof MapExpression
+                    && !isAssignableTo(ClassHelper.MAP_TYPE, parameters[index].getType()))
+                return false;
+            if (expression instanceof ClosureExpression
+                    && !parameters[index].getType().equals(ClassHelper.CLOSURE_TYPE))
+                return false;
+            ClassNode expressionType = expression.getType();
+            if (expressionType != null
+                    && !expressionType.equals(ClassHelper.OBJECT_TYPE)
+                    && !isAssignableTo(expressionType, parameters[index].getOriginType()))
+                return false;
+        }
+        return true;
+    }
+
+    private static final class BuilderPhaseProjectionTransformer implements ExpressionTransformer {
+        private final ClassNode context;
+
+        private BuilderPhaseProjectionTransformer(ClassNode context) {
+            this.context = context;
+        }
+
+        private Statement cloneStatement(Statement source) {
+            if (source == null) return null;
+            Statement result;
+            if (source instanceof BlockStatement block) {
+                List<Statement> statements = new ArrayList<>();
+                block.getStatements().forEach(statement -> statements.add(cloneStatement(statement)));
+                result = new BlockStatement(statements, block.getVariableScope());
+            } else if (source instanceof ReturnStatement returnStatement) {
+                result = new ReturnStatement(transform(returnStatement.getExpression()));
+            } else if (source instanceof ExpressionStatement expressionStatement) {
+                result = new ExpressionStatement(transform(expressionStatement.getExpression()));
+            } else if (source instanceof IfStatement ifStatement) {
+                result = new IfStatement(
+                        (BooleanExpression) transform(ifStatement.getBooleanExpression()),
+                        cloneStatement(ifStatement.getIfBlock()),
+                        cloneStatement(ifStatement.getElseBlock())
+                );
+            } else if (source instanceof ForStatement forStatement) {
+                ForStatement copy = new ForStatement(
+                        forStatement.getVariable(),
+                        transform(forStatement.getCollectionExpression()),
+                        cloneStatement(forStatement.getLoopBlock())
+                );
+                copy.setVariableScope(forStatement.getVariableScope());
+                result = copy;
+            } else if (source instanceof ThrowStatement throwStatement) {
+                result = new ThrowStatement(transform(throwStatement.getExpression()));
+            } else if (source instanceof EmptyStatement) {
+                return source;
+            } else {
+                return source;
+            }
+            result.setSourcePosition(source);
+            result.copyNodeMetaData(source);
+            result.copyStatementLabels(source);
+            return result;
+        }
+
+        @Override
+        public Expression transform(Expression expression) {
+            if (expression == null) return null;
+            if (expression instanceof StaticMethodCallExpression source) {
+                Expression arguments = transform(source.getArguments());
+                MethodNode twin = builderTwinFor(null, sourceClassFor(source.getOwnerType(), context), source.getMethod(), source.getArguments());
+                if (twin == null) {
+                    StaticMethodCallExpression result = new StaticMethodCallExpression(
+                            source.getOwnerType(), source.getMethod(), arguments);
+                    result.setSourcePosition(source);
+                    result.copyNodeMetaData(source);
+                    return result;
+                }
+                MethodCallExpression result = new MethodCallExpression(
+                        classX(source.getOwnerType()), new ConstantExpression(twin.getName()), arguments);
+                result.setImplicitThis(false);
+                result.setType(source.getType());
+                result.setSourcePosition(source);
+                result.copyNodeMetaData(source);
+                return result;
+            }
+            if (expression instanceof MethodCallExpression source) {
+                MethodCallExpression result = (MethodCallExpression) source.transformExpression(this);
+                ClassNode owner = sourceClassFor(source.getObjectExpression(), context);
+                MethodNode twin = owner == null ? null
+                        : builderTwinFor(source.getMethodTarget(), owner, source.getMethodAsString(), source.getArguments());
+                if (twin == null) return result;
+                result.setMethod(new ConstantExpression(twin.getName()));
+                result.setType(source.getType());
+                return result;
+            }
+            return expression.transformExpression(this);
+        }
     }
 
     private static MethodNode createTwinShell(MethodNode source, ClassNode expectedModel) {
@@ -511,6 +730,14 @@ final class BuilderMethodProjection {
                 return result;
             }
 
+            MethodNode externalTwin = findQualifiedBuilderTwin(source);
+            if (externalTwin != null) {
+                candidate.directBuilderCall = true;
+                result.setMethod(new ConstantExpression(externalTwin.getName()));
+                result.setMethodTarget(externalTwin);
+                return result;
+            }
+
             RootFactoryCall rootCall = findRootFactoryCall(source);
             if (rootCall != null) {
                 MethodNode builderMethod = findBuilderFactoryMethod(source, rootCall.model);
@@ -541,7 +768,16 @@ final class BuilderMethodProjection {
             StaticMethodCallExpression result = (StaticMethodCallExpression) source.transformExpression(this);
 
             Candidate dependency = findDependency(source);
-            if (dependency == null) return result;
+            if (dependency == null) {
+                MethodNode externalTwin = findQualifiedBuilderTwin(source);
+                if (externalTwin == null) return result;
+                candidate.directBuilderCall = true;
+                StaticMethodCallExpression projected = new StaticMethodCallExpression(
+                        source.getOwnerType(), externalTwin.getName(), result.getArguments());
+                projected.setSourcePosition(source);
+                projected.copyNodeMetaData(source);
+                return projected;
+            }
 
             candidate.dependencies.add(dependency);
             StaticMethodCallExpression projected = new StaticMethodCallExpression(
@@ -575,12 +811,29 @@ final class BuilderMethodProjection {
             return resolvedOriginal == null ? null : state.candidateFor(resolvedOriginal);
         }
 
+        private MethodNode findQualifiedBuilderTwin(MethodCallExpression call) {
+            if (!(call.getObjectExpression() instanceof ClassExpression owner)) return null;
+            ClassNode sourceOwner = sourceClassFor(owner.getType(), candidate.original.getDeclaringClass());
+            ensureProjectedMethods(sourceOwner, sourceOwner);
+            return builderTwinFor(call.getMethodTarget(), sourceOwner, call.getMethodAsString(), call.getArguments());
+        }
+
+        private MethodNode findQualifiedBuilderTwin(StaticMethodCallExpression call) {
+            ClassNode sourceOwner = sourceClassFor(call.getOwnerType(), candidate.original.getDeclaringClass());
+            ensureProjectedMethods(sourceOwner, sourceOwner);
+            return builderTwinFor(null, sourceOwner, call.getMethod(), call.getArguments());
+        }
+
         /**
          * Dynamic Groovy source calls do not always have a MethodNode target yet. Resolve only the original
          * source overload here; the hidden twin is then obtained exclusively from that MethodNode's metadata.
          */
         private MethodNode resolveOriginalSourceTarget(MethodCallExpression call) {
-            if (!call.isImplicitThis()) return null;
+            if (!call.isImplicitThis()) {
+                if (!(call.getObjectExpression() instanceof ClassExpression owner)
+                        || !owner.getType().redirect().equals(candidate.original.getDeclaringClass().redirect()))
+                    return null;
+            }
             return resolveOriginalSourceTarget(call.getMethodAsString(), call.getArguments());
         }
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -93,6 +93,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     private static final String ADD_ELEMENT_TO_COLLECTION = "addElementToCollection";
     private static final String ADD_ELEMENT_TO_MAP = "addElementToMap";
     private static final String ADD_NEW_DSL_ELEMENT_TO_MAP = "addNewDslElementToMap";
+    private static final String SET_SINGLE_FIELD = "setSingleField";
     private static final String CREATE_SINGLE_CHILD = "createSingleChild";
     private static final String FACTORY_NAME = "factory";
     private static final String SCHEDULE_APPLY_LATER = "scheduleApplyLater";
@@ -928,7 +929,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         int visibility = DslAstHelper.isProtected(fieldNode) ? ACC_PROTECTED : ACC_PUBLIC;
         String fieldName = fieldNode.getName();
 
-        createProxyMethod(fieldName, "setSingleField")
+        createProxyMethod(fieldName, SET_SINGLE_FIELD)
                 .optional()
                 .returning(fieldNode.getType(), "The set value")
                 .mod(visibility)
@@ -939,7 +940,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 .addTo(rwClass);
 
         if (isDSLObject(fieldNode.getType())) {
-            createProxyMethod(fieldName, "setSingleField")
+            createProxyMethod(fieldName, SET_SINGLE_FIELD)
                     .optional()
                     .returning(makeClassSafeWithGenerics(KlumBuilder.class, fieldNode.getType()), "The set Builder value")
                     .mod(visibility)
@@ -950,7 +951,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         }
 
         if (fieldNode.getType().equals(ClassHelper.boolean_TYPE)) {
-            createProxyMethod(fieldName, "setSingleField")
+            createProxyMethod(fieldName, SET_SINGLE_FIELD)
                     .optional()
                     .returning(Boolean_TYPE, "always true")
                     .mod(visibility)

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -938,6 +938,17 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 .decoratedParam(fieldNode, "value", "the value to set")
                 .addTo(rwClass);
 
+        if (isDSLObject(fieldNode.getType())) {
+            createProxyMethod(fieldName, "setSingleField")
+                    .optional()
+                    .returning(makeClassSafeWithGenerics(KlumBuilder.class, fieldNode.getType()), "The set Builder value")
+                    .mod(visibility)
+                    .linkToField(fieldNode)
+                    .constantParam(fieldName)
+                    .param(makeClassSafeWithGenerics(KlumBuilder.class, fieldNode.getType()), "value", "the Builder value to set")
+                    .addTo(rwClass);
+        }
+
         if (fieldNode.getType().equals(ClassHelper.boolean_TYPE)) {
             createProxyMethod(fieldName, "setSingleField")
                     .optional()

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/WriteAccessMethodsMover.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/mutators/WriteAccessMethodsMover.java
@@ -26,6 +26,7 @@ package com.blackbuild.klum.ast.compiler.internal.ast.mutators;
 import com.blackbuild.klum.ast.FieldType;
 import com.blackbuild.klum.ast.Owner;
 import com.blackbuild.klum.ast.WriteAccess;
+import com.blackbuild.klum.ast.compiler.internal.ast.BuilderMethodProjection;
 import com.blackbuild.klum.ast.compiler.internal.ast.DSLASTTransformation;
 import com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper;
 import com.blackbuild.klum.ast.compiler.internal.common.CommonAstHelper;
@@ -70,6 +71,7 @@ public class WriteAccessMethodsMover {
     static void moveMethodFromModelToRWClass(MethodNode method) {
         ClassNode declaringClass = method.getDeclaringClass();
         ClassNode rwClass = declaringClass.getNodeMetaData(DSLASTTransformation.RWCLASS_METADATA_KEY);
+        BuilderMethodProjection.projectQualifiedStaticCallsInBuilderMethod(method);
         retargetOwnerParameters(method);
         retargetVirtualFieldParameter(method);
         retargetFieldVariables(method, rwClass);

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -187,6 +187,50 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
         instance.mutations.source == 'mutator'
     }
 
+    @Issue("662")
+    def "qualified static converters project through Builder method control flow"() {
+        given:
+        createClass '''
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL class Root {
+                Registry docs
+                Registry defaults
+
+                @AutoCreate
+                void createDocs() {
+                    try {
+                        docs Registry.fromString('try')
+                    } catch (RuntimeException ignored) {
+                        docs Registry.fromString('catch')
+                    }
+                }
+
+                @Default
+                void createDefaults() {
+                    while (!defaults) {
+                        defaults Registry.fromString('while')
+                    }
+                }
+            }
+
+            @DSL class Registry {
+                String source
+
+                static Registry fromString(String value) {
+                    return Registry.Create.With(source: value)
+                }
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With()
+
+        then:
+        instance.docs.source == 'try'
+        instance.defaults.source == 'while'
+    }
+
     @Issue("642")
     def "unqualified static recursive converters project relationship overloads"() {
         given:
@@ -544,6 +588,89 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
         clazz.Create.With { child 'nested' }
 
         then:
+        def error = thrown(KlumModelException)
+        error.message.contains('omitted Builder-producing projection child(java.lang.String)')
+        error.message.contains('active-session Create.AsBuilder')
+    }
+
+    @Issue("662")
+    def "qualified opaque converter calls in Builder methods retain the root factory rejection"() {
+        given:
+        createClass '''
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL class Root {
+                Child child
+
+                @AutoCreate
+                void createChild() {
+                    child Child.fromString('nested')
+                }
+            }
+
+            @DSL class Child {
+                String value
+
+                static Child fromString(String value) {
+                    return materialize(value)
+                }
+
+                private static Child materialize(String value) {
+                    return Child.Create.With(value: value)
+                }
+            }
+        '''
+
+        expect: 'the opaque source converter remains a completed-model factory at the root'
+        getClass('Child').fromString('root').value == 'root'
+
+        when:
+        clazz.Create.With()
+
+        then: 'the unavailable twin cannot start an independent model factory during Builder execution'
+        def error = thrown(RuntimeException)
+        error.message.contains('Cannot start an independent DSL Object factory while a Builder lifecycle is active')
+    }
+
+    @Issue("662")
+    def "qualified precompiled converter calls are omitted from Builder projection"() {
+        given: 'the converter type is already compiled and has no active-session AST twin'
+        createSecondaryClass '''
+            package external
+
+            class Converters {
+                static Object fromString(String value) {
+                    return Class.forName('Child').Create.With(value: value)
+                }
+            }
+        '''
+
+        createClass '''
+            import external.Converters
+
+            @DSL class Root {
+                Child child
+            }
+
+            @DSL class Child {
+                String value
+
+                static Child fromString(String value) {
+                    return (Child) Converters.fromString(value)
+                }
+            }
+        '''
+
+        expect: 'the precompiled converter remains an ordinary completed-model factory'
+        getClass('Child').fromString('root').value == 'root'
+
+        and: 'the relationship surface does not advertise an unavailable Builder-producing twin'
+        !rwClazz.methods.any { it.name == 'child' && it.parameterTypes.toList() == [String] }
+
+        when:
+        clazz.Create.With { child 'nested' }
+
+        then: 'the dynamic relationship call retains the established projection guidance'
         def error = thrown(KlumModelException)
         error.message.contains('omitted Builder-producing projection child(java.lang.String)')
         error.message.contains('active-session Create.AsBuilder')

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -196,6 +196,11 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
             @DSL class Root {
                 Registry docs
                 Registry defaults
+                Registry finallyDocs
+                Registry doWhileDocs
+                Registry switchDocs
+                Registry synchronizedDocs
+                Registry closureDocs
 
                 @AutoCreate
                 void createDocs() {
@@ -203,6 +208,8 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
                         docs Registry.fromString('try')
                     } catch (RuntimeException ignored) {
                         docs Registry.fromString('catch')
+                    } finally {
+                        finallyDocs Registry.fromString('finally')
                     }
                 }
 
@@ -211,6 +218,24 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
                     while (!defaults) {
                         defaults Registry.fromString('while')
                     }
+                    do {
+                        doWhileDocs Registry.fromString('do-while')
+                    } while (false)
+                    switch (defaults.source) {
+                        case 'while':
+                            switchDocs Registry.fromString('switch')
+                            break
+                        default:
+                            switchDocs Registry.fromString('default')
+                    }
+                    synchronized (this) {
+                        synchronizedDocs Registry.fromString('synchronized')
+                    }
+                    assert defaults.source == 'while'
+                    def configure = {
+                        closureDocs Registry.fromString('closure')
+                    }
+                    configure()
                 }
             }
 
@@ -229,6 +254,11 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
         then:
         instance.docs.source == 'try'
         instance.defaults.source == 'while'
+        instance.finallyDocs.source == 'finally'
+        instance.doWhileDocs.source == 'do-while'
+        instance.switchDocs.source == 'switch'
+        instance.synchronizedDocs.source == 'synchronized'
+        instance.closureDocs.source == 'closure'
     }
 
     @Issue("642")

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -200,6 +200,7 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
                 Registry doWhileDocs
                 Registry switchDocs
                 Registry synchronizedDocs
+                Registry assertionDocs
                 Registry closureDocs
 
                 @AutoCreate
@@ -231,7 +232,7 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
                     synchronized (this) {
                         synchronizedDocs Registry.fromString('synchronized')
                     }
-                    assert defaults.source == 'while'
+                    assert assertionDocs(Registry.fromString('assert'))
                     def configure = {
                         closureDocs Registry.fromString('closure')
                     }
@@ -258,6 +259,7 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
         instance.doWhileDocs.source == 'do-while'
         instance.switchDocs.source == 'switch'
         instance.synchronizedDocs.source == 'synchronized'
+        instance.assertionDocs.source == 'assert'
         instance.closureDocs.source == 'closure'
     }
 

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -633,47 +633,44 @@ class BuilderProjectionSpec extends AbstractDSLSpec {
     }
 
     @Issue("662")
-    def "qualified precompiled converter calls are omitted from Builder projection"() {
+    def "qualified precompiled converter calls in Builder methods retain the root factory rejection"() {
         given: 'the converter type is already compiled and has no active-session AST twin'
         createSecondaryClass '''
             package external
 
-            class Converters {
-                static Object fromString(String value) {
-                    return Class.forName('Child').Create.With(value: value)
+            @DSL class PrecompiledChild {
+                String value
+
+                static PrecompiledChild fromString(String value) {
+                    return PrecompiledChild.Create.With(value: value)
                 }
             }
         '''
 
         createClass '''
-            import external.Converters
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+            import groovy.transform.TypeChecked
+            import groovy.transform.TypeCheckingMode
+            import external.PrecompiledChild
 
             @DSL class Root {
-                Child child
-            }
-
-            @DSL class Child {
-                String value
-
-                static Child fromString(String value) {
-                    return (Child) Converters.fromString(value)
+                @AutoCreate
+                @TypeChecked(TypeCheckingMode.SKIP)
+                void createChild() {
+                    PrecompiledChild.fromString('nested')
                 }
             }
         '''
 
-        expect: 'the precompiled converter remains an ordinary completed-model factory'
-        getClass('Child').fromString('root').value == 'root'
-
-        and: 'the relationship surface does not advertise an unavailable Builder-producing twin'
-        !rwClazz.methods.any { it.name == 'child' && it.parameterTypes.toList() == [String] }
+        expect: 'the precompiled converter remains an ordinary completed-model factory at the root'
+        getClass('external.PrecompiledChild').fromString('root').value == 'root'
 
         when:
-        clazz.Create.With { child 'nested' }
+        clazz.Create.With()
 
-        then: 'the dynamic relationship call retains the established projection guidance'
-        def error = thrown(KlumModelException)
-        error.message.contains('omitted Builder-producing projection child(java.lang.String)')
-        error.message.contains('active-session Create.AsBuilder')
+        then: 'the unavailable precompiled twin cannot start an independent factory during Builder execution'
+        def error = thrown(RuntimeException)
+        error.message.contains('Cannot start an independent DSL Object factory while a Builder lifecycle is active')
     }
 
     def "unrelated unknown dynamic name remains an ordinary MissingMethodException"() {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionSpec.groovy
@@ -33,6 +33,160 @@ import spock.lang.Issue
 
 class BuilderProjectionSpec extends AbstractDSLSpec {
 
+    @Issue("662")
+    def "qualified static recursive converters project scalar relationship overloads"() {
+        given:
+        createClass '''
+            import java.net.URL
+
+            @DSL class Root {
+                Registry registry
+            }
+
+            @DSL class Registry {
+                String source
+
+                static Registry fromString(String value) {
+                    return Registry.fromStrings(value)
+                }
+
+                static Registry fromStrings(String value) {
+                    return Registry.Create.With(source: "string:${value}")
+                }
+
+                static Registry fromString(URL value) {
+                    return Registry.fromStrings(value)
+                }
+
+                static Registry fromStrings(URL value) {
+                    return Registry.Create.With(source: "url:${value}")
+                }
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            registry 'one'
+        }
+
+        then:
+        instance.registry.source == 'string:one'
+
+        when:
+        instance = clazz.Create.With {
+            registry new URL('https://example.test/two')
+        }
+
+        then:
+        instance.registry.source == 'url:https://example.test/two'
+
+        and: 'direct root calls retain their completed-model contract'
+        getClass('Registry').fromString('root').source == 'string:root'
+    }
+
+    @Issue("662")
+    def "nested qualified converters preserve keyed single collection and map relationships"() {
+        given:
+        createClass '''
+            import java.net.URI
+
+            @DSL class Root {
+                Storage primary
+                List<Storage> secondaryStorages
+                Map<String, Storage> storages
+            }
+
+            @DSL class Registry {
+                URI uri
+
+                static Registry fromString(String value) {
+                    return Registry.Create.With(uri: new URI(value))
+                }
+            }
+
+            @DSL class Storage {
+                @Key String name
+                Registry source
+                Registry target
+
+                static Storage fromStrings(String name, String source, String target) {
+                    return Storage.Create.With(
+                            name,
+                            source: Registry.fromString(source),
+                            target: Registry.fromString(target)
+                    )
+                }
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            primary 'primary', 'uri://primary/source', 'uri://primary/target'
+            secondaryStorage 'secondary', 'uri://secondary/source', 'uri://secondary/target'
+            storage 'named', 'uri://named/source', 'uri://named/target'
+        }
+
+        then:
+        instance.primary.name == 'primary'
+        instance.primary.source.uri == new URI('uri://primary/source')
+        instance.secondaryStorages*.name == ['secondary']
+        instance.secondaryStorages*.target.uri == [new URI('uri://secondary/target')]
+        instance.storages.keySet() == ['named'] as Set
+        instance.storages['named'].name == 'named'
+        instance.storages['named'].source.uri == new URI('uri://named/source')
+    }
+
+    @Issue("662")
+    def "qualified static converters project into relocated Builder methods"() {
+        given:
+        createClass '''
+            import com.blackbuild.klum.ast.layer3.AutoCreate
+
+            @DSL class Root {
+                Registry docs
+                Registry defaults
+                Registry mutations
+
+                @AutoCreate
+                void createDocs() {
+                    docs Registry.fromString('auto')
+                }
+
+                @Default
+                void createDefaults() {
+                    defaults Registry.fromString('default')
+                }
+
+                @Mutator
+                void setMutation(String value) {
+                    mutations Registry.fromString(value)
+                }
+            }
+
+            @DSL class Registry {
+                String source
+
+                static Registry fromString(String value) {
+                    return Registry.fromStrings(value)
+                }
+
+                static Registry fromStrings(String value) {
+                    return Registry.Create.With(source: value)
+                }
+            }
+        '''
+
+        when:
+        instance = clazz.Create.With {
+            setMutation 'mutator'
+        }
+
+        then:
+        instance.docs.source == 'auto'
+        instance.defaults.source == 'default'
+        instance.mutations.source == 'mutator'
+    }
+
     @Issue("642")
     def "unqualified static recursive converters project relationship overloads"() {
         given:

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/ConvertersDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/ConvertersDocumentaryTest.groovy
@@ -30,6 +30,36 @@ import spock.lang.Tag
 @Tag("documentary")
 class ConvertersDocumentaryTest extends AbstractDSLSpec {
 
+    @Issue("662")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Converters.md#factory-method-converters")
+    def "uses fluent scalar converter syntax for an owned relationship"() {
+        given:
+        createClass '''
+            import java.net.URI
+
+            @DSL class Root { Storage storage }
+            @DSL class Registry {
+                URI uri
+                static Registry fromString(String value) { Registry.Create.With(uri: new URI(value)) }
+            }
+            @DSL class Storage {
+                Registry source
+                Registry target
+                static Storage fromStrings(String source, String target) {
+                    Storage.Create.With(
+                        source: Registry.fromString(source),
+                        target: Registry.fromString(target)
+                    )
+                }
+            }
+        '''
+        when:
+        def root = clazz.Create.With { storage('uri://bla/blub', 'uri://bli/blu') }
+        then:
+        root.storage.source.uri == new URI('uri://bla/blub')
+        root.storage.target.uri == new URI('uri://bli/blu')
+    }
+
     @Issue("148")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Converters.md#field-based-converters")
     def "converts timestamp input for a simple field and map entry"() {


### PR DESCRIPTION
## Summary

Projects source-visible, same-compilation qualified static model converters to Builder-producing twins in relocated Builder-phase code and recursive generated twin bodies.

Adds coverage for fluent scalar, keyed, collection, map, nested URI conversion, lifecycle methods, overload selection, opaque and precompiled boundaries, plus documentary and release-facing documentation.

## Validation

- `./gradlew :klum-ast:test`
- `./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests`
- Local standards and specification reviews

Related: #662

This pull request intentionally leaves issue state unchanged.