### PR TITLE
Publish Builder-first migration starter as a documentation asset

### DIFF
--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -89,8 +89,8 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'public RC rendering must not retain a portable or legacy KlumAST version placeholder')
         assertContains(new File(fixture, 'docs/user/Guide/Nested.md').text, '<klum-version>',
                 'source documentation must remain portable after rendering an exact version')
-        assertContains(new File(project.rootDir, 'docs/user/Builder-First-Migration.md').text, 'if [[ -n',
-                'fenced shell examples must retain literal double-bracket syntax')
+        assertContains(new File(project.rootDir, 'docs/user/assets/migrate-3x-to-4x-builder-first.sh').text, 'if [[ -n',
+                'the migration script must retain literal double-bracket syntax')
         assertContains(nestedPage.text, "github.com/klum-dsl/klum-ast/blob/$revision/agent-skills/example/SKILL.md",
                 'authoring-root escapes must become immutable repository-source links')
         assertContains(changelog.text, 'href="../Builder-First-Migration/"',
@@ -106,6 +106,11 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'season lockup must retain its authored alternate text')
         assertContains(exactLanding.text, '&lt;dependencies&gt;', 'XML code examples must remain escaped code')
         assertTrue(!new File(currentOne, '4.0.0-rc.1/Home').exists(), 'the landing source must not produce a second public page')
+        File migrationPage = new File(currentOne, '4.0.0-rc.1/Builder-First-Migration/index.html')
+        assertContains(migrationPage.text, 'href="../assets/migrate-3x-to-4x-builder-first.sh"',
+                'the migration page must link to the exact-tree migration script')
+        assertTrue(new File(currentOne, '4.0.0-rc.1/assets/migrate-3x-to-4x-builder-first.sh').file,
+                'the exact tree must contain the migration script asset')
         File legacyOnboarding = new File(currentOne, '4.0.0-rc.1/Getting-Started/index.html')
         assertTrue(legacyOnboarding.file, 'legacy onboarding route must remain available in the exact tree')
         assertContains(legacyOnboarding.text, 'href="../Gradle-Onboarding/"', 'legacy onboarding route must point to the canonical route')
@@ -744,7 +749,7 @@ dependencies {
 ```
 '''
         new File(repository, 'docs/user/Gradle-Onboarding.md').text = '# Gradle onboarding\n\nCurrent setup guidance.\n'
-        new File(repository, 'docs/user/Builder-First-Migration.md').text = '# Builder-first migration\n\nFixture migration.\n'
+        new File(repository, 'docs/user/Builder-First-Migration.md').text = '# Builder-first migration\n\n[Migration starter](assets/migrate-3x-to-4x-builder-first.sh).\n'
         new File(repository, 'docs/user/_Sidebar.md').text = '* [Home](Home.md)\n* [Gradle Onboarding](Gradle-Onboarding.md)\n* [Nested](Guide/Nested.md)\n* [Changelog](Changelog.md)\n'
         new File(repository, 'docs/user/_Footer.md').text = '*KlumAST* — fixture footer\n'
         new File(repository, 'docs/user/_Aliases.json').text = JsonOutput.prettyPrint(JsonOutput.toJson([
@@ -753,6 +758,10 @@ dependencies {
         new File(repository, 'CHANGES.md').text = '# Changelog\n\nFixture changes. See [migration](docs/user/Builder-First-Migration.md).\n'
         byte[] logo = 'fixture-logo'.getBytes(StandardCharsets.UTF_8)
         new File(repository, 'docs/user/img/klumlogo.png').bytes = logo
+        new File(repository, 'docs/user/assets/migrate-3x-to-4x-builder-first.sh').with {
+            parentFile.mkdirs()
+            text = '#!/usr/bin/env bash\n# fixture migration starter\n'
+        }
         new File(repository, 'docs/user/img/klumast-season-4-documentation.svg').text = '<svg xmlns="http://www.w3.org/2000/svg"/>'
         new File(repository, 'docs/user/img/klumast-season-4-documentation-compact.svg').text = '<svg xmlns="http://www.w3.org/2000/svg"/>'
         new File(repository, 'wiki/Home.md').text = '# Historical home\n\nHistorical landing content.\n'

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -139,7 +139,8 @@ graph and the completed model graph.
 
 ## Optional Mechanical Starting Point
 
-The following **best-effort convenience script** performs only a small set of mechanical 3.x-to-4.0 edits. It is not a
+The [**best-effort convenience script**](assets/migrate-3x-to-4x-builder-first.sh) performs only a small set of mechanical
+3.x-to-4.0 edits. It is not a
 KlumAST migration tool: it does not promise a compiling project, understand application semantics, or replace the
 checklist below. Run it only from the **schema module directory**—the Gradle subproject containing the Schema's
 `src/main` and `src/test` sources—not from a multi-module project's top-level directory. That module must be in a
@@ -152,78 +153,6 @@ and `KlumModelException`/`KlumValidationException` imports. It also converts onl
 intentionally does **not** rewrite internal packages, `ValidatorBase`, validation result readers, explicit-target
 `Validator` calls, fully qualified type references, Builders, factories, relationships, lifecycle structure, or any other
 semantic migration.
-
-```bash
-#!/usr/bin/env bash
-# Run from a schema module directory in a clean, disposable Git worktree.
-# Do not run this from a multi-module project's top-level directory. Requires Bash and Perl.
-set -euo pipefail
-
-git rev-parse --is-inside-work-tree >/dev/null
-if [[ -n "$(git status --porcelain)" ]]; then
-  echo "Refusing to edit a non-clean worktree; commit, stash, or create a fresh worktree first." >&2
-  exit 1
-fi
-command -v perl >/dev/null || {
-  echo "This convenience script requires Perl." >&2
-  exit 1
-}
-
-roots=()
-for candidate in src/main/groovy src/test/groovy src/main/java src/test/java; do
-  [[ -d "$candidate" ]] && roots+=("$candidate")
-done
-(( ${#roots[@]} )) || {
-  echo "No conventional Groovy or Java source roots found." >&2
-  exit 1
-}
-
-# Known public annotation moves, exception imports, and canonical deprecated annotation spelling.
-while IFS= read -r -d '' file; do
-  perl -0pi -e '
-    s{^(\s*import\s+(?:static\s+)?)(com\.blackbuild\.groovy\.configdsl\.transform\.)}{$1com.blackbuild.klum.ast.}mg;
-    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.layer3\.annotations\.)}{$1com.blackbuild.klum.ast.layer3.}mg;
-    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.copy\.)}{$1com.blackbuild.klum.ast.copy.}mg;
-    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.KlumModelException\b)}{$1com.blackbuild.klum.ast.runtime.KlumModelException}mg;
-    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.KlumValidationException\b)}{$1com.blackbuild.klum.ast.runtime.validation.KlumValidationException}mg;
-    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.runtime\.KlumValidationException\b)}{$1com.blackbuild.klum.ast.runtime.validation.KlumValidationException}mg;
-    s{\bDelegatesToRW\b}{DelegatesToBuilder}g;
-  ' "$file"
-done < <(find "${roots[@]}" -type f \( -name '*.groovy' -o -name '*.java' \) -print0)
-
-# Current-target Groovy Validator calls only. Explicit-target calls, ValidatorBase,
-# and validation-result readers deliberately remain for manual migration.
-groovy_roots=()
-for candidate in src/main/groovy src/test/groovy; do
-  [[ -d "$candidate" ]] && groovy_roots+=("$candidate")
-done
-
-if (( ${#groovy_roots[@]} )); then
-  while IFS= read -r -d '' file; do
-    if grep -qE 'Validator\.(addError|addErrorToMember|addIssue|addIssueToMember|suppressFurtherIssues)' "$file"; then
-    perl -0pi -e '
-      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*,\s*([^\)]+)\)}{klumValidation.suppressAll($1)}g;
-      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*\)}{klumValidation.suppressAll()}g;
-      s{\bValidator\.addErrorToMember\b}{klumValidation.errorAt}g;
-      s{\bValidator\.addError\b}{klumValidation.error}g;
-      s{\bValidator\.addIssueToMember\b}{klumValidation.issueAt}g;
-      s{\bValidator\.addIssue\b}{klumValidation.issue}g;
-      s{\bValidator\.suppressFurtherIssues\b}{klumValidation.suppressOn}g;
-      if (!/Validator\./) {
-        s{^\s*import\s+com\.blackbuild\.klum\.ast\.validation\.Validator\s*\n}{}mg;
-      }
-      if (/\bklumValidation\./ && !/import\s+static\s+com\.blackbuild\.klum\.ast\.runtime\.KlumSchemaSupport\.klumValidation/) {
-        if (!s{^(package[^\n]*\n)}{$1\nimport static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n}m) {
-          s{\A}{import static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n\n};
-        }
-      }
-    ' "$file"
-    fi
-  done < <(find "${groovy_roots[@]}" -type f -name '*.groovy' -print0)
-fi
-
-echo "Starter edits applied. Review 'git diff', then compile, run a representative model, and follow Builder-First-Migration.md."
-```
 
 Do not broaden this script by guessing package destinations or rewriting unresolved compiler errors. The compilation and
 model checks are the handoff from mechanical edits to the actual migration.

--- a/docs/user/assets/migrate-3x-to-4x-builder-first.sh
+++ b/docs/user/assets/migrate-3x-to-4x-builder-first.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run from a schema module directory in a clean, disposable Git worktree.
+# Do not run this from a multi-module project's top-level directory. Requires Bash and Perl.
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Refusing to edit a non-clean worktree; commit, stash, or create a fresh worktree first." >&2
+  exit 1
+fi
+command -v perl >/dev/null || {
+  echo "This convenience script requires Perl." >&2
+  exit 1
+}
+
+roots=()
+for candidate in src/main/groovy src/test/groovy src/main/java src/test/java; do
+  [[ -d "$candidate" ]] && roots+=("$candidate")
+done
+(( ${#roots[@]} )) || {
+  echo "No conventional Groovy or Java source roots found." >&2
+  exit 1
+}
+
+# Known public annotation moves, exception imports, and canonical deprecated annotation spelling.
+while IFS= read -r -d '' file; do
+  perl -0pi -e '
+    s{^(\s*import\s+(?:static\s+)?)(com\.blackbuild\.groovy\.configdsl\.transform\.)}{$1com.blackbuild.klum.ast.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.layer3\.annotations\.)}{$1com.blackbuild.klum.ast.layer3.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.copy\.)}{$1com.blackbuild.klum.ast.copy.}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.KlumModelException\b)}{$1com.blackbuild.klum.ast.runtime.KlumModelException}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.util\.KlumValidationException\b)}{$1com.blackbuild.klum.ast.runtime.validation.KlumValidationException}mg;
+    s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.runtime\.KlumValidationException\b)}{$1com.blackbuild.klum.ast.runtime.validation.KlumValidationException}mg;
+    s{\bDelegatesToRW\b}{DelegatesToBuilder}g;
+  ' "$file"
+done < <(find "${roots[@]}" -type f \( -name '*.groovy' -o -name '*.java' \) -print0)
+
+# Current-target Groovy Validator calls only. Explicit-target calls, ValidatorBase,
+# and validation-result readers deliberately remain for manual migration.
+groovy_roots=()
+for candidate in src/main/groovy src/test/groovy; do
+  [[ -d "$candidate" ]] && groovy_roots+=("$candidate")
+done
+
+if (( ${#groovy_roots[@]} )); then
+  while IFS= read -r -d '' file; do
+    if grep -qE 'Validator\.(addError|addErrorToMember|addIssue|addIssueToMember|suppressFurtherIssues)' "$file"; then
+    perl -0pi -e '
+      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*,\s*([^\)]+)\)}{klumValidation.suppressAll($1)}g;
+      s{Validator\.suppressFurtherIssues\(\s*Validator\.ANY_MEMBER\s*\)}{klumValidation.suppressAll()}g;
+      s{\bValidator\.addErrorToMember\b}{klumValidation.errorAt}g;
+      s{\bValidator\.addError\b}{klumValidation.error}g;
+      s{\bValidator\.addIssueToMember\b}{klumValidation.issueAt}g;
+      s{\bValidator\.addIssue\b}{klumValidation.issue}g;
+      s{\bValidator\.suppressFurtherIssues\b}{klumValidation.suppressOn}g;
+      if (!/Validator\./) {
+        s{^\s*import\s+com\.blackbuild\.klum\.ast\.validation\.Validator\s*\n}{}mg;
+      }
+      if (/\bklumValidation\./ && !/import\s+static\s+com\.blackbuild\.klum\.ast\.runtime\.KlumSchemaSupport\.klumValidation/) {
+        if (!s{^(package[^\n]*\n)}{$1\nimport static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n}m) {
+          s{\A}{import static com.blackbuild.klum.ast.runtime.KlumSchemaSupport.klumValidation\n\n};
+        }
+      }
+    ' "$file"
+    fi
+  done < <(find "${groovy_roots[@]}" -type f -name '*.groovy' -print0)
+fi
+
+echo "Starter edits applied. Review 'git diff', then compile, run a representative model, and follow Builder-First-Migration.md."


### PR DESCRIPTION
## Summary

- moves the existing best-effort 3.x-to-4.0 helper verbatim into a versioned `docs/user/assets/` download
- keeps the Builder-first guide concise while retaining its schema-module, non-project-root, clean-disposable-worktree, diff-review, compile, and checklist safety boundary
- extends immutable renderer coverage to verify both asset copying and the rendered migration-page link

## Validation

- `./gradlew verifyVersionedDocumentationRenderer`
- `git diff --check`

Documentation-only scope: Groovy test lanes are not applicable.

## Review brief

Local review found no scope creep or standards issues. The script content is byte-for-text equivalent to the former fenced block; the renderer already has the intended generic asset mechanism, so no renderer production behavior changed.

## Tracker impact

Related: #694

Issue #694 remains open for maintainer review and delivery reconciliation. This localized documentation-asset change does not alter release gates, dependencies, owners, or curation.