### PR TITLE
Restore Pages writer reusable secret context

### DIFF
--- a/.github/workflows/promote-public-documentation.yml
+++ b/.github/workflows/promote-public-documentation.yml
@@ -348,7 +348,7 @@ jobs:
           set -euo pipefail
           if [[ -z "$PAGES_WRITER_APP_ID" || -z "$PAGES_WRITER_APP_PRIVATE_KEY" ]]; then
             echo 'The protected documentation-pages-writer environment must contain non-empty PAGES_WRITER_APP_ID and PAGES_WRITER_APP_PRIVATE_KEY secrets.' >&2
-            echo 'Do not pass these credentials through the reusable-workflow caller or add them at repository scope.' >&2
+            echo 'Its reusable-workflow caller must retain secrets: inherit; do not move these environment credentials to repository scope.' >&2
             exit 1
           fi
       - name: Mint the dedicated Pages writer token

--- a/.github/workflows/verify-public-release.yml
+++ b/.github/workflows/verify-public-release.yml
@@ -144,6 +144,10 @@ jobs:
       commit: ${{ inputs.commit }}
       proof_run: ${{ needs.resolve.outputs.proof_run }}
       proof_attempt: ${{ needs.resolve.outputs.proof_attempt }}
+    # The called writer job still resolves its App credentials only from its own
+    # approved environment. GitHub requires this reusable-workflow secret context
+    # for those environment expressions to be populated.
+    secrets: inherit
 
   finalize-release-record:
     name: Create or verify the immutable release record

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -128,15 +128,16 @@ The called writer job resolves the Pages-writer credentials from the protected
 `documentation-pages-writer` environment instead of requiring them as caller inputs; it neither
 targets a release environment nor receives publication credentials.
 
-For **Verify public release**, the nested promotion call deliberately does *not* use
-`secrets: inherit`. Its `promote` job names `documentation-pages-writer` directly, so GitHub
-releases that environment's two writer secrets only after its required approval. Keep
-`PAGES_WRITER_APP_ID` and `PAGES_WRITER_APP_PRIVATE_KEY` as non-empty environment secrets there;
-their names appearing in `gh secret list --env documentation-pages-writer` verifies only that
-records exist, not that their stored values are usable. If the protected credential check reports
-an empty value, restore both values in that environment and re-run the failed job from the same
-Verify public release run. Do not move the secrets to repository scope, add them to the caller,
-or create a new dispatch with a copied proof identity.
+For **Verify public release**, the nested promotion call must use `secrets: inherit`. GitHub's
+reusable-workflow secret-context handling otherwise leaves the called job's environment expressions
+empty, as RC.14 demonstrated. This does not pass the Pages-writer environment secrets through the
+caller: the caller cannot name that environment, and the called `promote` job still resolves
+`PAGES_WRITER_APP_ID` and `PAGES_WRITER_APP_PRIVATE_KEY` only after the
+`documentation-pages-writer` approval. Keep those names only as non-empty secrets in that
+environment; do not add them to repository scope or as caller inputs. If the protected credential
+check reports an empty value, first verify that the unified caller retains `secrets: inherit`, then
+re-run the failed job from the same Verify public release run. Do not create a new dispatch with a
+copied proof identity.
 
 The Pages job writes the rendered static HTML, local assets, exact Javadocs, `site-manifest.json`,
 and a small handoff below the protected `gh-pages` branch. It refuses an existing pending path,

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -533,6 +533,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'the credential-free proof job must expose its retained immutable identity to downstream jobs')
         assertContains(publicProofWorkflow, 'uses: ./.github/workflows/promote-public-documentation.yml',
                 'the unified verification workflow must call proof-gated documentation promotion itself')
+        assertTrue(!publicProofWorkflow.contains('PAGES_WRITER_'),
+                'the unified caller must not name or receive the Pages writer credentials')
         assertContains(publicProofWorkflow, 'proof_run: ${{ needs.resolve.outputs.proof_run }}',
                 'documentation promotion must receive the proof run internally from the completed proof job')
         assertContains(publicProofWorkflow, 'proof_attempt: ${{ needs.resolve.outputs.proof_attempt }}',
@@ -567,8 +569,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'only the promotion call may receive Pages deployment authority')
         assertTrue(!promotionJob.contains('contents: write'),
                 'documentation promotion must not receive repository-record write authority')
-        assertTrue(!promotionJob.contains('secrets: inherit'),
-                'unified verification must not forward repository secrets into the called promotion workflow')
+        assertContains(promotionJob, 'secrets: inherit',
+                'the reusable promotion caller must preserve the called writer job\'s environment secret context')
         assertContains(recordJob, 'contents: write',
                 'only the protected release-record job may receive repository-record write authority')
         assertTrue(!recordJob.contains('pages: write') && !recordJob.contains('id-token: write'),
@@ -589,8 +591,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         assertContains(promotionWorkflow, 'secrets.PAGES_WRITER_APP_PRIVATE_KEY',
                 'the writer app private key must resolve inside the protected writer job')
         assertContains(promotionWorkflow,
-                'Do not pass these credentials through the reusable-workflow caller or add them at repository scope.',
-                'an empty writer secret must fail closed without widening its credential boundary')
+                'Its reusable-workflow caller must retain secrets: inherit; do not move these environment credentials to repository scope.',
+                'an empty writer secret must fail closed while preserving its environment boundary')
         assertContains(promotionWorkflow, 'name: documentation-pages',
                 'public documentation deployment must remain separate from the writer environment')
         assertContains(promotionWorkflow, 'public-release-proof-$PROOF_RUN.$PROOF_ATTEMPT',


### PR DESCRIPTION
## Summary

- Restore `secrets: inherit` on the unified reusable-promotion call.
- Keep the App ID and private key named only inside the approved `documentation-pages-writer` job.
- Correct the runbook guidance merged in #679 and add static boundary assertions.

## Evidence and cause

[Publish protected release run 31161702069](https://github.com/klum-dsl/klum-ast/actions/runs/31161702069) successfully entered `documentation-pages-writer`, passed the credential check, minted the Pages writer App token, and pushed the ledger. Its reusable caller used `secrets: inherit`.

Both unified verification failures (31169720792 and 31171636872) omitted that call contract and resolved the identical called-job expressions empty. The App credentials are therefore not empty; the missing reusable-workflow secret context is the material change. This restores the demonstrated contract without moving those environment credentials to repository scope or caller inputs.

## Validation

- `ruby -e "require 'yaml'; ARGV.each { |path| YAML.load_file(path) }" .github/workflows/promote-public-documentation.yml .github/workflows/verify-public-release.yml`
- `./gradlew verifyVersionedDocumentationRenderer --no-daemon`
- `git diff --check`

Related: #456
Related: #488
Supersedes the incorrect configuration diagnosis in #679.

## Operation

After merge, re-run only the failed promotion job of Verify public release run 31171636872. Do not create a new dispatch or copy its proof identity; no GitHub environment-secret change is required.
