### PR TITLE
Reject public static custom Factory methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 - Fixed cross-source `@Owner(root = true)` public Builder accessors to expose the target model's
   `Root_DSL.Builder<Root>` contract instead of the hidden `Root$Builder` implementation. Generated
   AnnoDocimal source mirrors now preserve that same public type ([#702](https://github.com/klum-dsl/klum-ast/issues/702)).
+- Public static methods declared on custom `Factory` classes now fail compilation instead of being silently omitted from
+  `Create`. Make these public factory operations instance methods; private, protected, and package-private static helpers
+  and model-level static converters remain supported ([#706](https://github.com/klum-dsl/klum-ast/issues/706)).
 - Qualified same-source static model converters now project to active-session Builders in relocated lifecycle and
   mutator code, while ordinary root converter calls retain their completed-model result ([#662](https://github.com/klum-dsl/klum-ast/issues/662)).
 

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -33,6 +33,7 @@ use this guide for Builder-first diagnostics:
 | A polymorphic relationship closure cannot see members of the selected subtype under static compilation | A dynamic `ChildType` Class selector retains the declared base Builder delegate. | Pass the generated factory, for example `child(ConcreteChild.Create) { concreteProperty 'value' }`, to select the exact public `ConcreteChild_DSL.Builder<ConcreteChild>` delegate. |
 | `instanceof SomeDslModel` is rejected in a Builder-phase callback | The relationship value is a Builder before materialization, not the completed DSL Object. The diagnostic names the inferred Builder type when available. | Do not use a completed-model type check in a mutator, mutating lifecycle method, or Builder-retargeted annotation closure. Move a completed-model invariant to `@Validate`; ordinary checks and operands known only as `Object` remain valid. |
 | `Child.Create.With`, `One`, or `From` is rejected in Builder-phase code | That call starts an independent root lifecycle and returns a completed model, which cannot become owned composition in the active Builder graph. | Use `Child.Create.AsBuilder.With`, `One`, or `From`, then attach the returned Builder to an owned relationship. Root factories remain valid in `@Validate` and ordinary static source factory methods. |
+| A public static method declared on a custom `Factory` is rejected | Public `Factory` methods become root operations on `Create`, which delegates to a Factory instance. | Remove `static`. Move model-level static converters out of `Factory`; they remain model methods. Non-public static Factory helpers remain valid. |
 | A member beginning with `$klum$` is rejected | The namespace is reserved for generated implementation members. | Rename the source member. |
 | A custom creator or converter is absent from `Foo_DSL` or its IDE mirror | Its model-producing path is opaque or precompiled, so KlumAST cannot safely adapt it to the active session. Source-visible recursive calls, including unqualified static calls to same-source converters, are projected. | Use the generated child method, return an explicit `KlumBuilder<Foo>`, or compile the producer source together with the schema. |
 
@@ -84,6 +85,31 @@ void supplySource() {
 
 The returned Builder must be attached to an owned relationship. Do not use `Create.AsBuilder` for an independent root
 model; use the ordinary root factory outside Builder-phase code instead.
+
+### Factory Methods Exposed Through `Create`
+
+Public methods declared on a custom `Factory` are exposed through `Create`, so they must be instance methods. Keep
+`Factory` itself `static`; this rule applies only to its public methods. Private, protected, and package-private static
+helpers remain internal to the Factory. Model-level static converters remain outside the Factory contract.
+
+(See: `BuilderFirstMigrationDocumentaryTest#'exposes an instance Factory method through Create'`.)
+
+```groovy
+@DSL
+class ServicePlan {
+    String name
+
+    static class Factory extends KlumFactory.Unkeyed<ServicePlan> {
+        protected Factory() { super(ServicePlan) }
+
+        ServicePlan standard(String name) {
+            Create.With(name: name)
+        }
+    }
+}
+
+assert ServicePlan.Create.standard('catalog').name == 'catalog'
+```
 
 ### Map Configurator Overrides
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -96,6 +96,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     private static final String SET_SINGLE_FIELD = "setSingleField";
     private static final String CREATE_SINGLE_CHILD = "createSingleChild";
     private static final String FACTORY_NAME = "factory";
+    private static final String STATIC_FACTORY_METHOD_MESSAGE = "Public methods declared on a DSL Factory are exposed through Create and must be instance methods. Remove static, or move a model-level static converter out of Factory.";
     private static final String SCHEDULE_APPLY_LATER = "scheduleApplyLater";
     private static final String OPTIONAL_PARAMETERS_DOCUMENTATION = "the optional parameters";
     private static final String CONFIGURATION_CLOSURE_DOCUMENTATION = "the closure to configure the new element";
@@ -1611,6 +1612,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         ClassNode defaultImpl = getNullSafeClassMember(getAnnotation(annotatedClass, DSL_CONFIG_ANNOTATION), "defaultImpl", annotatedClass);
         ClassNode factoryType = getFactoryBase(defaultImpl);
         rejectReservedKlumNamespace(factoryType);
+        rejectPublicStaticFactoryMethods(factoryType);
         BuilderMethodProjection.ensureProjectedMethods(factoryType, defaultImpl);
 
         boolean factoryIsGeneric = factoryType.redirect().getGenericsTypes() != null;
@@ -1650,6 +1652,17 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         GeneratedDslSupport.linkFactory(annotatedClass, factoryClass);
         factoryField.setType(GeneratedDslSupport.of(annotatedClass).getFactoryInterface().getPlainNodeReference());
         annotatedClass.addField(factoryField);
+    }
+
+    private void rejectPublicStaticFactoryMethods(ClassNode factoryType) {
+        if (factoryType.equals(KLUM_FACTORY) || factoryType.equals(KEYED_FACTORY) || factoryType.equals(UNKEYED_FACTORY))
+            return;
+
+        factoryType.getMethods().stream()
+                .filter(method -> method.getDeclaringClass().redirect().equals(factoryType.redirect()))
+                .filter(MethodNode::isPublic)
+                .filter(MethodNode::isStatic)
+                .forEach(method -> addError(STATIC_FACTORY_METHOD_MESSAGE, method));
     }
 
     private ClassNode getFactoryBase(ClassNode defaultImpl) {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationDocumentaryTest.groovy
@@ -91,4 +91,31 @@ class BuilderFirstMigrationDocumentaryTest extends AbstractDSLSpec {
         then:
         deployment.service.class == getClass("Service")
     }
+
+    @Issue("706")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Builder-First-Migration.md#factory-methods-exposed-through-create")
+    def "exposes an instance Factory method through Create"() {
+        given:
+        createClass '''
+            package pk
+
+            import com.blackbuild.klum.ast.runtime.KlumFactory
+
+            @DSL
+            class ServicePlan {
+                String name
+
+                static class Factory extends KlumFactory.Unkeyed<ServicePlan> {
+                    protected Factory() { super(ServicePlan) }
+
+                    ServicePlan standard(String name) {
+                        ServicePlan.Create.With(name: name)
+                    }
+                }
+            }
+        '''
+
+        expect:
+        clazz.Create.standard('catalog').name == 'catalog'
+    }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FactoryMethodProjectionTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FactoryMethodProjectionTest.groovy
@@ -80,7 +80,7 @@ class FactoryMethodProjectionTest extends AbstractDSLSpec {
     }
 
     def "allows non-public static Factory helpers"() {
-        expect:
+        when:
         createClass '''
             import com.blackbuild.klum.ast.runtime.KlumFactory
             import groovy.transform.PackageScope
@@ -96,10 +96,13 @@ class FactoryMethodProjectionTest extends AbstractDSLSpec {
                 }
             }
         '''
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
     }
 
     def "allows model-level static converters"() {
-        expect:
+        when:
         createClass '''
             @DSL
             class Product {
@@ -110,5 +113,8 @@ class FactoryMethodProjectionTest extends AbstractDSLSpec {
                 }
             }
         '''
+
+        then:
+        notThrown(MultipleCompilationErrorsException)
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FactoryMethodProjectionTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/FactoryMethodProjectionTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import spock.lang.Issue
+
+@Issue("706")
+class FactoryMethodProjectionTest extends AbstractDSLSpec {
+
+    private static final STATIC_FACTORY_METHOD_MESSAGE = "Public methods declared on a DSL Factory are exposed through Create and must be instance methods. Remove static, or move a model-level static converter out of Factory."
+
+    def "rejects a public static method declared on a custom Factory"() {
+        when:
+        createClass '''
+            import com.blackbuild.klum.ast.runtime.KlumFactory
+
+            @DSL
+            class Product {
+                static class Factory extends KlumFactory.Unkeyed<Product> {
+                    protected Factory() { super(Product) }
+
+                    public static Product named(String name) {
+                        Product.Create.With(name: name)
+                    }
+                }
+
+                String name
+            }
+        '''
+
+        then:
+        def error = thrown(MultipleCompilationErrorsException)
+        error.message.contains(STATIC_FACTORY_METHOD_MESSAGE)
+        error.message.contains("@ line 9")
+    }
+
+    def "projects a public instance method declared on a custom Factory through Create"() {
+        given:
+        createClass '''
+            import com.blackbuild.klum.ast.runtime.KlumFactory
+
+            @DSL
+            class Product {
+                static class Factory extends KlumFactory.Unkeyed<Product> {
+                    protected Factory() { super(Product) }
+
+                    Product named(String name) {
+                        Product.Create.With(name: name)
+                    }
+                }
+
+                String name
+            }
+        '''
+
+        expect:
+        clazz.Create.named('catalog').name == 'catalog'
+    }
+
+    def "allows non-public static Factory helpers"() {
+        expect:
+        createClass '''
+            import com.blackbuild.klum.ast.runtime.KlumFactory
+            import groovy.transform.PackageScope
+
+            @DSL
+            class Product {
+                static class Factory extends KlumFactory.Unkeyed<Product> {
+                    protected Factory() { super(Product) }
+
+                    private static String privateHelper() { 'private' }
+                    protected static String protectedHelper() { 'protected' }
+                    @PackageScope static String packageHelper() { 'package' }
+                }
+            }
+        '''
+    }
+
+    def "allows model-level static converters"() {
+        expect:
+        createClass '''
+            @DSL
+            class Product {
+                String name
+
+                static Product fromName(String name) {
+                    Product.Create.With(name: name)
+                }
+            }
+        '''
+    }
+}


### PR DESCRIPTION
## Summary
- reject directly declared public static custom Factory methods before Create projection omits them
- preserve public instance projection, non-public static helpers, and model-level static converters
- document the migration rule and its executable Factory example

## Validation
- ./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.FactoryMethodProjectionTest
- ./gradlew :klum-ast:test
- ./gradlew groovy4Tests groovy5Tests
- ./gradlew check
- git diff --check

Related: #706

This pull request leaves the issue state unchanged.