### PR TITLE
Repair public-proof parent identity check

### DIFF
--- a/.github/workflows/promote-public-documentation.yml
+++ b/.github/workflows/promote-public-documentation.yml
@@ -101,7 +101,7 @@ jobs:
             --arg repository "$GITHUB_REPOSITORY" \
             '.name == "Verify public release" and .event == "workflow_dispatch" and
              .head_branch == "master" and .head_repository.full_name == $repository and
-             (.path | endswith("/.github/workflows/verify-public-release.yml@refs/heads/master"))' \
+             .path == ".github/workflows/verify-public-release.yml"' \
             <<< "$run_json" > /dev/null || {
               echo 'The named proof run is not a trusted Verify public release run.' >&2
               exit 1

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -588,6 +588,10 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'promotion must consume the exact public-proof run and attempt artifact')
         assertContains(promotionWorkflow, 'actions/runs/$PROOF_RUN/attempts/$PROOF_ATTEMPT/jobs?per_page=100',
                 'promotion must validate the completed exact proof job rather than wait for its parent workflow to finish')
+        assertContains(promotionWorkflow, '.path == ".github/workflows/verify-public-release.yml"',
+                'promotion must accept the documented API path of its manually dispatched parent run')
+        assertTrue(!promotionWorkflow.contains('endswith("/.github/workflows/verify-public-release.yml@refs/heads/master")'),
+                'promotion must not confuse its parent run API path with a reusable-workflow ref')
         assertContains(promotionWorkflow, '.name == "Resolve Maven modules and Gradle plugin markers" and',
                 'promotion must require the credential-free public resolve-back job')
         assertContains(promotionWorkflow, '.status == "completed" and .conclusion == "success"',


### PR DESCRIPTION
## Summary

- accept the documented GitHub Actions API path for a manually dispatched Verify public release parent run
- keep all existing proof identity, master, repository, job, artifact, and fail-closed validation intact
- lock the real API shape into the static workflow acceptance checks

## Root cause

Run 31168704392 reported `.path == ".github/workflows/verify-public-release.yml"`; the previous guard incorrectly expected a reusable-workflow ref suffix and rejected the valid parent before any promotion mutation.

## Validation

- YAML parsing for Verify public release and Promote proven public documentation workflows
- evaluated the repaired predicate against failed run 31168704392 metadata
- `./gradlew verifyVersionedDocumentationRenderer`
- `./gradlew check`
- `git diff --check`
- local standards/spec review

Related: #488
Related: #456

No workflow dispatch, tag, release, alias advance, artifact publication, documentation promotion, backfill, or issue mutation occurred.