### PR TITLE
Render public docs before gh-pages checkout

### DIFF
--- a/.github/workflows/promote-public-documentation.yml
+++ b/.github/workflows/promote-public-documentation.yml
@@ -182,6 +182,26 @@ jobs:
           distribution: temurin
           java-version: '17'
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+      - name: Render and verify the public exact-version tree
+        env:
+          RELEASE_STAGE: ${{ needs.validate-proof.outputs.stage }}
+          RELEASE_VERSION: ${{ needs.validate-proof.outputs.version }}
+          EXPECTED_COMMIT: ${{ needs.validate-proof.outputs.commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          public_status=current
+          if [[ "$RELEASE_STAGE" == candidate ]]; then
+            public_status=public-rc
+          fi
+          ./gradlew verifyRenderedDocumentationSite \
+            "-PdocumentationRevision=$EXPECTED_COMMIT" \
+            "-PdocumentationRendererRevision=$EXPECTED_COMMIT" \
+            "-PdocumentationVersion=$RELEASE_VERSION" \
+            "-PdocumentationStatus=$public_status" \
+            '-PdocumentationBrandingManifest=docs/branding/season-4-klumast.json' \
+            '-PdocumentationObjectDirectory=.' \
+            '-PdocumentationOutputDirectory=build/public-documentation'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: gh-pages
@@ -219,26 +239,6 @@ jobs:
             --arg sha "$EXPECTED_COMMIT" \
             '.schemaVersion == 2 and .documentation == {version: $version, status: "pending"} and .source.revision == $sha' \
             "$manifest" > /dev/null
-      - name: Render and verify the public exact-version tree
-        env:
-          RELEASE_STAGE: ${{ needs.validate-proof.outputs.stage }}
-          RELEASE_VERSION: ${{ needs.validate-proof.outputs.version }}
-          EXPECTED_COMMIT: ${{ needs.validate-proof.outputs.commit }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          public_status=current
-          if [[ "$RELEASE_STAGE" == candidate ]]; then
-            public_status=public-rc
-          fi
-          ./gradlew verifyRenderedDocumentationSite \
-            "-PdocumentationRevision=$EXPECTED_COMMIT" \
-            "-PdocumentationRendererRevision=$EXPECTED_COMMIT" \
-            "-PdocumentationVersion=$RELEASE_VERSION" \
-            "-PdocumentationStatus=$public_status" \
-            '-PdocumentationBrandingManifest=docs/branding/season-4-klumast.json' \
-            '-PdocumentationObjectDirectory=.' \
-            '-PdocumentationOutputDirectory=build/public-documentation'
       - id: idempotence
         name: Reject conflicting state or accept the identical completed promotion
         env:

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -602,6 +602,11 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'promotion must require matching immutable pending-stage evidence')
         assertContains(promotionWorkflow, 'documentationStatus=$public_status',
                 'promotion must re-render public status chrome rather than expose pending content')
+        int publicRenderStart = promotionWorkflow.indexOf('      - name: Render and verify the public exact-version tree\n')
+        int pagesCheckout = promotionWorkflow.indexOf('          ref: gh-pages\n')
+        int pendingEvidenceStart = promotionWorkflow.indexOf('      - name: Verify the immutable pending-stage evidence\n')
+        assertTrue(publicRenderStart >= 0 && pagesCheckout > publicRenderStart && pendingEvidenceStart > pagesCheckout,
+                'promotion must render the clean source worktree before checking out and validating the gh-pages ledger')
         assertContains(promotionWorkflow, 'aliases=\'["preview"]\'',
                 'candidate promotion must advance only the preview alias')
         assertContains(promotionWorkflow, 'aliases="[\\"stable\\",\\"$line\\"]"',


### PR DESCRIPTION
## Summary

- Render and verify the exact public documentation tree before checking out `gh-pages` into the source worktree.
- Preserve the renderer's immutable-worktree guard and retain the existing pending-evidence validation and promotion behavior after rendering.
- Add a focused static assertion that enforces the required workflow order.

## Root cause

The nested `pages/` checkout was untracked in the source checkout when `verifyRenderedDocumentationSite` ran with `documentationObjectDirectory=.`. The renderer correctly rejected that dirty worktree.

## Validation

- YAML syntax parse
- `git diff --check`
- `./gradlew verifyVersionedDocumentationRenderer`
- `./gradlew check`
- Independent standards and specification reviews (no findings)

## Delivery authorization audit

- GitHub CLI: denied for PR creation (local authentication unavailable).
- Git transport: authorized; pushed `codex/rc14-doc-render-order`.
- GitHub App connector: denied for PR creation (integration permission unavailable).
- Signed-in GitHub web session: authorized; creating this draft PR.

No workflows were dispatched and no artifacts, documentation, tags, releases, or aliases were published or advanced.