### PR TITLE
Wire Schema classpath into source mirrors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,13 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Dependency compatibility
 
-- Migrated to released [AnnoDocimal 1.0.0-rc.7](https://github.com/blackbuild/anno-docimal/releases/tag/v1.0.0-rc.7)
-  (`11324cfea7d8b8ea27d13c6f2ffaeb370f3ef466`). KlumAST now uses its supported documentation-authoring and source-projection
+- Migrated to released [AnnoDocimal 1.0.0-rc.8](https://github.com/blackbuild/anno-docimal/releases/tag/v1.0.0-rc.8)
+  (`a01ef0a7a507a5800401886b63e9106f351997cd`). KlumAST now uses its supported documentation-authoring and source-projection
   APIs. The schema plugin retains its IDEA-only mirror policy while using the configuration-cache-safe projection task;
   property documentation is projected verbatim to generated Model and Builder accessors unless an accessor supplies its
-  own documentation ([#461](https://github.com/klum-dsl/klum-ast/issues/461)). Final AnnoDocimal 1.0 remains a KlumAST
+  own documentation ([#461](https://github.com/klum-dsl/klum-ast/issues/461)). Source-mirror projection now resolves
+  public generated-interface references from the Schema compile classpath without making mirrors compilation inputs
+  ([#700](https://github.com/klum-dsl/klum-ast/issues/700)). Final AnnoDocimal 1.0 remains a KlumAST
   final-release prerequisite; this change validates the immutable RC train only.
 - Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0.
 - Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes. Invalid `@Overwrite.Single(MERGE)` strategies on non-DSL fields are rejected during compilation ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).

--- a/docs/user/Usage.md
+++ b/docs/user/Usage.md
@@ -102,7 +102,8 @@ After changing a Schema, refresh the generated `Foo_DSL` source mirrors and relo
 
 For a multi-project build, use `./gradlew generateAllKlumDslSourceMirrors` to refresh every Schema project's mirror, including Layer 3 `api` and `schema` projects. The root task coordinates only; mirrors remain owned by their Schema projects. They provide completion metadata and are not build or publication inputs. [AnnoDoc Support for IntelliJ IDEA](https://github.com/blackbuild/annodoc-intellij)
 provides the complementary Quick Documentation view for compiled declarations; install it according to its current
-release instructions when you choose to use it. This 4.0 onboarding route remains a preview until a real-project field
+release instructions when you choose to use it. Mirror refresh uses the Schema's declared compile classpath to resolve
+public generated-interface references without adding mirror sources to compilation. This 4.0 onboarding route remains a preview until a real-project field
 test after the first RC confirms it; [#469](https://github.com/klum-dsl/klum-ast/issues/469) owns that evaluation.
  
  

--- a/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
+++ b/klum-ast-gradle-plugin/src/main/java/com/blackbuild/klum/ast/gradle/KlumAstSchemaPlugin.java
@@ -96,6 +96,7 @@ public class KlumAstSchemaPlugin extends AbstractKlumPlugin<KlumExtension> {
                     task.setGroup("klum");
                     task.setDescription("Refreshes IDE-only AnnoDocimal source mirrors for generated Foo_DSL namespaces.");
                     task.getClassesDirectories().from(main.getOutput().getClassesDirs());
+                    task.getReferencedClassesClasspath().from(main.getCompileClasspath());
                     task.getIncludes().set(Set.of("**/*_DSL.class"));
                     task.getExcludes().set(Set.of("**/*$*"));
                     task.getOutputDirectory().convention(mirrorDirectory);

--- a/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/build.gradle
+++ b/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'maven-publish'
 }
 
+klumSchema {
+    groovyVersion = providers.gradleProperty('fixtureGroovyVersion').orElse('3').get()
+}
+
 // The fixture supplies a synthetic AST output and resolves its generated public descriptor from Maven Central.
 configurations.api.dependencies.clear()
 configurations.compileOnly.dependencies.clear()

--- a/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/build.gradle
+++ b/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/build.gradle
@@ -6,9 +6,13 @@ plugins {
     id 'maven-publish'
 }
 
-// The fixture supplies a synthetic AST output and does not need unpublished Klum artifacts on its compiler classpath.
+// The fixture supplies a synthetic AST output and resolves its generated public descriptor from Maven Central.
 configurations.api.dependencies.clear()
 configurations.compileOnly.dependencies.clear()
+
+dependencies {
+    compileOnly 'com.blackbuild.klum.ast:klum-ast-runtime:4.0.0-rc.14'
+}
 
 tasks.named('compileJava') {
     classpath = files()
@@ -16,8 +20,13 @@ tasks.named('compileJava') {
 
 tasks.named('compileGroovy') {
     source(fileTree('compiler-input'))
-    classpath = files()
+    classpath = configurations.compileClasspath
     groovyClasspath = configurations.groovy
+}
+
+// The generic fixture input is also visible to AnnoDocimal's Javadoc stub task, which is not KlumAST-created.
+tasks.named('createClassStubs') {
+    referencedClassesClasspath.from(configurations.compileClasspath)
 }
 
 publishing {
@@ -74,6 +83,20 @@ tasks.register('assertKlumDslIsolation') {
         checks.each { name, consumed ->
             println "isolation.${name}=${consumed}"
             assert !consumed
+        }
+    }
+}
+
+tasks.register('assertKlumDslReferencedClassesClasspath') {
+    doLast {
+        def mirrorTask = tasks.named('createKlumDslSourceMirrors').get()
+        def nestedFactoryProvider = 'com.blackbuild.klum.ast.runtime.KlumFactory$BuilderFactoryProvider'
+        assert mirrorTask.referencedClassesClasspath.files == configurations.compileClasspath.files
+        try {
+            mirrorTask.class.classLoader.loadClass(nestedFactoryProvider)
+            assert false: "The plugin classloader unexpectedly contains ${nestedFactoryProvider}"
+        } catch (ClassNotFoundException ignored) {
+            println 'projection.pluginLoaderContainsFactoryProvider=false'
         }
     }
 }

--- a/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/compiler-input/example/Foo_DSL.groovy
+++ b/klum-ast-gradle-plugin/src/test/fixtures/dsl-g/schema/compiler-input/example/Foo_DSL.groovy
@@ -1,10 +1,18 @@
 package example
 
 import com.blackbuild.annodocimal.annotations.AnnoDoc
+import com.blackbuild.klum.ast.runtime.KlumBuilder
+import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactoryProvider
+
+interface Recipient {
+}
 
 @AnnoDoc('Documentation for Foo_DSL')
 interface Foo_DSL {
     @AnnoDoc('Documentation for Builder')
-    interface Builder {
+    interface Builder<T extends Recipient> extends KlumBuilder<T> {
+        BuilderFactoryProvider<T, ? extends KlumBuilder<T>> recipient(
+                BuilderFactoryProvider<T, ? extends KlumBuilder<T>> factory,
+                Closure<?> body)
     }
 }

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Issue
+import spock.lang.Unroll
 
 import java.nio.file.Files
 import java.security.MessageDigest
@@ -142,9 +143,12 @@ class KlumDslSourceMirrorsIntegrationTest extends Specification {
     }
 
     @Issue('700')
-    def "source mirrors resolve polymorphic factory providers from the Schema compile classpath"() {
+    @Unroll
+    def "source mirrors resolve polymorphic factory providers from the Schema compile classpath with Groovy #groovyVersion"() {
         when: 'the external Schema project projects a generated signature that names a nested runtime type'
-        BuildResult generated = run(':schema:createKlumDslSourceMirrors', ':schema:assertKlumDslReferencedClassesClasspath')
+        BuildResult generated = run(
+                ':schema:createKlumDslSourceMirrors', ':schema:assertKlumDslReferencedClassesClasspath',
+                "-PfixtureGroovyVersion=$groovyVersion")
 
         then: 'the dependency is supplied to projection but remains absent from the plugin loader'
         generated.task(':schema:createKlumDslSourceMirrors').outcome == TaskOutcome.SUCCESS
@@ -158,6 +162,9 @@ class KlumDslSourceMirrorsIntegrationTest extends Specification {
         and: 'the mirror does not become a compilation input'
         BuildResult isolation = run(':schema:assertKlumDslIsolation')
         isolation.output.readLines().findAll { it.startsWith('isolation.') }.every { it.endsWith('=false') }
+
+        where:
+        groovyVersion << [3, 4, 5]
     }
 
     @Issue('559')

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
@@ -141,6 +141,25 @@ class KlumDslSourceMirrorsIntegrationTest extends Specification {
         mirror.text.contains('Updated documentation for Foo_DSL')
     }
 
+    @Issue('700')
+    def "source mirrors resolve polymorphic factory providers from the Schema compile classpath"() {
+        when: 'the external Schema project projects a generated signature that names a nested runtime type'
+        BuildResult generated = run(':schema:createKlumDslSourceMirrors', ':schema:assertKlumDslReferencedClassesClasspath')
+
+        then: 'the dependency is supplied to projection but remains absent from the plugin loader'
+        generated.task(':schema:createKlumDslSourceMirrors').outcome == TaskOutcome.SUCCESS
+        generated.output.contains('projection.pluginLoaderContainsFactoryProvider=false')
+
+        and: 'the IDE-only mirror retains the nested public factory-provider reference'
+        File mirror = new File(testProject, 'schema/build/generated/sources/klum-dsl-ide/main/example/Foo_DSL.java')
+        mirror.text.contains('KlumFactory.BuilderFactoryProvider')
+        mirror.text.contains('recipient(')
+
+        and: 'the mirror does not become a compilation input'
+        BuildResult isolation = run(':schema:assertKlumDslIsolation')
+        isolation.output.readLines().findAll { it.startsWith('isolation.') }.every { it.endsWith('=false') }
+    }
+
     @Issue('559')
     def "root aggregate refreshes one Schema mirror without producing a payload"() {
         when: 'the root entry point refreshes the Schema-owned mirror'

--- a/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
+++ b/klum-ast-gradle-plugin/src/test/groovy/com/blackbuild/klum/ast/gradle/KlumDslSourceMirrorsIntegrationTest.groovy
@@ -160,7 +160,7 @@ class KlumDslSourceMirrorsIntegrationTest extends Specification {
         mirror.text.contains('recipient(')
 
         and: 'the mirror does not become a compilation input'
-        BuildResult isolation = run(':schema:assertKlumDslIsolation')
+        BuildResult isolation = run(':schema:assertKlumDslIsolation', "-PfixtureGroovyVersion=$groovyVersion")
         isolation.output.readLines().findAll { it.startsWith('isolation.') }.every { it.endsWith('=false') }
 
         where:

--- a/settings.gradle
+++ b/settings.gradle
@@ -63,7 +63,7 @@ dependencyResolutionManagement {
 
             bundle "spockRuntime", ["bytebuddy", "objenesis"]
 
-            version("annodocimal", "1.0.0-rc.7")
+            version("annodocimal", "1.0.0-rc.8")
             library("annodocimal-annotations", "com.blackbuild.annodocimal", "anno-docimal-annotations").versionRef("annodocimal")
             library("annodocimal-global-ast", "com.blackbuild.annodocimal", "anno-docimal-global-ast").versionRef("annodocimal")
             library("annodocimal-gradle-plugin", "com.blackbuild.annodocimal", "anno-docimal-gradle-plugin").versionRef("annodocimal")


### PR DESCRIPTION
## Summary

- supplies each Schema project’s compile classpath to the IDE-only source-mirror projection task
- upgrades to AnnoDocimal 1.0.0-rc.8 and proves nested factory-provider projection from an external dependency
- covers the external fixture on Groovy 3, 4, and 5 while preserving mirror isolation

## Validation

- `./gradlew :klum-ast-gradle-plugin:test --tests com.blackbuild.klum.ast.gradle.KlumDslSourceMirrorsIntegrationTest --console=plain --warning-mode=none`
- `./gradlew check --console=plain --warning-mode=none`
- `git diff --check origin/master...HEAD`

Related: #700

Issue #700 remains open for Hive acceptance reconciliation.