### PR TITLE
Clarify compiler-test success controls

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -34,6 +34,20 @@ Typical commands are:
 ./gradlew check
 ```
 
+## Compiler-test success controls
+
+In a Spock compiler test, do not use a bare `expect:` block that contains only a side-effecting `createClass(...)` call.
+That form does not make the compile-success intent evident. Express successful compilation explicitly, normally as:
+
+```groovy
+when:
+createClass(...)
+then:
+notThrown(MultipleCompilationErrorsException)
+```
+
+An equally explicit success assertion is acceptable when it makes the tested compiler contract materially clearer.
+
 ## Issue traceability
 
 Every newly added test must carry Spock's `@Issue` annotation with the number of its driving GitHub issue. When a complete

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -34,10 +34,12 @@ Typical commands are:
 ./gradlew check
 ```
 
-## Compiler-test success controls
+## Spock assertion clarity
 
-Use Spock's `expect:` only for a simple one-line statement whose method names or operators make its meaning
+Use Spock's `expect:` only for a rather simple, one-line statement whose method names or operators make its meaning
 self-explanatory.
+
+## Compiler-test success controls
 
 In a Spock compiler test, do not use a bare `expect:` block that contains only a side-effecting `createClass(...)` call.
 That form does not make the compile-success intent evident. Express successful compilation explicitly, normally as:

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -36,6 +36,9 @@ Typical commands are:
 
 ## Compiler-test success controls
 
+Use Spock's `expect:` only for a simple one-line statement whose method names or operators make its meaning
+self-explanatory.
+
 In a Spock compiler test, do not use a bare `expect:` block that contains only a side-effecting `createClass(...)` call.
 That form does not make the compile-success intent evident. Express successful compilation explicitly, normally as:
 


### PR DESCRIPTION
## Summary

- clarify that `expect:` is reserved for simple one-line assertions whose method names or operators make the meaning self-explanatory
- clarify that compiler success controls must not rely on a bare side-effecting `expect:` block
- document the preferred explicit `when:` / `then:` assertion using `notThrown(MultipleCompilationErrorsException)`
- allow equally explicit assertions where they explain the compiler contract more clearly

## Context and scope

This documentation-only clarification follows maintainer review of PR #707. It changes no test code, behavior, public documentation, changelog, issues, or release workflow.

## Validation

- `git diff --check`
- Documentation-only change; Groovy test lanes were not run under `docs/agents/testing.md`.