### PR TITLE
Project cross-source Builder descriptors into public API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Fixed cross-source `@Owner(root = true)` public Builder accessors to expose the target model's
+  `Root_DSL.Builder<Root>` contract instead of the hidden `Root$Builder` implementation. Generated
+  AnnoDocimal source mirrors now preserve that same public type ([#702](https://github.com/klum-dsl/klum-ast/issues/702)).
 - Qualified same-source static model converters now project to active-session Builders in relocated lifecycle and
   mutator code, while ordinary root converter calls retain their completed-model result ([#662](https://github.com/klum-dsl/klum-ast/issues/662)).
 

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -36,6 +36,26 @@ use this guide for Builder-first diagnostics:
 | A member beginning with `$klum$` is rejected | The namespace is reserved for generated implementation members. | Rename the source member. |
 | A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. Source-visible recursive calls, including unqualified static calls to same-source converters, are projected. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
 
+### Public Builder Contracts
+
+Generated accessors always expose `Foo_DSL.Builder<Foo>`, never the hidden `Foo$Builder` implementation. This also
+applies when two source files compile together and an `@Owner(root = true)` target has not yet been resolved. (See:
+`GeneratedDslSupportSpec#'projects an unresolved cross-source owner Builder into the public namespace'`.)
+
+```groovy
+// Child.groovy
+@DSL
+class Child {
+    @Owner(root = true) Root root
+}
+
+// Root.groovy
+@DSL
+class Root {}
+```
+
+In generated signatures and IDE source mirrors, `Child_DSL.Builder` uses `Root_DSL.Builder<Root>` for `root`.
+
 ### Builder-phase Type Checks
 
 Relationships are Builders until the graph materializes. A completed-model `instanceof` check therefore belongs in a

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -481,14 +481,14 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         ClassNode type = field.getType();
         ClassNode storageValueType = getBuilderStorageValueType(field);
         if (!isCollection(type) && !isMap(type) && isDSLObject(storageValueType))
-            return getRwClassOf(storageValueType).getPlainNodeReference();
+            return getRwClassOf(storageValueType, field.getOwner()).getPlainNodeReference();
         if (isCollection(type) && isDSLObject(storageValueType))
-            return makeClassSafeWithGenerics(type, new GenericsType(getRwClassOf(storageValueType).getPlainNodeReference()));
+            return makeClassSafeWithGenerics(type, new GenericsType(getRwClassOf(storageValueType, field.getOwner()).getPlainNodeReference()));
         if (isMap(type) && isDSLObject(storageValueType))
                 return makeClassSafeWithGenerics(
                         type,
                         new GenericsType(getKeyTypeForMap(type)),
-                        new GenericsType(getRwClassOf(storageValueType).getPlainNodeReference())
+                        new GenericsType(getRwClassOf(storageValueType, field.getOwner()).getPlainNodeReference())
                 );
         return type;
     }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
@@ -55,6 +55,7 @@ public class DslAstHelper {
     private static final String KEY_FIELD_METADATA_KEY = DSLASTTransformation.class.getName() + ".keyfield";
     private static final String OWNER_FIELD_METADATA_KEY = DSLASTTransformation.class.getName() + ".ownerfield";
     private static final String ELEMENT_NAME_METADATA_KEY = DSLASTTransformation.class.getName() + ".elementName";
+    private static final String MODEL_CLASS_METADATA_KEY = DSLASTTransformation.class.getName() + ".modelclass";
     public static final ClassNode KLUM_GENERATED_CLASSNODE = ClassHelper.make(KlumGenerated.class);
 
     private static final String DELAYED_ACTIONS_METADATA_KEY = DSLASTTransformation.class.getName() + ".delayedActions";
@@ -126,9 +127,26 @@ public class DslAstHelper {
         return result;
     }
 
+    /**
+     * Returns a Builder type for a field that may be projected into another source's public contract.
+     * Cross-source unresolved placeholders have no {@linkplain ClassNode#getOuterClass() outer class}, so retain
+     * their model identity explicitly for {@link GeneratedDslSupport#publicType(ClassNode)}.
+     */
+    public static ClassNode getRwClassOf(ClassNode classNode, ClassNode projectionConsumer) {
+        ClassNode result = getRwClassOf(classNode);
+        if (result != null && !classNode.isResolved() && classNode.getModule() != projectionConsumer.getModule()
+                && result.redirect().getNodeMetaData(MODEL_CLASS_METADATA_KEY) == null)
+            result.redirect().setNodeMetaData(MODEL_CLASS_METADATA_KEY, classNode.redirect());
+        return result;
+    }
+
     public static ClassNode getModelClassFor(ClassNode classNode) {
         if (!classNode.getName().endsWith(DSLASTTransformation.RW_CLASS_SUFFIX))
             return null;
+
+        ClassNode modelClass = classNode.redirect().getNodeMetaData(MODEL_CLASS_METADATA_KEY);
+        if (modelClass != null)
+            return modelClass;
 
         ClassNode outerClass = classNode.getOuterClass();
 

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -42,12 +42,16 @@ import com.blackbuild.klum.ast.runtime.internal.process.BreadcrumbCollector
 import groovy.lang.DelegatesTo
 import groovy.transform.CompileStatic
 import org.intellij.lang.annotations.Language
+import org.codehaus.groovy.control.CompilationUnit
 import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
 
 import javax.tools.ToolProvider
 import java.io.DataInputStream
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import java.net.URLClassLoader
 
 class GeneratedDslSupportSpec extends AbstractDSLSpec {
 
@@ -564,6 +568,55 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         mirror.contains('The generated DSL support namespace for sample.Foo.')
         mirror.contains('Creates a new')
         getClass('sample.Foo_DSL$Builder').getAnnotation(AnnoDoc).value().contains('public Builder contract')
+    }
+
+    @Issue('702')
+    @Tag('documentary')
+    @See('https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Builder-First-Migration.md#public-builder-contracts')
+    def "projects an unresolved cross-source owner Builder into the public namespace"() {
+        given: 'Child is transformed before the Root source is resolved'
+        def unit = new CompilationUnit(compilerConfiguration, null, loader)
+        unit.addSource('Child.groovy', '''
+            package crosssource
+
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Owner
+
+            @DSL class Child {
+                @Owner(root = true) Root root
+            }
+        ''')
+        unit.addSource('Root.groovy', '''
+            package crosssource
+
+            import com.blackbuild.klum.ast.DSL
+
+            @DSL class Root {
+            }
+        ''')
+
+        when:
+        unit.compile()
+        def crossSourceLoader = new URLClassLoader([compilerConfiguration.targetDirectory.toURI().toURL()] as URL[], loader)
+        Class<?> childBuilder = crossSourceLoader.loadClass('crosssource.Child_DSL$Builder')
+        Class<?> rootBuilder = crossSourceLoader.loadClass('crosssource.Root_DSL$Builder')
+
+        and: 'the AnnoDocimal mirror is projected from the generated public namespace'
+        File mirrorRoot = new File(tempFolder.root, 'cross-source-mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'crosssource/Child_DSL.class')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        String mirror = new File(mirrorRoot, 'crosssource/Child_DSL.java').text
+
+        then: 'the public descriptors retain the Root model identity instead of leaking Root$Builder'
+        childBuilder.getMethod('getRoot').returnType == rootBuilder
+        childBuilder.getMethod('setRoot', rootBuilder)
+        childBuilder.declaredMethods.findAll { it.name in ['getRoot', 'setRoot'] }.every { method ->
+            !method.toGenericString().contains('Root$Builder')
+        }
+
+        and: 'the IDE-only source mirror names the same public Builder contract'
+        mirror.contains('Root_DSL.Builder<Root>')
+        !mirror.contains('Root.Builder')
     }
 
     private void createRepresentativeSchema() {


### PR DESCRIPTION
## Summary

Corrects unresolved cross-source Builder projection for @Owner(root = true) fields. Generated Child_DSL.Builder descriptors and AnnoDocimal mirrors now use Root_DSL.Builder<Root> instead of leaking Root$Builder or Root.Builder.

The compiler records the model identity only for unresolved placeholders crossing source modules, preserving ordinary same-source generated Builder behavior.

## Validation

- Focused GeneratedDslSupportSpec regression and source-mirror projection (Groovy 3)
- Full :klum-ast:test (Groovy 3)
- Focused #702 regression in :klum-ast:groovy4Tests and :klum-ast:groovy5Tests
- Root ./gradlew check
- git diff --check
- Local standards and spec review: no findings

Related: #702

Issue #702 remains open; this PR does not change AnnoDocimal, release workflows, or broader generated API scope.