### PR TITLE
Add read-only GitHub Pages deployment probe

### DIFF
--- a/.github/workflows/probe-pages-deployment.yml
+++ b/.github/workflows/probe-pages-deployment.yml
@@ -1,0 +1,198 @@
+name: Probe GitHub Pages deployment
+
+on:
+  workflow_dispatch:
+
+# This workflow is deliberately diagnostic only. It deploys an unchanged,
+# read-only snapshot of the existing Pages ledger; it does not render, publish,
+# tag, or release anything.
+permissions:
+  contents: read
+
+# Serialize with the protected pending-documentation path so this probe cannot
+# race a release-stage ledger update.
+concurrency:
+  group: pending-documentation-gh-pages
+  cancel-in-progress: false
+
+jobs:
+  snapshot-ledger:
+    name: Snapshot trusted source and Pages ledger
+    runs-on: ubuntu-latest
+    outputs:
+      source_commit: ${{ steps.source.outputs.commit }}
+      ledger_commit: ${{ steps.ledger.outputs.commit }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - id: source
+        name: Require the current trusted master source
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/master
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_COMMIT"
+          test "$(git rev-parse origin/master)" = "$EXPECTED_SOURCE_COMMIT"
+          test -z "$(git status --porcelain=v1)"
+          echo "commit=$EXPECTED_SOURCE_COMMIT" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: gh-pages
+          path: pages
+          persist-credentials: false
+      - id: ledger
+        name: Snapshot the unchanged gh-pages ledger
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f pages/.nojekyll
+          test -z "$(git -C pages status --porcelain=v1)"
+          ledger_commit=$(git -C pages rev-parse HEAD)
+          git -C pages fetch --no-tags origin gh-pages
+          test "$(git -C pages rev-parse FETCH_HEAD)" = "$ledger_commit"
+          git -C pages diff --quiet HEAD FETCH_HEAD
+          echo "commit=$ledger_commit" >> "$GITHUB_OUTPUT"
+
+  upload-probe:
+    name: Upload the unchanged Pages ledger as a probe artifact
+    needs: snapshot-ledger
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: gh-pages
+          path: pages
+          persist-credentials: false
+      - name: Recheck the snapshotted Pages ledger before artifact upload
+        env:
+          EXPECTED_LEDGER_COMMIT: ${{ needs.snapshot-ledger.outputs.ledger_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f pages/.nojekyll
+          test "$(git -C pages rev-parse HEAD)" = "$EXPECTED_LEDGER_COMMIT"
+          test -z "$(git -C pages status --porcelain=v1)"
+          git -C pages fetch --no-tags origin gh-pages
+          test "$(git -C pages rev-parse FETCH_HEAD)" = "$EXPECTED_LEDGER_COMMIT"
+          git -C pages diff --quiet HEAD FETCH_HEAD
+      - name: Upload the probe-only Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          name: pages-deployment-probe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: pages
+
+  deploy-probe:
+    name: Deploy the unchanged ledger through protected Pages
+    needs: [snapshot-ledger, upload-probe]
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: documentation-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      deployment_result: ${{ steps.report.outputs.result }}
+      elapsed_seconds: ${{ steps.report.outputs.elapsed_seconds }}
+
+    steps:
+      - id: start
+        name: Start Pages deployment timing
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "epoch=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+          echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+      - id: deployment
+        name: Deploy the probe artifact with the official Pages action
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        with:
+          artifact_name: pages-deployment-probe-${{ github.run_id }}-${{ github.run_attempt }}
+          # Do not override the action's hard 600000 ms polling ceiling.
+      - id: report
+        name: Report the diagnostic deployment result and timing
+        if: always()
+        env:
+          DEPLOYMENT_RESULT: ${{ steps.deployment.outcome }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          STARTED_AT: ${{ steps.start.outputs.timestamp }}
+          STARTED_EPOCH: ${{ steps.start.outputs.epoch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          elapsed_seconds=$(( $(date -u +%s) - STARTED_EPOCH ))
+          {
+            echo '## GitHub Pages deployment probe'
+            echo
+            echo 'Diagnostic only: this run deployed a read-only snapshot of the existing `gh-pages` ledger.'
+            echo 'It did not render documentation, write the ledger, publish artifacts, create tags, releases, aliases, or release evidence.'
+            echo
+            echo "- Trusted source commit: \`${{ needs.snapshot-ledger.outputs.source_commit }}\`"
+            echo "- Snapshotted gh-pages commit: \`${{ needs.snapshot-ledger.outputs.ledger_commit }}\`"
+            echo "- Deployment status: \`$DEPLOYMENT_RESULT\`"
+            echo "- Started: \`$STARTED_AT\`"
+            echo "- Finished: \`$finished_at\`"
+            echo "- Elapsed seconds: \`$elapsed_seconds\`"
+            echo "- Pages URL: ${PAGE_URL:-not reported}"
+            echo
+            echo 'One probe is diagnostic evidence only; its result does not establish the root cause of a Pages delay or failure.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "result=$DEPLOYMENT_RESULT" >> "$GITHUB_OUTPUT"
+          echo "elapsed_seconds=$elapsed_seconds" >> "$GITHUB_OUTPUT"
+      - name: Fail the probe when Pages did not deploy
+        if: steps.deployment.outcome != 'success'
+        shell: bash
+        run: |
+          echo 'The Pages deployment probe failed; consult its status and timing summary.' >&2
+          exit 1
+
+  verify-ledger-unchanged:
+    name: Verify gh-pages stayed unchanged through the probe
+    needs: [snapshot-ledger, upload-probe, deploy-probe]
+    if: >-
+      ${{ always() && needs.snapshot-ledger.result == 'success' &&
+          needs.upload-probe.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: gh-pages
+          path: pages
+          persist-credentials: false
+      - name: Prove the remote ledger still matches its snapshot
+        env:
+          EXPECTED_LEDGER_COMMIT: ${{ needs.snapshot-ledger.outputs.ledger_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f pages/.nojekyll
+          test "$(git -C pages rev-parse HEAD)" = "$EXPECTED_LEDGER_COMMIT"
+          test -z "$(git -C pages status --porcelain=v1)"
+          git -C pages fetch --no-tags origin gh-pages
+          test "$(git -C pages rev-parse FETCH_HEAD)" = "$EXPECTED_LEDGER_COMMIT"
+          git -C pages diff --quiet HEAD FETCH_HEAD
+      - name: Record the final diagnostic status
+        if: always()
+        env:
+          DEPLOYMENT_RESULT: ${{ needs.deploy-probe.outputs.deployment_result }}
+          ELAPSED_SECONDS: ${{ needs.deploy-probe.outputs.elapsed_seconds }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Probe completion'
+            echo
+            echo '- gh-pages: unchanged from the snapshotted commit'
+            echo "- Deployment status: \`$DEPLOYMENT_RESULT\`"
+            echo "- Deployment elapsed seconds: \`$ELAPSED_SECONDS\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -419,6 +419,33 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'the pending Pages workflow must check GitHub releases through the authoritative remote API')
         assertTrue(!pagesWorkflow.contains('git show-ref --verify'),
                 'the pending Pages workflow must not decide release identity from runner-local Git refs')
+        String pagesProbeWorkflow = new File(project.rootDir, '.github/workflows/probe-pages-deployment.yml').text
+        assertContains(pagesProbeWorkflow, 'workflow_dispatch:',
+                'the Pages probe must require an explicit manual dispatch')
+        assertContains(pagesProbeWorkflow, 'test "$GITHUB_REF" = refs/heads/master',
+                'the Pages probe must reject dispatches outside master')
+        assertContains(pagesProbeWorkflow, 'test "$(git rev-parse origin/master)" = "$EXPECTED_SOURCE_COMMIT"',
+                'the Pages probe must require the current trusted master commit')
+        assertContains(pagesProbeWorkflow, 'name: documentation-pages',
+                'the Pages probe must use the protected Pages deployment environment')
+        assertContains(pagesProbeWorkflow, 'pages-deployment-probe-${{ github.run_id }}-${{ github.run_attempt }}',
+                'the Pages probe artifact must be unambiguously diagnostic')
+        assertContains(pagesProbeWorkflow, 'actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b',
+                'the Pages probe must upload through the pinned official Pages artifact action')
+        assertContains(pagesProbeWorkflow, 'actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128',
+                'the Pages probe must deploy through the pinned official Pages action')
+        assertContains(pagesProbeWorkflow, 'test "$(git -C pages rev-parse FETCH_HEAD)" = "$EXPECTED_LEDGER_COMMIT"',
+                'the Pages probe must prove the remote ledger stays at its snapshot')
+        assertContains(pagesProbeWorkflow, 'One probe is diagnostic evidence only',
+                'the Pages probe must not overstate one deployment result as a root-cause finding')
+        assertTrue(!pagesProbeWorkflow.contains('PAGES_WRITER_'),
+                'the Pages probe must not receive gh-pages writer credentials')
+        assertTrue(!pagesProbeWorkflow.contains('publishCompleteKlumAstProduct'),
+                'the Pages probe must not publish artifacts')
+        assertTrue(!pagesProbeWorkflow.contains('pending-rejected/'),
+                'the Pages probe must not create rejected release paths')
+        assertTrue(!pagesProbeWorkflow.contains('timeout:'),
+                'the Pages probe must not override the Pages action polling ceiling')
         String releaseWorkflow = new File(project.rootDir, '.github/workflows/release.yml').text
         int identityPreflightStart = releaseWorkflow.indexOf('  verify-release-identity-available:\n')
         int pendingStageStart = releaseWorkflow.indexOf('  stage-pending-documentation:\n')

--- a/docs/implementation/evidence/issue-456-vd6-pages-deployment-probe.md
+++ b/docs/implementation/evidence/issue-456-vd6-pages-deployment-probe.md
@@ -1,0 +1,39 @@
+# #456 VD-6 Pages deployment probe
+
+This narrow, manually dispatched workflow is diagnostic-only evidence for a
+GitHub Pages deployment delay or failure. It is not a release operation and it
+does not change the versioned-documentation or prerelease policy.
+
+## Safety boundary
+
+- The workflow accepts no release inputs and contains no Maven, Plugin Portal,
+  signing, release, or Pages-writer credentials.
+- It runs only from the current `master` tip: it rejects any other ref and
+  proves that `HEAD`, `origin/master`, and the dispatch SHA agree.
+- It snapshots the exact `gh-pages` commit, uploads that entire untouched
+  ledger through `actions/upload-pages-artifact`, and verifies the remote
+  ledger still equals the snapshot after the deployment attempt.
+- The Pages deployment remains in the existing protected
+  `documentation-pages` environment. Its artifact name is uniquely and
+  visibly probe-only: `pages-deployment-probe-<run-id>-<attempt>`.
+- It uses the same pinned official artifact and deployment actions as the
+  protected pending-documentation path. It does not pass a deployment timeout,
+  so `actions/deploy-pages` retains its documented 600,000 ms ceiling.
+- It does not render documentation, write `gh-pages`, create a tag or GitHub
+  release, publish artifacts or plugin markers, advance aliases, create
+  pending/rejected release paths, or create release evidence.
+
+## Operation and interpretation
+
+After the workflow has reached `master`, a maintainer must manually dispatch
+**Probe GitHub Pages deployment** and satisfy any `documentation-pages`
+environment approval required by GitHub. The workflow summary records source
+and ledger commits, the Pages action result, timestamps, elapsed seconds, and
+the Pages URL if reported. Its final job proves that the remote ledger stayed
+unchanged.
+
+A successful or failed run is a bounded platform observation, not a root-cause
+finding by itself. Compare the recorded status and timing with the failed and
+successful release-stage runs before deciding on further remediation. The
+standard protected release workflow and the immutable RC/final policy remain
+unchanged.


### PR DESCRIPTION
## Summary

Adds a manually dispatched, diagnostic-only Pages deployment probe that uploads and deploys the existing `gh-pages` ledger without changing it.

- accepts no release inputs or credentials and rejects anything except the current `master` tip
- snapshots and rechecks the exact `gh-pages` commit before upload and after the deployment attempt
- uses the existing pinned Pages artifact/deployment actions with a unique probe artifact name, the protected `documentation-pages` environment, and the action's default 600,000 ms ceiling
- records deployment status and timing without interpreting one run as a root-cause conclusion

The protected release workflow and immutable release policy are unchanged. A maintainer must manually dispatch the probe only after this PR is merged and satisfy any environment approval.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/probe-pages-deployment.yml .github/workflows/publish-pending-documentation.yml .github/workflows/release.yml`
- `git diff --check`
- `./gradlew verifyVersionedDocumentationRenderer`
- `./gradlew check`