### PR TITLE
Validate release records through annotated tags

### DIFF
--- a/.github/workflows/recover-public-release-record.yml
+++ b/.github/workflows/recover-public-release-record.yml
@@ -229,9 +229,12 @@ jobs:
               exit 1
             }
           release="$(get "releases/tags/$tag")"
-          jq -e --arg tag "$tag" --arg sha "$EXPECTED_COMMIT" --argjson prerelease "$prerelease" \
-            '.tag_name == $tag and .target_commitish == $sha and .prerelease == $prerelease and .draft == false' \
+          # GitHub may report its UI/default-branch target here even when the
+          # release is attached to an existing exact tag. The annotated tag
+          # above is the authoritative binding to EXPECTED_COMMIT.
+          jq -e --arg tag "$tag" --argjson prerelease "$prerelease" \
+            '.tag_name == $tag and .prerelease == $prerelease and .draft == false' \
             <<< "$release" > /dev/null || {
-              echo 'The GitHub release does not exactly match the annotated tag, commit, and stage.' >&2
+              echo 'The GitHub release does not match the annotated tag and stage.' >&2
               exit 1
             }

--- a/.github/workflows/verify-public-release.yml
+++ b/.github/workflows/verify-public-release.yml
@@ -106,10 +106,13 @@ jobs:
             }
 
           release="$(get "releases/tags/$tag")"
-          jq -e --arg tag "$tag" --arg sha "$EXPECTED_COMMIT" --argjson prerelease "$prerelease" \
-            '.tag_name == $tag and .target_commitish == $sha and .prerelease == $prerelease and .draft == false' \
+          # GitHub may report its UI/default-branch target here even when the
+          # release is attached to an existing exact tag. The annotated tag
+          # above is the authoritative binding to EXPECTED_COMMIT.
+          jq -e --arg tag "$tag" --argjson prerelease "$prerelease" \
+            '.tag_name == $tag and .prerelease == $prerelease and .draft == false' \
             <<< "$release" > /dev/null || {
-              echo 'The GitHub release does not exactly match the annotated tag, commit, and stage.' >&2
+              echo 'The GitHub release does not match the annotated tag and stage.' >&2
               exit 1
             }
 

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -580,8 +580,10 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'public proof must wait for exact tag and release validation')
         assertContains(publicProofWorkflow, 'select(.object.type == "tag") | .object.sha',
                 'verification must reject lightweight tags')
-        assertContains(publicProofWorkflow, '.target_commitish == $sha and .prerelease == $prerelease and .draft == false',
-                'verification must verify the matching GitHub release identity and candidate flag')
+        assertContains(publicProofWorkflow, '.tag_name == $tag and .prerelease == $prerelease and .draft == false',
+                'verification must verify the matching GitHub release name and candidate flag')
+        assertTrue(!publicProofWorkflow.contains('target_commitish'),
+                'the annotated tag, not GitHub\'s display-oriented release target, must bind the release to the commit')
         assertTrue(!publicProofWorkflow.contains('SONATYPE_') && !publicProofWorkflow.contains('SIGNING_') && !publicProofWorkflow.contains('GRADLE_PUBLISH_'),
                 'unified verification must not receive artifact-publishing credentials')
         assertTrue(!publicProofWorkflow.contains('contents: write') && !publicProofWorkflow.contains('git push ') && !publicProofWorkflow.contains('--request POST'),
@@ -625,6 +627,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'recovery must validate, rather than create, the maintainer-created record')
         assertContains(recoveryWorkflow, 'select(.object.type == "tag") | .object.sha',
                 'recovery must reject lightweight tags')
+        assertTrue(!recoveryWorkflow.contains('target_commitish'),
+                'recovery must bind the release to the verified annotated tag rather than GitHub\'s display target')
         assertTrue(!recoveryWorkflow.contains('name: release-record') && !recoveryWorkflow.contains('contents: write') &&
                 !recoveryWorkflow.contains('git push ') && !recoveryWorkflow.contains('--request POST'),
                 'recovery must be read-only and must not require a release-record writer environment')


### PR DESCRIPTION
## Summary
- use the annotated tag object as the authoritative SHA binding for a manually created release record
- stop rejecting correct releases when GitHub reports the default branch in target_commitish
- add static regression coverage for both normal verification and exceptional recovery

## Validation
- red: exact RC.14 release predicate with target_commitish=SHA returned false
- green: repaired live tag/release predicate returned true
- ./gradlew verifyVersionedDocumentationRenderer
- YAML parsing, bash syntax checks, git diff --check