### PR TITLE
docs: convert current user links to Markdown

### DIFF
--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -42,6 +42,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
     void verifyRendererContract() {
         assertNoAuthoredPresentationHtml(project.rootDir)
         assertNoLegacyKlumVersionPlaceholder(project.rootDir)
+        assertNoWikiStyleLinksOutsideCode(project.rootDir)
         String readme = new File(project.rootDir, 'README.md').text
         assertContains(readme, 'https://klum-dsl.github.io/klum-ast/',
                 'README must use the canonical versioned documentation entry point')
@@ -72,12 +73,14 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(exactLanding.text, 'is a prerelease, not stable', 'RC chrome')
         assertContains(exactLanding.text, 'href="status/"', 'RC status link must remain inside the exact tree')
         assertContains(nestedPage.text, 'href="../../status/"', 'nested RC status link must remain inside the exact tree')
-        assertContains(exactLanding.text, 'href="Guide/Nested/"', 'authored Markdown links must resolve to directory URLs')
+        assertContains(exactLanding.text, 'href="Guide/Nested/">Nested guide</a>',
+                'authored labelled Markdown links must resolve to directory URLs')
         assertContains(exactLanding.text, 'href="Gradle-Onboarding/">Gradle Onboarding</a>',
                 'current navigation must use the canonical Gradle Onboarding route and visible label')
         assertContains(exactLanding.text, 'href="#same-heading"', 'same-page Markdown fragments must use rendered heading slugs')
         assertContains(nestedPage.text, 'href="../../"', 'nested pages must link relatively to the exact landing')
-        assertContains(nestedPage.text, 'href="../../#same-heading"', 'cross-page Markdown fragments must use rendered heading slugs')
+        assertContains(nestedPage.text, 'href="../../#same-heading">Current documentation</a>',
+                'labelled cross-page Markdown fragments must use rendered heading slugs')
         assertContains(nestedPage.text, "id 'com.blackbuild.klum-ast-schema' version '4.0.0-rc.1'",
                 'public RC rendering must substitute the portable KlumAST plugin version token')
         assertContains(nestedPage.text, 'com.blackbuild.klum.ast:klum-ast-runtime:4.0.0-rc.1',
@@ -86,6 +89,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'public RC rendering must not retain a portable or legacy KlumAST version placeholder')
         assertContains(new File(fixture, 'docs/user/Guide/Nested.md').text, '<klum-version>',
                 'source documentation must remain portable after rendering an exact version')
+        assertContains(new File(project.rootDir, 'docs/user/Builder-First-Migration.md').text, 'if [[ -n',
+                'fenced shell examples must retain literal double-bracket syntax')
         assertContains(nestedPage.text, "github.com/klum-dsl/klum-ast/blob/$revision/agent-skills/example/SKILL.md",
                 'authoring-root escapes must become immutable repository-source links')
         assertContains(changelog.text, 'href="../Builder-First-Migration/"',
@@ -563,7 +568,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         new File(repository, '.gitignore').text = '*/build/\n'
         new File(repository, 'docs/user/Home.md').text = '''# Current documentation
 
-[Nested guide](Guide/Nested.md), [Gradle onboarding](Gradle-Onboarding.md), [same-page heading](#Same%20heading), and [[Changelog]].
+[Nested guide](Guide/Nested.md), [Gradle onboarding](Gradle-Onboarding.md), [same-page heading](#Same%20heading), and [Changelog](Changelog.md).
 
 ![Local logo](img/klumlogo.png)
 
@@ -587,7 +592,7 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
 '''
         new File(repository, 'docs/user/Guide/Nested.md').text = '''# Nested current documentation
 
-[Home](../Home.md), [home heading](../Home.md#Same%20heading), [[Home#same-heading|Current documentation]], and [source skill](../../../agent-skills/example/SKILL.md).
+[Home](../Home.md), [home heading](../Home.md#Same%20heading), [Current documentation](../Home.md#same-heading), and [source skill](../../../agent-skills/example/SKILL.md).
 
 ```groovy
 plugins {
@@ -601,7 +606,7 @@ dependencies {
 '''
         new File(repository, 'docs/user/Gradle-Onboarding.md').text = '# Gradle onboarding\n\nCurrent setup guidance.\n'
         new File(repository, 'docs/user/Builder-First-Migration.md').text = '# Builder-first migration\n\nFixture migration.\n'
-        new File(repository, 'docs/user/_Sidebar.md').text = '* [[Home]]\n* [[Gradle Onboarding]]\n* [[Guide/Nested|Nested]]\n* [[Changelog]]\n'
+        new File(repository, 'docs/user/_Sidebar.md').text = '* [Home](Home.md)\n* [Gradle Onboarding](Gradle-Onboarding.md)\n* [Nested](Guide/Nested.md)\n* [Changelog](Changelog.md)\n'
         new File(repository, 'docs/user/_Footer.md').text = '*KlumAST* — fixture footer\n'
         new File(repository, 'docs/user/_Aliases.json').text = JsonOutput.prettyPrint(JsonOutput.toJson([
                 'Getting-Started.md': 'Gradle-Onboarding.md'
@@ -655,6 +660,23 @@ dependencies {
             }
         })
         found[0]
+    }
+
+    private static void assertNoWikiStyleLinksOutsideCode(File repository) {
+        new File(repository, 'docs/user').eachFileRecurse { File file ->
+            if (!file.file || !file.name.endsWith('.md')) return
+            String fenceDelimiter
+            file.readLines().eachWithIndex { String line, int index ->
+                def fence = line =~ /^ {0,3}(`{3,}|~{3,})/
+                if (fence.find()) {
+                    String delimiter = fence.group(1)
+                    if (!fenceDelimiter) fenceDelimiter = delimiter
+                    else if (delimiter[0] == fenceDelimiter[0] && delimiter.length() >= fenceDelimiter.length()) fenceDelimiter = null
+                } else if (!fenceDelimiter && line.replaceAll(/`+[^`]*`+/, '').contains('[[')) {
+                    throw new GradleException("Current user documentation retains a wiki-style link outside code: ${repository.toPath().relativize(file.toPath())}:${index + 1}")
+                }
+            }
+        }
     }
 
     private static Map<String, File> initializeModuleJavadocs(File repository) {

--- a/docs/user/Advanced-Techniques.md
+++ b/docs/user/Advanced-Techniques.md
@@ -30,7 +30,7 @@ class Container {
 
 Here both Mutators execute on the `Container` Builder and delegate `body` to a newly created `Element` Builder.
 `@DelegatesToBuilder` does not add a completed-model `apply` or `configure` path. An API that configures a DSL Object must
-participate in factory/Builder construction; see [[Builder First Migration]] for the lifecycle boundary.
+participate in factory/Builder construction; see [Builder First Migration](Builder-First-Migration.md) for the lifecycle boundary.
 
 ## Behavior Models and Parameter Hints
 
@@ -86,7 +86,7 @@ ValueProvider.Create.With {
 
 The closure has one `Map` parameter and returns `String`, so the compiler can check both parts of the contract.
 
-`DescriptionProvider` could instead be an abstract class, for example to add [[Converters#factory-method-converters]].
+`DescriptionProvider` could instead be an abstract class, for example to add [Converters#factory-method-converters](Converters.md#factory-method-converters).
 
 ### Closure Attributes
 

--- a/docs/user/Alternatives-Syntax.md
+++ b/docs/user/Alternatives-Syntax.md
@@ -57,10 +57,10 @@ Keep these constraints in mind:
 - Other than with the regular solution, the `elements` closure is no longer optional.
 - The necessary methods are only generated if `Config` and all subclasses of `Element` are compiled in __same compiler run__.
   This means that if you split your schema into different projects, you need to depend on the sources, not on the compiled
-  classes of other schema parts (see [[Usage]] for details).
+  classes of other schema parts (see [Usage](Usage.md) for details).
 - Child classes with the same simple name, even in different packages, are not allowed.
-- [[Convenience Factories]] and source-visible converter methods also work on alternative methods. For the 4.0 Builder
-  boundary and opaque-producer diagnostics, see [[Behind the Curtain#builder-projection-for-custom-producers]].
+- [Convenience Factories](Convenience-Factories.md) and source-visible converter methods also work on alternative methods. For the 4.0 Builder
+  boundary and opaque-producer diagnostics, see [Behind the Curtain#builder-projection-for-custom-producers](Behind-the-Curtain.md#builder-projection-for-custom-producers).
 
 ## Naming Strategies
 
@@ -163,4 +163,4 @@ In any other case, KlumAST lowercases the first character of the subclass name. 
 
 The executable example is `AlternativesDocumentaryTest.groovy`, feature `uses alternative names derived from child class names`.
 
-For more complex cases, custom [[Factory Classes]] can be used.
+For more complex cases, custom [Factory Classes](Factory-Classes.md) can be used.

--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -102,7 +102,7 @@ def deployment = Deployment.Create.With('catalog') {
 `deployment` is the completed DSL Object. The same example is executable in
 `FactoryConstructionTest.groovy`, feature `builds a completed deployment configuration with Create.With`.
 
-There are also a couple of [[Convenience Factories]] to load a model into client code.
+There are also a couple of [Convenience Factories](Convenience-Factories.md) to load a model into client code.
 
 ## Lifecycle Methods
 
@@ -121,7 +121,7 @@ Each Builder gets a `copyFrom()` DSL method. This method copies fields from a DS
 excluding key, owner and `@Role` fields, as well as fields marked `FieldType.TRANSIENT`
 or `FieldType.IGNORED`. Copying is further governed by `@Overwrite` / the configured `OverwriteStrategy`. This is done
 recursively: nested Template composition is rehydrated into fresh Builders. Completed ordinary models are not adopted as
-owned composition. [[Copy Strategies]] describes the available merge behavior.
+owned composition. [Copy Strategies](Copy-Strategies.md) describes the available merge behavior.
 
 ## `equals()` Method
 
@@ -583,7 +583,7 @@ assert instance.twobars.bli.key == "bunk"
 As with [Polymorphic DSL members](#polymorphic-dsl-members), members of collections can also be of subclasses of the declared types. The
 same mechanisms for single members can be used for collections, too (with the same caveats as above).
 
-Also, a more powerful approach is available using the [[Alternatives Syntax]].
+Also, a more powerful approach is available using the [Alternatives Syntax](Alternatives-Syntax.md).
 
 ## On collections
 
@@ -830,7 +830,7 @@ is generated on the completed DSL Object. They are intended for construction-onl
 ## TRANSIENT
 `TRANSIENT` fields are similar in that they don't get dsl methods either. However, in contrast
 to all other fields, they retain a public setter in the completed model, taking them effectively
-out of the [[Static Models]] concept. They can be used to add transient data that is not
+out of the [Static Models](Static-Models.md) concept. They can be used to add transient data that is not
 part of the model itself. Transient fields are ignored when checking for equality.
 
 ## IGNORED
@@ -846,7 +846,7 @@ the owner's Builder lifecycle.
 ## OPTIONAL_LINK
 `OPTIONAL_LINK` accepts either a locally created child Builder as owned composition or an existing completed DSL Object
 as an aggregation target. `@LinkTo` selects this mode by default; use `@Field(FieldType.LINK) @LinkTo` when a
-relationship must be aggregation-only. See [[Layer3]] for the relationship boundary.
+relationship must be aggregation-only. See [Layer3](Layer3.md) for the relationship boundary.
 
 ## DSL Interfaces
 Interfaces can be marked with `@DSL`. No transformation will be done for these interfaces; however, a field with an

--- a/docs/user/Behind-the-Curtain.md
+++ b/docs/user/Behind-the-Curtain.md
@@ -17,7 +17,7 @@ an explicit `KlumBuilder<T>` contract cannot safely join the active Construction
 generated relationship API and reports focused migration guidance. Use the generated child method, expose a concrete
 `KlumBuilder<T>` result, or compile the producer source with the Schema.
 
-This protocol is relevant to [[Converters]], [[Factory Classes]], and [[Alternatives Syntax]]. Its architectural boundary
+This protocol is relevant to [Converters](Converters.md), [Factory Classes](Factory-Classes.md), and [Alternatives Syntax](Alternatives-Syntax.md). Its architectural boundary
 is recorded in [ADR 0004](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0004-asbuilder-composition-protocol.md).
 
 ## Managed Jackson Import Mechanics
@@ -32,7 +32,7 @@ Each operation consumes one `KlumJacksonInput`; parsers remain caller-owned and 
 `copyFrom` do not participate in Jackson binding. This boundary is why managed import is interoperable with foreign JSON
 and YAML but is not Klum persistence or document layering.
 
-See [[Jackson Integration]] for the supported API and foreign-format workflow.
+See [Jackson Integration](Jackson-Integration.md) for the supported API and foreign-format workflow.
 
 ## Builder-First Materialization
 
@@ -42,6 +42,6 @@ DSL Objects. Builders and completed objects are intentionally different states, 
 active parent lifecycle and a completed object cannot become new owned composition.
 
 Generated `$klum$asBuilder$...` methods are JVM linkage details for projected producers, not a client API. Generated
-`Foo_DSL.Builder` interfaces are the supported public construction capability. See [[Builder First Migration]] for the
+`Foo_DSL.Builder` interfaces are the supported public construction capability. See [Builder First Migration](Builder-First-Migration.md) for the
 actionable migration checklist and [ADR 0003](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0003-builder-first-materialization.md)
 for the design decision.

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -281,7 +281,7 @@ class CustomerRoster {
 
 The migration checklist above is sufficient for ordinary Schema and Model work. For the Builder/materialization boundary,
 generated producer projection, lifecycle state, and the public-versus-synthetic generated API, see
-[[Behind the Curtain#builder-first-materialization]].
+[Behind the Curtain#builder-first-materialization](Behind-the-Curtain.md#builder-first-materialization).
 
 ## Templates, Serialization, and Jackson
 
@@ -313,7 +313,7 @@ normal lifecycle rather than rebound.
 
 Rename migrated JSON with `@JsonAlias` while keeping the new `@JsonProperty` name canonical. Configured naming strategies,
 mixins, ignore/access rules, and unknown-property policy are resolved by Jackson. Ambient Templates, `@Overwrite`, and
-`copyFrom` no longer affect JSON input. See [[Jackson Integration]] and
+`copyFrom` no longer affect JSON input. See [Jackson Integration](Jackson-Integration.md) and
 [ADR 0009](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0009-jackson-interoperability.md).
 
 `LINK` import requires an explicit reference schema, property conversion, or lifecycle resolution. Put

--- a/docs/user/Completed-Object-Support.md
+++ b/docs/user/Completed-Object-Support.md
@@ -151,4 +151,4 @@ String pathFromDeployment = support.getStructure().getRelativePath(service);
 supported client extension API.
 
 `Validator` result readers are removed in 4.0 with no compatibility adapter. Completed-object code uses
-`KlumObjectSupport.getValidation()` as described in [[Validation]].
+`KlumObjectSupport.getValidation()` as described in [Validation](Validation.md).

--- a/docs/user/Convenience-Factories.md
+++ b/docs/user/Convenience-Factories.md
@@ -33,7 +33,7 @@ name 'Klaus'
 
 or configure `GroovyClassLoader` / `GroovyShell` with a `BaseScript` (see the Javadoc of `DelegatingScript` for details).
 
-For a [[Usage#schema---model---consumer]] setup, the most convenient solution is to configure the Model project with a
+For a [Usage#schema---model---consumer](Usage.md#schema---model---consumer) setup, the most convenient solution is to configure the Model project with a
 compiler customizer.
 
 See the example projects for details.
@@ -161,7 +161,7 @@ Model.Create.With {
 }
 ```
 
-By including a separate properties file in the JAR of [[Usage#model]], this Model can automatically be instantiated. The
+By including a separate properties file in the JAR of [Usage#model](Usage.md#model), this Model can automatically be instantiated. The
 file must be named `/META-INF/klum-model/<schema-classname>.properties` and contain the single `model-class` property,
 whose value is the fully qualified class name of the entry-point script (either a regular `Script` or a
 `DelegatingScript`):
@@ -230,4 +230,4 @@ For String values, some simple transformations are applied:
 
 - enums are resolved by name
 - primitive types are converted via `asType`
-- existing [[Converters]] are used to convert the string to the target type
+- existing [Converters](Converters.md) are used to convert the string to the target type

--- a/docs/user/Converters.md
+++ b/docs/user/Converters.md
@@ -52,7 +52,7 @@ Date payDay(String $key, int $date, int $month, int $year) {
 The closures must return an instance of the field (or element) type.
 
 For a DSL Object result, a source-visible converter participates in the active Builder construction. Field converters for
-Simple Values are unaffected. See [[Behind the Curtain#builder-projection-for-custom-producers]] when the distinction
+Simple Values are unaffected. See [Behind the Curtain#builder-projection-for-custom-producers](Behind-the-Curtain.md#builder-projection-for-custom-producers) when the distinction
 matters to an integration.
 
 ## Factory Method Converters
@@ -91,7 +91,7 @@ assert server.endpoint.port == 8443
 ```
 
 For the Builder-projection rules, source-visibility boundary, and diagnostics for opaque producers, see
-[[Behind the Curtain#builder-projection-for-custom-producers]].
+[Behind the Curtain#builder-projection-for-custom-producers](Behind-the-Curtain.md#builder-projection-for-custom-producers).
 
 Source-visible same-compilation converters also work in Builder lifecycle methods and in nested converter bodies. For
 example, `storage('uri://bla/blub', 'uri://bli/blu')` can select `Storage.fromStrings`, whose implementation calls

--- a/docs/user/Copy-Strategies.md
+++ b/docs/user/Copy-Strategies.md
@@ -1,7 +1,7 @@
 # Copy strategies
 
 Copy strategies control how `copyFrom` applies a donor recipe to the current mutable Builder. This is mainly used for
-[[Templates]], but can also merge multiple recipe sources in a Helm-like way. In the descriptions below, **target** always
+[Templates](Templates.md), but can also merge multiple recipe sources in a Helm-like way. In the descriptions below, **target** always
 means the Builder being configured; a completed DSL Object is never mutated.
 
 ## Copy source protocol

--- a/docs/user/Default-Values.md
+++ b/docs/user/Default-Values.md
@@ -1,7 +1,7 @@
 # Default Values
 
 Non-DSL fields can be annotated with `@Default` to designate a default value, which is set in the
-[[Model Phases#default-25|Default phase]] when the value is not Groovy Truth. Booleans are the exception: a `false`
+[Default phase](Model-Phases.md#default-25) when the value is not Groovy Truth. Booleans are the exception: a `false`
 boolean is not treated as empty and is therefore not re-defaulted. For DSL-object fields, use `@AutoCreate` to create an
 owned child or `@AutoLink`/`@LinkTo` to resolve an existing target instead. `@Default` supports three mutually exclusive
 members; each produces a value that is coerced to the field's type.
@@ -133,12 +133,12 @@ assert config.lower == 'hans' // defaults to lowercase name
 (See: `DefaultValuesDocumentaryTest#'runs a default lifecycle method when a value is absent'`.)
 
 As with other annotations, `@Default` can also annotate parameterless methods or Closure fields that run in the
-Default phase. See [[Model Phases]] for more information.
+Default phase. See [Model Phases](Model-Phases.md) for more information.
 
 ## `@DefaultValues` Annotation
 
 Another option is an annotation that is itself annotated with `@DefaultValues`. This is primarily useful with inheritance
-and [[Layer3]].
+and [Layer3](Layer3.md).
 
 Use such an annotation either on a class or on a field.
 

--- a/docs/user/Domain-First-Modeling.md
+++ b/docs/user/Domain-First-Modeling.md
@@ -3,13 +3,13 @@
 > This is a 4.0 preview pending field testing. Use the documentation that matches the KlumAST version you adopt; [#456](https://github.com/klum-dsl/klum-ast/issues/456) owns versioned documentation and Javadocs.
 
 Domain-first modeling starts from the domain a completed model must represent. The model is the canonical abstraction, and
-adapters translate it for a dashboard, automation hub, report, or other target. That differs from [[Target Contract Modeling|target-contract modeling]], where an existing technical contract remains authoritative.
+adapters translate it for a dashboard, automation hub, report, or other target. That differs from [target-contract modeling](Target-Contract-Modeling.md), where an existing technical contract remains authoritative.
 
 ## Choose the consumer boundary
 
 Choose this independently from domain-first versus target-contract:
 
-- **[[Layer3|Layer 3]]** fits when a Domain API Developer defines a stable consumer-facing contract before a Schema Developer realizes it. Client Developers compile against that API, while Model Writers configure the concrete Model.
+- **[Layer 3](Layer3.md)** fits when a Domain API Developer defines a stable consumer-facing contract before a Schema Developer realizes it. Client Developers compile against that API, while Model Writers configure the concrete Model.
 - **Direct-schema** fits when Schema types are the appropriate consumer contract. The Schema Developer also assumes the Domain API Developer role.
 
 Layer 3 is an API–Schema–Model pattern, not a package or Java-module boundary. It is useful when a generic client should not depend on concrete Schema types; it is not a requirement for every domain-first project. The wider terminology, variants, and policy remain under [#454](https://github.com/klum-dsl/klum-ast/issues/454), so this guide does not treat an example as a new contract.

--- a/docs/user/Exception-Handling.md
+++ b/docs/user/Exception-Handling.md
@@ -1,6 +1,6 @@
 # Exception handling
 
-KlumAST supports a hierarchy of Exception to signal problems in the various [[Model Phases|phases of the model lifecycle]].
+KlumAST supports a hierarchy of Exception to signal problems in the various [phases of the model lifecycle](Model-Phases.md).
 The hierarchy is as follows:
 
 ## KlumException

--- a/docs/user/FAQ.md
+++ b/docs/user/FAQ.md
@@ -34,7 +34,7 @@ For a current IntelliJ setup, use the Gradle Schema plugin and refresh the gener
 
 The mirrors provide generated declaration metadata for completion; they are not compiled or published source. For Quick
 Documentation on compiled declarations, install [AnnoDoc Support for IntelliJ IDEA](https://github.com/blackbuild/annodoc-intellij)
-according to its release instructions. [[Usage#all-in-one]] describes the complete single-project setup. This is the 4.0
+according to its release instructions. [Usage#all-in-one](Usage.md#all-in-one) describes the complete single-project setup. This is the 4.0
 preview route; [#469](https://github.com/klum-dsl/klum-ast/issues/469) owns the first-RC real-project field test.
 
 For a separate compiled Schema artifact, a Consumer project can also obtain normal IDE assistance from the generated public

--- a/docs/user/Gradle-Onboarding.md
+++ b/docs/user/Gradle-Onboarding.md
@@ -14,10 +14,10 @@ Before creating a Schema, answer two independent questions.
    - **Direct-schema**: Schema types are the consumer-facing API, and the Schema Developer also owns that role.
 
 Record the choices near the project architecture. Layer 3 is a modeling pattern, not a requirement for every Gradle project.
-For route-specific guidance, read [[Domain First Modeling]] or [[Target Contract Modeling]]; the settled Layer 3 pattern
-is explained in [[Layer3]].
+For route-specific guidance, read [Domain First Modeling](Domain-First-Modeling.md) or [Target Contract Modeling](Target-Contract-Modeling.md); the settled Layer 3 pattern
+is explained in [Layer3](Layer3.md).
 
-`author-klum-model` is the Model Writer workflow: it creates and tests a representative configured model and may adapt the Schema types needed for that model. It is not a dedicated Schema Developer path. `start-klum-project` establishes the Schema project and its selected structure, while `feature-advisor` reviews both Schemas and configured models for supported improvements. For a domain-first Layer 3 journey, use `build-domain-first-schema` with the executable [smart-home fixture](Domain-First-Modeling.md#smart-home-journey); this keeps the shared Model Writer workflow intact rather than redefining it. `build-target-contract-schema` is the target-contract Schema Developer route; its [[Target Contract Modeling|executable Helm journey]] demonstrates intentional external mappings without redefining these role boundaries. The [#470](https://github.com/klum-dsl/klum-ast/issues/470) baseline established the common setup.
+`author-klum-model` is the Model Writer workflow: it creates and tests a representative configured model and may adapt the Schema types needed for that model. It is not a dedicated Schema Developer path. `start-klum-project` establishes the Schema project and its selected structure, while `feature-advisor` reviews both Schemas and configured models for supported improvements. For a domain-first Layer 3 journey, use `build-domain-first-schema` with the executable [smart-home fixture](Domain-First-Modeling.md#smart-home-journey); this keeps the shared Model Writer workflow intact rather than redefining it. `build-target-contract-schema` is the target-contract Schema Developer route; its [executable Helm journey](Target-Contract-Modeling.md) demonstrates intentional external mappings without redefining these role boundaries. The [#470](https://github.com/klum-dsl/klum-ast/issues/470) baseline established the common setup.
 
 ## Create the Gradle project
 
@@ -36,13 +36,13 @@ klumSchema {
 For a new project, Groovy 3 is the justified default: it is KlumAST's baseline and keeps the first build small. Keep an existing supported Groovy line instead. Groovy 3 uses `org.codehaus.groovy`; Groovy 4 and 5 use `org.apache.groovy`. The plugin selects matching Groovy and Spock dependencies.
 
 If this Schema must be a Java named module, use Groovy 4 or 5 and add the
-user-owned `src/main/java/module-info.java` described in [[Migration#named-modules-and-groovy]].
+user-owned `src/main/java/module-info.java` described in [Migration#named-modules-and-groovy](Migration.md#named-modules-and-groovy).
 The Schema plugin validates that descriptor as part of
 `check` (and Maven publication) but never writes it. Groovy 3 remains an
 ordinary-classpath setup; do not create a descriptor or add JPMS workaround
 flags for it.
 
-Place Schema classes in `src/main/groovy`, add one root `@DSL` type, and write a test in `src/test/groovy` that constructs a completed model through `Create.With`. Run `./gradlew test` before expanding the model. Use the model plugin only when a separate configured-model artifact is needed; see [[Gradle Plugins]].
+Place Schema classes in `src/main/groovy`, add one root `@DSL` type, and write a test in `src/test/groovy` that constructs a completed model through `Create.With`. Run `./gradlew test` before expanding the model. Use the model plugin only when a separate configured-model artifact is needed; see [Gradle Plugins](Gradle-Plugins.md).
 
 ```groovy
 @DSL
@@ -63,7 +63,7 @@ def deployment = Deployment.Create.With('catalog') {
 }
 ```
 
-`deployment` is the completed model. The callback configures its Builder; owned children must be created through the parent callback. See [[Builder First Migration]] for the construction boundary and [[Validation]] for domain invariants.
+`deployment` is the completed model. The callback configures its Builder; owned children must be created through the parent callback. See [Builder First Migration](Builder-First-Migration.md) for the construction boundary and [Validation](Validation.md) for domain invariants.
 
 ## IntelliJ and generated DSL support
 
@@ -91,4 +91,4 @@ The repository's [`agent-skills/`](https://github.com/klum-dsl/klum-ast/tree/mas
 
 The minimal fixture at `agent-skills/fixtures/minimal-gradle-project` exercises the baseline locally against the 4.0 sources. Its `ADOPTER-DRY-RUN.md` captures the setup, Model Writer, and feature-advisor field-test flow, including a deliberately improvable Schema case.
 
-The domain-first smart-home fixture at `agent-skills/fixtures/domain-first-smart-home` proves the separate Layer 3 API–Schema–Model path, its API-only client demo, and a later field-test starting artifact. For an external target such as Helm, start from two representative values files, retain the target contract as authoritative, and use `build-target-contract-schema` to choose intentional mappings. [[Target Contract Modeling]] uses the same `agent-skills/fixtures/helm-target-contract` fixture as the skill, including its direct-schema rationale, golden generated values, and later field-test prompt.
+The domain-first smart-home fixture at `agent-skills/fixtures/domain-first-smart-home` proves the separate Layer 3 API–Schema–Model path, its API-only client demo, and a later field-test starting artifact. For an external target such as Helm, start from two representative values files, retain the target contract as authoritative, and use `build-target-contract-schema` to choose intentional mappings. [Target Contract Modeling](Target-Contract-Modeling.md) uses the same `agent-skills/fixtures/helm-target-contract` fixture as the skill, including its direct-schema rationale, golden generated values, and later field-test prompt.

--- a/docs/user/Gradle-Plugins.md
+++ b/docs/user/Gradle-Plugins.md
@@ -60,7 +60,7 @@ Groovy 4 and 5 may use a named Schema module. Its descriptor requires the
 annotations and runtime modules, `requires static com.blackbuild.klum.ast.compiler`,
 and `org.apache.groovy`; when the project declares the Jackson or Bean Validation
 adapter, it must also require that adapter and open each Schema package to its
-reflection target. See [[Migration#named-modules-and-groovy]] for a complete
+reflection target. See [Migration#named-modules-and-groovy](Migration.md#named-modules-and-groovy) for a complete
 descriptor example.
 
 Groovy 3 is classpath-only for KlumAST Schema projects. If it finds a descriptor,

--- a/docs/user/Home.md
+++ b/docs/user/Home.md
@@ -9,7 +9,7 @@ KlumAST turns annotated model classes into concise, statically checked Groovy DS
 Schema Developer to describe a model once, a Model Writer to configure it through a readable DSL, and client code to
 consume the completed model without generated mutation methods.
 
-The [[Terms|Terms and role guide]] defines the core terms — especially Schema and Model — along with these responsibilities
+The [Terms and role guide](Terms.md) defines the core terms — especially Schema and Model — along with these responsibilities
 and the value kinds used throughout the documentation.
 
 ## Why models as code?
@@ -40,12 +40,12 @@ example, an illustrative failure from `models/production.groovy` could read:
 ```
 
 Generated factories configure a mutable Builder graph and return completed, structurally immutable DSL Objects. Lifecycle
-work through `POST_TREE` runs on Builders; materialization happens before validation. See [[Basics]], [[Model Phases]], and
-the [[Builder First Migration]] guide. [[Exception Handling|Construction paths]] describe model-source locations in detail.
+work through `POST_TREE` runs on Builders; materialization happens before validation. See [Basics](Basics.md), [Model Phases](Model-Phases.md), and
+the [Builder First Migration](Builder-First-Migration.md) guide. [Construction paths](Exception-Handling.md) describe model-source locations in detail.
 
 These capabilities make KlumAST especially useful for GitOps and other *\*aC* (anything-as-code) workflows. Git can record a
 configuration's structure, but a checked-in structure is not necessarily a verified model. Read
-[[Why aC is not enough|why *\*aC* needs model-level tests]] before treating configuration in Git as the end of the story.
+[why *\*aC* needs model-level tests](Why-aC-is-not-enough.md) before treating configuration in Git as the end of the story.
 
 ## Example
 
@@ -132,4 +132,4 @@ if (projectsWithoutClean) {
 }
 ```
 
-For the recommended 4.0 Gradle setup and generated-source-mirror workflow, start with [[Gradle Onboarding]].
+For the recommended 4.0 Gradle setup and generated-source-mirror workflow, start with [Gradle Onboarding](Gradle-Onboarding.md).

--- a/docs/user/Jackson-Integration.md
+++ b/docs/user/Jackson-Integration.md
@@ -28,7 +28,7 @@ resolved-property, Builder, identity, and customization groundwork.
 - A **Model Writer** can combine Groovy-authored and YAML-authored model parts without knowing Jackson or Builder internals.
 - In Layer 3, the **Domain API Developer** defines the consumer-facing model contract independently of the concrete Schema.
 
-See [[Terms]] for the project-wide role definitions.
+See [Terms](Terms.md) for the project-wide role definitions.
 
 ## Setup
 
@@ -42,7 +42,7 @@ dependencies {
 }
 ```
 
-See [[Usage#gradle-setup-supported]] for the supported plugin and BOM setup.
+See [Usage#gradle-setup-supported](Usage.md#gradle-setup-supported) for the supported plugin and BOM setup.
 
 ### Manual Gradle Dependency
 
@@ -107,7 +107,7 @@ values follow the caller's Jackson null, merge, and replacement configuration. E
 `KlumJacksonInput`; arrays, Maps, and YAML multi-document streams do not create a shared Klum lifecycle.
 
 For the importer snapshot, binding order, and Builder-state mechanics, see
-[[Behind the Curtain#managed-jackson-import-mechanics]]. Raw `ObjectMapper.readValue(DslType)` remains a discouraged
+[Behind the Curtain#managed-jackson-import-mechanics](Behind-the-Curtain.md#managed-jackson-import-mechanics). Raw `ObjectMapper.readValue(DslType)` remains a discouraged
 standalone-root compatibility path; do not use it to start a DSL root inside an active Construction session.
 
 ## One Foreign YAML Input, One Enriched Output

--- a/docs/user/Layer3.md
+++ b/docs/user/Layer3.md
@@ -328,7 +328,7 @@ assert db.dml.role == "dml"
 assert db.monitoring.role == "monitoring"
 ```
 
-That way some kind of environment checker can, for example, use [[Completed Object Support]] to validate that all non
+That way some kind of environment checker can, for example, use [Completed Object Support](Completed-Object-Support.md) to validate that all non
 ddl users have the correct privileges:
 
 ```groovy

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -4,8 +4,8 @@
 
 4.0 replaces the generated mutable RW object with a true Builder and materializes a completed, structurally immutable DSL Object graph before validation. Completed models no longer expose generated `apply`, owned composition cannot adopt already completed objects, lifecycle extensions are split at the new `INSTANTIATE` phase, and collection declarations now have explicit snapshot-safe limits. Templates now have persistent graph-wide recipe identity separate from ordinary models; marked Templates cannot be relationship values or ordinary Jackson export values, and deferred Builder actions cannot be scheduled at phase 40 or later. Jackson is an asymmetric external-format integration rather than Klum persistence and adds no wire metadata.
 
-See the dedicated [[Builder First Migration]] guide for the complete migration checklist and compatibility breaks, plus
-[[Templates]], [[Copy Strategies]], and [[Model Phases]] for materialization boundaries and [[Jackson Integration]] for
+See the dedicated [Builder First Migration](Builder-First-Migration.md) guide for the complete migration checklist and compatibility breaks, plus
+[Templates](Templates.md), [Copy Strategies](Copy-Strategies.md), and [Model Phases](Model-Phases.md) for materialization boundaries and [Jackson Integration](Jackson-Integration.md) for
 foreign-data import and ordinary POJO export.
 
 Validation callers must import and catch
@@ -94,7 +94,7 @@ It is strongly advised to first update to 2.0 and the to 2.1.
 ## To 2.0
 
 The sections below describe historical migration steps and may show APIs, such as completed-model `apply`, that were
-subsequently removed in 4.0. Apply the historical migration first, then follow [[Builder First Migration]].
+subsequently removed in 4.0. Apply the historical migration first, then follow [Builder First Migration](Builder-First-Migration.md).
 
 ## Validation now throws KlumValidationException
 
@@ -362,7 +362,7 @@ eventually be replace with a compiler error). Consider using a more domain speci
 
 the following features were dropped:
 - pre using existing `create` and `apply` methods is no longer supported, this has been replaced by a lifecycle mechanism 
-  ([#38](https://github.com/klum-dsl/klum-core/issues/38)), see [[Basics#lifecycle-methods]]
+  ([#38](https://github.com/klum-dsl/klum-core/issues/38)), see [Basics#lifecycle-methods](Basics.md#lifecycle-methods)
 - named alternatives for dsl collections
 - shortcut named mappings
 - under the hood: the inner class for dsl-collections is now optional (GDSL needs to be adapted)

--- a/docs/user/Model-Phases.md
+++ b/docs/user/Model-Phases.md
@@ -28,7 +28,7 @@ a `@Default` field will only be handled if the field is not set yet, while a `@D
 ## Creation
 
 The creation phase starts with the first factory call in a thread. It creates and configures the root Builder and its owned
-Builder graph. Creating a Builder includes applying [[Templates]], then calling `@PostCreate`, explicit configuration, and
+Builder graph. Creating a Builder includes applying [Templates](Templates.md), then calling `@PostCreate`, explicit configuration, and
 `@PostApply` methods and closures. No completed DSL Object exists yet.
 
 Before the initial create methods return, control is passed to the PhaseDriver that is responsible to execute all
@@ -127,7 +127,7 @@ more of a semantic nature. So AutoCreate methods should actually create objects,
 ## Error handling
 
 Exceptions during a phase are wrapped in `KlumException` or a subclass and retain the relevant phase and, where
-available, a construction path. See [[Exception Handling]] for the hierarchy and path details.
+available, a construction path. See [Exception Handling](Exception-Handling.md) for the hierarchy and path details.
 
 ## `applyLater` Methods
 

--- a/docs/user/Roadmap.md
+++ b/docs/user/Roadmap.md
@@ -2,10 +2,10 @@
 
 KlumAST 4.0 is an unreleased breaking release. Its headline change is Builder-first construction: factories configure
 mutable Builders, materialize a completed structurally immutable DSL Object graph, and then validate it. Read
-[[Builder First Migration]] before moving existing Schema, client, or extension code to 4.0.
+[Builder First Migration](Builder-First-Migration.md) before moving existing Schema, client, or extension code to 4.0.
 
 The current 4.0 documentation set also includes version-matched Gradle onboarding, domain-first and target-contract
-journeys, completed-object support, and the asymmetric Jackson integration. The release notes in [[Changelog]] are the
+journeys, completed-object support, and the asymmetric Jackson integration. The release notes in [Changelog](Changelog.md) are the
 authoritative inventory of delivered user-visible behavior.
 
 ## Content pending maintainer acceptance
@@ -21,7 +21,7 @@ Layer 3 contract.
 ## Historical roadmap
 
 The 2.x and 3.0 roadmap notes were planning material for releases that are now historical. Their migration guidance is
-preserved in [[Migration]]; this page intentionally does not present those earlier plans as current commitments.
+preserved in [Migration](Migration.md); this page intentionally does not present those earlier plans as current commitments.
 
 
 

--- a/docs/user/Static-Models.md
+++ b/docs/user/Static-Models.md
@@ -18,7 +18,7 @@ KlumAST supports this style with the following techniques:
 
 - Setters, generated DSL methods, and mutating lifecycle methods move to a generated Builder. Builders own mutable
   construction state through `POST_TREE`; `INSTANTIATE` then creates the completed DSL Object graph before validation.
-  See [[Model Phases]] for the lifecycle boundary. DSL features remain available during construction without polluting
+  See [Model Phases](Model-Phases.md) for the lifecycle boundary. DSL features remain available during construction without polluting
   the completed-model interface.
 - Other state-changing methods, such as pseudo-setters, must be marked with an annotation meta-annotated with
   `@WriteAccess`. Those methods also move to the Builder. Built-in write-access annotations include `@Mutator` for

--- a/docs/user/Target-Contract-Modeling.md
+++ b/docs/user/Target-Contract-Modeling.md
@@ -9,7 +9,7 @@ Use target-contract modeling when an existing system such as a Helm chart owns t
 Make the consumer-shape decision independently:
 
 - Choose **direct-schema** when the Schema Developer also owns the authors who consume the types, and there is no separate stable Domain API to protect.
-- Choose **[[Layer3|Layer 3]]** only when client developers must compile against a distinct Domain API rather than Schema types.
+- Choose **[Layer 3](Layer3.md)** only when client developers must compile against a distinct Domain API rather than Schema types.
 
 Do not add Layer 3 merely as insurance for a future client. Record the selected shape and the reason in the project architecture note.
 

--- a/docs/user/Templates.md
+++ b/docs/user/Templates.md
@@ -92,7 +92,7 @@ def c2 = Config.Create.With(copyFrom: template) {
 
 In both notations, the `copyFrom` entry should be the first, otherwise it might override values set before it. A marked
 Template contributes both values and recipe actions. An ordinary completed model contributes values only. See
-[[Copy Strategies#copy-source-protocol]] for the complete copy-source rules.
+[Copy Strategies#copy-source-protocol](Copy-Strategies.md#copy-source-protocol) for the complete copy-source rules.
 
 ## Template.With()
  
@@ -149,7 +149,7 @@ Config.Template.With(url: "http://x.y") {
 
 ## Templates for Collection Factories
 
-When using the optional collection factory (see [[Basics#collections-of-dsl-objects]]), a template can directly be
+When using the optional collection factory (see [Basics#collections-of-dsl-objects](Basics.md#collections-of-dsl-objects)), a template can directly be
 specified, either explicitly or as an anonymous template. This template is automatically valid for all elements
 that are created inside this collection factory:
 
@@ -334,7 +334,7 @@ Child.Template.WithAll([parentTemplate, childTemplate]) {
 
 ## `applyLater` and Templates
 
-As stated in [[Model Phases]], Templates can contain `applyLater` closures. These actions are not executed on the Template;
+As stated in [Model Phases](Model-Phases.md), Templates can contain `applyLater` closures. These actions are not executed on the Template;
 they are detached as recipe state and cloned into every fresh recipient Builder. The closure must address that fresh
 Builder through its delegate. Capturing any Builder, even through a serializable holder, is rejected. Other captured values
 must be serializable so the Template recipe remains serializable with its companion state.

--- a/docs/user/Terms.md
+++ b/docs/user/Terms.md
@@ -5,7 +5,7 @@
 A Schema is annotated Groovy source containing the class definitions for a model's DSL Object types, fields,
 relationships, defaults, lifecycle behavior, and validation rules. It is analogous to an XSD for an XML document or a
 JSON Schema for JSON data, but is also executable source: KlumAST generates the model-construction API from it. See
-[[Basics]] and [[Gradle Onboarding]].
+[Basics](Basics.md) and [Gradle Onboarding](Gradle-Onboarding.md).
 
 ## Model
 
@@ -20,8 +20,8 @@ create Model configuration; clients consume the resulting completed, read-only M
 
 A Client or Consumer uses a completed Model through its public domain API. It may invoke supported construction or
 import operations, handle validation results, and serialize the completed Model for downstream systems; it does not
-depend on generated Builder implementations or Schema-only types in a Layer 3 model. See [[Layer3]] and
-[[Completed Object Support]].
+depend on generated Builder implementations or Schema-only types in a Layer 3 model. See [Layer3](Layer3.md) and
+[Completed Object Support](Completed-Object-Support.md).
 
 # Roles
 
@@ -29,7 +29,7 @@ KlumAST documentation distinguishes four roles. One person can assume several ro
 
 ## Domain API Developer
 
-Defines the stable, consumer-facing model contract. In a [[Layer3|Layer 3 model]], this API is designed before the Schema and is the
+Defines the stable, consumer-facing model contract. In a [Layer 3 model](Layer3.md), this API is designed before the Schema and is the
 only model surface on which generic clients depend.
 
 ## Schema Developer
@@ -44,8 +44,8 @@ validation-result handling, and downstream serialization.
 
 ## Model Writer
 
-Creates concrete configured models using Groovy DSL scripts, YAML/JSON inputs, [[Templates]], or combinations of those
-authoring forms. A [[Jackson Integration|Jackson import operation]] always consumes one external input; source composition
+Creates concrete configured models using Groovy DSL scripts, YAML/JSON inputs, [Templates](Templates.md), or combinations of those
+authoring forms. A [Jackson import operation](Jackson-Integration.md) always consumes one external input; source composition
 is not a Model Writer promise of the Jackson adapter.
 
 # Construction lifecycle
@@ -54,48 +54,48 @@ is not a Model Writer promise of the Jackson adapter.
 
 A lifecycle phase is a named step in model construction, such as `POST_TREE`, `INSTANTIATE`, `VALIDATE`, or `VERIFY`.
 Builder phases run while configuration remains mutable; `INSTANTIATE` materializes the completed Model, and later phases
-inspect it. See [[Model Phases]].
+inspect it. See [Model Phases](Model-Phases.md).
 
 ## Lifecycle methods and closures
 
 Lifecycle methods and closure fields are Schema members annotated for a lifecycle phase. KlumAST invokes them at that
-phase, giving pre-materialization callbacks a Builder and later callbacks a completed Model. See [[Model Phases]].
+phase, giving pre-materialization callbacks a Builder and later callbacks a completed Model. See [Model Phases](Model-Phases.md).
 
 ## Validation
 
 Validation is the Schema-defined check of a completed Model. It can use field, method, or inner validation-class rules;
 the generated root factory records the result and `VERIFY` rejects errors at the configured failure level. See
-[[Validation]].
+[Validation](Validation.md).
 
 # Values
 In this documentation, we differentiate between these kinds of values:
 
 ## DSL-Objects
-DSL Objects are annotated with [[Basics|`@DSL`]]. These are (potentially complex) objects enhanced by the transformation. They
+DSL Objects are annotated with [`@DSL`](Basics.md). These are (potentially complex) objects enhanced by the transformation. They
 can either be *keyed* or *unkeyed*. Keyed means they have a designated field of type String (currently) decorated with the
  `@Key` annotation, acting as a key for this class. DSL classes are automatically made `Serializable`. Generated factories
 configure Builders and return completed DSL Objects; completed objects expose no generated mutation API.
 
 ## Builders
 Builders are the mutable construction-time counterparts of DSL Objects. They own field initializers, DSL mutators,
-relationship state, and lifecycle work through `POST_TREE`. The [[Model Phases#instantiate-40|`INSTANTIATE` phase]]
-materializes the complete Builder graph before validation. [[Builder First Migration|Builder-first construction]] explains
+relationship state, and lifecycle work through `POST_TREE`. The [`INSTANTIATE` phase](Model-Phases.md#instantiate-40)
+materializes the complete Builder graph before validation. [Builder-first construction](Builder-First-Migration.md) explains
 the supported construction boundary. Builders are generated implementation types and are not a stable client-facing
 naming contract.
 
 ## Templates
 
 A Template is a reusable configuration recipe. Applying it rehydrates fresh Builders with its values and recorded recipe
-actions; it is not an ordinary completed Model or a relationship value. See [[Templates]].
+actions; it is not an ordinary completed Model or a relationship value. See [Templates](Templates.md).
 
 ## Relationships
 
 An owned relationship creates part of a Model's composition graph through the parent Builder. A `LINK` relationship refers
-to an existing completed object instead of adopting it as owned composition. See [[Basics]] and
-[[Builder First Migration]].
+to an existing completed object instead of adopting it as owned composition. See [Basics](Basics.md) and
+[Builder First Migration](Builder-First-Migration.md).
 
 ## Collections
-Supported [[Basics#collections-of-dsl-objects|collection declarations]] are `List`, `Set`,
+Supported [collection declarations](Basics.md#collections-of-dsl-objects) are `List`, `Set`,
 `SortedSet`/`NavigableSet`, `Map`, `SortedMap`/`NavigableMap`, and `EnumSet`.
 Other concrete and custom Collection declarations are rejected during schema compilation. Map keys retain their declared type;
 collection and Map values can be Simple Values or DSL Objects. Collections of Collections are currently not supported.

--- a/docs/user/Usage.md
+++ b/docs/user/Usage.md
@@ -2,7 +2,7 @@
 
 KlumAST enhances quasi-static models with DSL methods at Groovy compile time. Annotate Schema classes with `@DSL` and
 the transformation is picked up during compilation. For a new 4.0 project, use the Gradle plugin setup below; it supplies
-the compatible KlumAST, Groovy, and test dependencies. [[Terms]] defines the Schema, Model, and Consumer responsibilities
+the compatible KlumAST, Groovy, and test dependencies. [Terms](Terms.md) defines the Schema, Model, and Consumer responsibilities
 used in the project shapes below.
 
 ## Gradle setup (supported)
@@ -20,8 +20,8 @@ klumSchema {
 }
 ```
 
-For a new project, Groovy 3 is the baseline. Keep an existing supported Groovy line instead. See [[Gradle Onboarding]] for
-the complete first Schema and test, [[Gradle Plugins]] for plugin details, and the model plugin when a separate configured
+For a new project, Groovy 3 is the baseline. Keep an existing supported Groovy line instead. See [Gradle Onboarding](Gradle-Onboarding.md) for
+the complete first Schema and test, [Gradle Plugins](Gradle-Plugins.md) for plugin details, and the model plugin when a separate configured
 Model artifact is required.
 
 ## Project setup
@@ -48,14 +48,14 @@ supported Gradle workflow for this case.
 #### Model
 
 The schema usually consists of one or more script files containing either a `Model.Create.With` statement or, even more 
- convenient, only the content of the `Create.With` closure (see [[Convenience Factories#delegating-scripts]]).
+ convenient, only the content of the `Create.With` closure (see [Convenience Factories#delegating-scripts](Convenience-Factories.md#delegating-scripts)).
  
 The model is than packed into a jar file (for convenience a shadowed jar containing the schema as well), which can 
  be used as the single dependency for all consumers.
 
 If the model has single entry points, i.e. instances of classes that are only present once in the
 model (which is usually the case), the model can make use of the new `Create.FromClasspath` feature, see
-[[Convenience Factories#classpath]] for details.
+[Convenience Factories#classpath](Convenience-Factories.md#classpath) for details.
 
 (See: `UsageDocumentaryTest#'loads a configured model through its classpath entry point'`.)
 
@@ -117,7 +117,7 @@ support for decorated collections. To allow nicer delegates is the goal of the K
 
 ### Layer3 structure: API - Schema - Model
 
-This approach is similar to the above approach, but adds an additional layer of abstraction. The API layer contains a generic API that is directly consumed, while the Schema makes the modelling easier. See [[Layer3]] for details.
+This approach is similar to the above approach, but adds an additional layer of abstraction. The API layer contains a generic API that is directly consumed, while the Schema makes the modelling easier. See [Layer3](Layer3.md) for details.
 
 ## Manual dependencies
 

--- a/docs/user/Validation.md
+++ b/docs/user/Validation.md
@@ -1,9 +1,9 @@
 # Validation
 
 Completed DSL Objects can be validated automatically. Builder phases may record provisional issues, which are transferred
-to the completed Model companion during [[Model Phases#instantiate-40|`INSTANTIATE`]]; `@Validate` methods and external
+to the completed Model companion during [`INSTANTIATE`](Model-Phases.md#instantiate-40); `@Validate` methods and external
 `InstanceValidator`s then run on the completed object. Each `InstanceValidator` type is memoized once per completed model.
-For reading stored results from a completed model, see [[Completed Object Support]].
+For reading stored results from a completed model, see [Completed Object Support](Completed-Object-Support.md).
 
 ## On Classes
 `@Validate` on classes behaves exactly like `@Validate` on fields, but is applied to all fields of the class not yet having an annotation, i.e., all not explicitly marked fields are validated

--- a/docs/user/Why-aC-is-not-enough.md
+++ b/docs/user/Why-aC-is-not-enough.md
@@ -29,7 +29,7 @@ test.
 
 A KlumAST Schema is executable model knowledge, not just a description of document shape:
 
-- Schema-specific rules can be declared with [[Validation|validation annotations and methods]]. A generated root factory
+- Schema-specific rules can be declared with [validation annotations and methods](Validation.md). A generated root factory
   materializes the model and runs validation, so every ordinary construction is an opportunity to reject an invalid
   model before it reaches a target.
 - A Model Writer can construct representative configurations with `Create.With` and assert the completed model or its
@@ -47,11 +47,11 @@ model into a fast, local layer of the testing pyramid and leaves target behavior
 The Schema Developer can keep constraints, defaults, relationship rules, and source documentation near the model they
 describe. Generated Builder Javadocs reuse that source documentation; generated IDE mirrors expose the same construction
 surface for completion. This separates concerns cleanly: the schema owns domain rules, Model Writers own concrete
-configuration, and clients consume completed models through their public contract. See [[Terms]] and [[Javadoc]].
+configuration, and clients consume completed models through their public contract. See [Terms](Terms.md) and [Javadoc](Javadoc.md).
 
 For a target-contract case such as Helm values, the target remains authoritative. A project can use a validated KlumAST
 authoring model and test an explicit target projection against representative target values. See
-[[Target Contract Modeling]].
+[Target Contract Modeling](Target-Contract-Modeling.md).
 
 ## Current standalone-script boundary
 

--- a/docs/user/_Sidebar.md
+++ b/docs/user/_Sidebar.md
@@ -1,37 +1,37 @@
-* [[Home]]
+* [Home](Home.md)
 * Introduction
-  * [[Why aC is not enough|Why *\*aC* is not enough]]
-  * [[Terms]]
+  * [Why *\*aC* is not enough](Why-aC-is-not-enough.md)
+  * [Terms](Terms.md)
 * Fundamentals
-  * [[Basics]]
-  * [[Model Phases]]
-  * [[Exception Handling]]
-  * [[Static Models]]
-  * [[Javadoc|Javadoc for models]]
+  * [Basics](Basics.md)
+  * [Model Phases](Model-Phases.md)
+  * [Exception Handling](Exception-Handling.md)
+  * [Static Models](Static-Models.md)
+  * [Javadoc for models](Javadoc.md)
 * Project setup
-  * [[Usage]]
-  * [[Gradle Plugins]]
-  * [[Gradle Onboarding]]
-  * [[Domain First Modeling]]
-  * [[Target Contract Modeling]]
+  * [Usage](Usage.md)
+  * [Gradle Plugins](Gradle-Plugins.md)
+  * [Gradle Onboarding](Gradle-Onboarding.md)
+  * [Domain First Modeling](Domain-First-Modeling.md)
+  * [Target Contract Modeling](Target-Contract-Modeling.md)
 * Advanced Features
-  * [[Behind the Curtain]]
-  * [[Completed Object Support]]
-  * [[Convenience Factories]]
-  * [[Factory Classes]]
-  * [[Templates]]
-  * [[Copy Strategies]]
-  * [[Validation]]
-  * [[Default Values]]
-  * [[Inheritance]]
-  * [[Converters]]
-  * [[Alternatives Syntax]]
-  * [[Advanced Techniques]]
-  * [[Layer3]]
-  * [[Jackson Integration]]
+  * [Behind the Curtain](Behind-the-Curtain.md)
+  * [Completed Object Support](Completed-Object-Support.md)
+  * [Convenience Factories](Convenience-Factories.md)
+  * [Factory Classes](Factory-Classes.md)
+  * [Templates](Templates.md)
+  * [Copy Strategies](Copy-Strategies.md)
+  * [Validation](Validation.md)
+  * [Default Values](Default-Values.md)
+  * [Inheritance](Inheritance.md)
+  * [Converters](Converters.md)
+  * [Alternatives Syntax](Alternatives-Syntax.md)
+  * [Advanced Techniques](Advanced-Techniques.md)
+  * [Layer3](Layer3.md)
+  * [Jackson Integration](Jackson-Integration.md)
 * More
-  * [[FAQ]]
-  * [[Changelog]]
-  * [[Migration]]
-  * [[Builder First Migration]]
-  * [[Roadmap]]
+  * [FAQ](FAQ.md)
+  * [Changelog](Changelog.md)
+  * [Migration](Migration.md)
+  * [Builder First Migration](Builder-First-Migration.md)
+  * [Roadmap](Roadmap.md)


### PR DESCRIPTION
## Summary
- convert current docs/user wiki links and navigation to source-relative Markdown links
- preserve labelled links and fragments while leaving literal shell double brackets in fenced code unchanged
- verify representative normal, labelled, and fragment renderer paths

## Validation
- ./gradlew verifyVersionedDocumentationRenderer
- local link and renderer-compatible fragment checks
- git diff --check

Documentation-only change; Groovy test lanes were not run.