### PR TITLE
Extend Pages deployment timeout

### DIFF
--- a/.github/workflows/publish-pending-documentation.yml
+++ b/.github/workflows/publish-pending-documentation.yml
@@ -278,7 +278,10 @@ jobs:
     name: Deploy the protected gh-pages ledger
     needs: publish-pending
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Pages can remain queued while GitHub provisions a deployment. Keep this
+    # longer than the action's polling budget so a transient queue does not
+    # reject an otherwise valid, immutable release candidate stage.
+    timeout-minutes: 35
     permissions:
       pages: write
       id-token: write
@@ -292,6 +295,10 @@ jobs:
       - id: deployment
         name: Deploy the uploaded static site to GitHub Pages
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        with:
+          # actions/deploy-pages defaults to ten minutes, which is too short
+          # for a delayed Pages deployment queue.
+          timeout: 1800000
 
   retain-rejected-evidence:
     name: Retain rejected pending-stage evidence


### PR DESCRIPTION
## Summary

- extend the protected Pages deployment job to 35 minutes
- give actions/deploy-pages 30 minutes to wait through a delayed Pages queue

The change preserves the immutable pending-stage policy while avoiding rejection solely from the action's default 10-minute polling timeout.

## Validation

- YAML parse
- git diff --check
- ./gradlew --no-daemon check --console=plain