### PR TITLE
fix(release): set tag identity explicitly

### DIFF
--- a/.github/workflows/recover-public-release-record.yml
+++ b/.github/workflows/recover-public-release-record.yml
@@ -228,7 +228,7 @@ jobs:
           tag_status="$(get_status "git/ref/tags/$tag")"
           release_status="$(get_status "releases/tags/$tag")"
           case "$tag_status:$release_status" in
-            404:404) git tag -a "$tag" -m "Release $RELEASE_VERSION" "$EXPECTED_COMMIT"; git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag" ;;
+            404:404) git -c user.name='klum-ast release bot' -c user.email='noreply@users.noreply.github.com' tag -a "$tag" -m "Release $RELEASE_VERSION" "$EXPECTED_COMMIT"; git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag" ;;
             200:404|200:200) verify_tag ;;
             404:200) echo 'A GitHub release exists without its immutable annotated tag.' >&2; exit 1 ;;
             *) echo 'Could not determine the remote release-record state.' >&2; exit 1 ;;

--- a/.github/workflows/verify-public-release.yml
+++ b/.github/workflows/verify-public-release.yml
@@ -275,7 +275,7 @@ jobs:
           release_status="$(get_status "releases/tags/$tag")"
           case "$tag_status:$release_status" in
             404:404)
-              git tag -a "$tag" -m "Release $RELEASE_VERSION" "$EXPECTED_COMMIT"
+              git -c user.name='klum-ast release bot' -c user.email='noreply@users.noreply.github.com' tag -a "$tag" -m "Release $RELEASE_VERSION" "$EXPECTED_COMMIT"
               git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag"
               ;;
             200:404)

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -545,8 +545,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'only the dedicated protected release-record environment may receive contents-write authority')
         assertContains(publicProofWorkflow, 'test "$PROOF_IDENTITY" = "$EXPECTED_PROOF_IDENTITY"',
                 'release-record finalization must bind the promotion to the parent proof identity')
-        assertContains(publicProofWorkflow, 'git tag -a "$tag" -m "Release $RELEASE_VERSION" "$EXPECTED_COMMIT"',
-                'release-record finalization must create an annotated tag at the accepted source SHA')
+        assertContains(publicProofWorkflow, "git -c user.name='klum-ast release bot' -c user.email='noreply@users.noreply.github.com' tag -a \"\$tag\" -m \"Release \$RELEASE_VERSION\" \"\$EXPECTED_COMMIT\"",
+                'release-record finalization must create its annotated tag with an explicit non-human Git identity')
         assertContains(publicProofWorkflow, 'A GitHub release exists without its immutable annotated tag.',
                 'release-record finalization must reject a release record that cannot be bound to an immutable tag')
         assertContains(publicProofWorkflow, '.target_commitish == $sha and .prerelease == $prerelease and .draft == false',
@@ -604,6 +604,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'recovery must require the completed Pages deployment')
         assertContains(recoveryWorkflow, 'name: release-record',
                 'only the protected release-record environment may authorize recovery writes')
+        assertContains(recoveryWorkflow, "git -c user.name='klum-ast release bot' -c user.email='noreply@users.noreply.github.com' tag -a",
+                'recovery must create its annotated tag with an explicit non-human Git identity')
         assertTrue(!recoveryWorkflow.contains('PAGES_WRITER_') && !recoveryWorkflow.contains('pages: write') && !recoveryWorkflow.contains('id-token: write'),
                 'release-record recovery must not receive Pages writer or deployment authority')
         assertTrue(!recoveryWorkflow.contains('SONATYPE_') && !recoveryWorkflow.contains('SIGNING_') && !recoveryWorkflow.contains('GRADLE_PUBLISH_'),


### PR DESCRIPTION
## Summary
- create annotated release tags with a command-local non-human Git identity
- apply the repair to both normal finalization and exceptional recovery
- statically require the identity in both paths

## Diagnosis
Recovery run 31176402402 failed at local `git tag -a` with `Committer identity unknown`, before any tag push or release API request.

## Validation
- focused assertion was red before the fix
- `./gradlew verifyVersionedDocumentationRenderer`
- YAML and embedded Bash parse
- `git diff --check`