### PR TITLE
Validate DefaultValues annotation targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Validation
 
+- Default-value annotations marked with `@DefaultValues` now reject compilation when used outside a `@DSL` class or a
+  field declared by one. The diagnostic names the misplaced annotation and the supported targets ([#697](https://github.com/klum-dsl/klum-ast/issues/697)).
 - `KlumValidationException` is now solely `com.blackbuild.klum.ast.runtime.validation.KlumValidationException`; update
   imports and caught types. The former runtime-package class has been removed as an intentional 4.0 source and binary
   compatibility break ([#657](https://github.com/klum-dsl/klum-ast/issues/657)).

--- a/docs/user/Default-Values.md
+++ b/docs/user/Default-Values.md
@@ -140,7 +140,13 @@ Default phase. See [Model Phases](Model-Phases.md) for more information.
 Another option is an annotation that is itself annotated with `@DefaultValues`. This is primarily useful with inheritance
 and [Layer3](Layer3.md).
 
-Use such an annotation either on a class or on a field.
+## Supported Targets
+
+Use such an annotation only on a `@DSL` class or on a field declared by a `@DSL` class. KlumAST validates each
+application at compilation time and reports the default-value annotation together with these allowed contexts when it is
+misplaced.
+
+(See: `DefaultValuesDocumentaryTest#'uses default-values annotations on DSL classes and DSL fields'`.)
 
 ### Class Annotation
 

--- a/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/layer3/DefaultValues.java
+++ b/klum-ast-annotations/src/main/java/com/blackbuild/klum/ast/layer3/DefaultValues.java
@@ -34,6 +34,7 @@ import java.lang.annotation.Target;
  * Marker interface to designate an annotation as a default value provider.
  * The attributes of the annotated annotation type will be used as default values for the annotated dsl object,
  * either as is, or, in the case of a closure member, the result of the closure.
+ * The resulting default-value annotation can only be used on a {@code @DSL} class or a field declared by one.
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/layer3/DefaultValuesCheck.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/layer3/DefaultValuesCheck.java
@@ -27,10 +27,14 @@ import com.blackbuild.klum.ast.layer3.DefaultValues;
 import com.blackbuild.klum.cast.spi.Check;
 import com.blackbuild.klum.cast.spi.CheckContext;
 import com.blackbuild.klum.cast.spi.Diagnostic;
+import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
 
 import java.util.List;
+
+import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.isDSLObject;
 
 public class DefaultValuesCheck implements Check {
     @Override
@@ -41,6 +45,11 @@ public class DefaultValuesCheck implements Check {
                 .isPresent();
         AnnotationNode annotationToCheck = context.getValidatedAnnotation();
         ClassNode targetAnnotation = annotationToCheck.getClassNode();
+        if (!isDslTarget(context.getTarget()))
+            return List.of(new Diagnostic(getClass().getName(), String.format(
+                    "Default-values annotation %s can only be applied to a @DSL class or a field declared by a @DSL class",
+                    targetAnnotation.getName()), annotationToCheck));
+
         boolean targetAnnotationHasValueMember = !targetAnnotation.getMethods("value").isEmpty();
 
         if (controlAnnotationHasValuesMapping && !targetAnnotationHasValueMember)
@@ -52,5 +61,13 @@ public class DefaultValuesCheck implements Check {
                 String.format("Target annotation %s does have a 'value' member, but DefaultValues does not have a 'valueTarget' member", targetAnnotation.getName()), context.getTarget()));
 
         return List.of();
+    }
+
+    private boolean isDslTarget(AnnotatedNode target) {
+        if (target instanceof ClassNode classNode)
+            return isDSLObject(classNode);
+        if (target instanceof FieldNode fieldNode)
+            return isDSLObject(fieldNode.getOwner());
+        return false;
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesDocumentaryTest.groovy
@@ -222,6 +222,53 @@ class DefaultValuesDocumentaryTest extends AbstractDSLSpec {
         floorPlan.north.shortLabel == 'N'
     }
 
+    @Issue("697")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Default-Values.md#supported-targets")
+    def "uses default-values annotations on DSL classes and DSL fields"() {
+        given:
+        createSecondaryClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.DefaultValues
+
+            import java.lang.annotation.ElementType
+            import java.lang.annotation.Retention
+            import java.lang.annotation.RetentionPolicy
+            import java.lang.annotation.Target
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target([ElementType.TYPE, ElementType.FIELD])
+            @DefaultValues
+            @interface DisplayDefaults {
+                String displayName() default ''
+            }
+        '''
+        createClass '''
+            package pk
+
+            @DisplayDefaults(displayName = 'Spring Catalog')
+            @DSL
+            class Release {
+                String displayName
+            }
+
+            @DSL
+            class Catalog {
+                @DisplayDefaults(displayName = 'Featured Release')
+                Release release
+            }
+        '''
+
+        when:
+        def catalog = getClass('pk.Catalog').Create.With {
+            release {}
+        }
+
+        then:
+        getClass('pk.Release').Create.One().displayName == 'Spring Catalog'
+        catalog.release.displayName == 'Featured Release'
+    }
+
     @Issue("361")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Default-Values.md#closure-and-coercion")
     def "evaluates a default-values closure and coerces its result"() {

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/DefaultValuesSpec.groovy
@@ -760,6 +760,80 @@ import java.lang.annotation.*
         notThrown(MultipleCompilationErrorsException)
     }
 
+    @Issue("697")
+    def "default-values annotations can only be applied to DSL classes or fields declared by DSL classes"() {
+        given:
+        createSecondaryClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.layer3.DefaultValues
+
+            import java.lang.annotation.*
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target([ElementType.TYPE, ElementType.FIELD])
+            @DefaultValues
+            @interface DisplayDefaults {
+                String displayName() default ""
+            }
+        '''
+
+        when: "the annotation is applied to a non-DSL class"
+        createNonDslClass '''
+            package pk
+
+            @DisplayDefaults(displayName = "Plain")
+            class PlainType {
+                String displayName
+            }
+        '''
+
+        then:
+        def classError = thrown(MultipleCompilationErrorsException)
+        classError.errorCollector.errors.size() == 1
+        classError.message.contains("Default-values annotation pk.DisplayDefaults can only be applied to a @DSL class or a field declared by a @DSL class")
+
+        when: "the annotation is applied to a field outside a DSL class"
+        createNonDslClass '''
+            package pk
+
+            class PlainContainer {
+                @DisplayDefaults(displayName = "Plain")
+                String displayName
+            }
+        '''
+
+        then:
+        def fieldError = thrown(MultipleCompilationErrorsException)
+        fieldError.errorCollector.errors.size() == 1
+        fieldError.message.contains("Default-values annotation pk.DisplayDefaults can only be applied to a @DSL class or a field declared by a @DSL class")
+
+        when: "the annotation is applied to a DSL class or field"
+        createClass '''
+            package pk
+
+            @DisplayDefaults(displayName = "Configured")
+            @DSL
+            class ConfiguredType {
+                String displayName
+            }
+
+            @DSL
+            class ConfiguredContainer {
+                @DisplayDefaults(displayName = "Child")
+                ConfiguredChild child
+            }
+
+            @DSL
+            class ConfiguredChild {
+                String displayName
+            }
+        '''
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
+    }
+
     @Issue("370")
     def "values member of defaultValues annotation can be remapped"() {
         given:


### PR DESCRIPTION
## Summary

- reject each `@DefaultValues`-composed annotation application unless it targets a `@DSL` class or a field declared by one
- preserve existing default and `valueTarget` semantics, with focused compiler and documentary coverage
- document the supported target guarantee and changelog entry

## Tracker impact

Related: #697

Issue #697 remains open pending review and merge. #696 is deferred context only; this pull request does not introduce a public generic target annotation. Curation impact: none beyond the localized 4.0 issue.

## Compatibility

This is a compile-time correction for previously ineffective annotation applications. Valid DSL class and DSL-field uses remain unchanged.

## Verification

- `./gradlew :klum-ast:test`
- `./gradlew groovy4Tests groovy5Tests`
- `./gradlew :klum-ast:groovy4Tests --tests com.blackbuild.klum.ast.DefaultValuesSpec --tests com.blackbuild.klum.ast.DefaultValuesDocumentaryTest :klum-ast:groovy5Tests --tests com.blackbuild.klum.ast.DefaultValuesSpec --tests com.blackbuild.klum.ast.DefaultValuesDocumentaryTest`
- `git diff --check`