### PR TITLE
fix(release): use portable alias recheck tool

### DIFF
--- a/.github/workflows/verify-public-release.yml
+++ b/.github/workflows/verify-public-release.yml
@@ -228,12 +228,12 @@ jobs:
             "$promotion" > /dev/null
           if [[ "$RELEASE_STAGE" == candidate ]]; then
             test -f pages/preview/index.html
-            rg -F "../$RELEASE_VERSION/" pages/preview/index.html > /dev/null
+            grep -F "../$RELEASE_VERSION/" pages/preview/index.html > /dev/null
           else
             line="${RELEASE_VERSION%.*}"
             test -f pages/stable/index.html
             test -f "pages/$line/index.html"
-            rg -F "../$RELEASE_VERSION/" pages/stable/index.html "pages/$line/index.html" > /dev/null
+            grep -F "../$RELEASE_VERSION/" pages/stable/index.html "pages/$line/index.html" > /dev/null
           fi
       - name: Create or verify the annotated tag and matching GitHub release
         env:

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -575,6 +575,12 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'only the protected release-record job may receive repository-record write authority')
         assertTrue(!recordJob.contains('pages: write') && !recordJob.contains('id-token: write'),
                 'release-record finalization must not receive Pages deployment authority')
+        assertContains(recordJob, 'grep -F "../$RELEASE_VERSION/" pages/preview/index.html > /dev/null',
+                'candidate release-record recheck must use the standard runner grep tool')
+        assertContains(recordJob, 'grep -F "../$RELEASE_VERSION/" pages/stable/index.html "pages/$line/index.html" > /dev/null',
+                'final release-record recheck must use the standard runner grep tool')
+        assertTrue(!recordJob.contains('rg -F'),
+                'release-record finalization must not depend on non-guaranteed ripgrep')
 
         String promotionWorkflow = new File(project.rootDir, '.github/workflows/promote-public-documentation.yml').text
         assertContains(promotionWorkflow, 'workflow_call:', 'documentation promotion must be callable only from the unified verification workflow')


### PR DESCRIPTION
## Summary
- replace the release-record alias checks' runner-optional `rg` dependency with POSIX `grep -F`
- statically require the portable checks and forbid `rg` in the finalizer

## Validation
- `./gradlew verifyVersionedDocumentationRenderer`
- YAML parse and `git diff --check`

This only repairs future/new workflow attempts. GitHub reruns retain the original event SHA, so it cannot change the already-failed finalizer in run 31175000628.