### PR TITLE
Plan Template creation entrypoint

### DIFF
--- a/docs/adr/0016-template-creation-and-scoped-application.md
+++ b/docs/adr/0016-template-creation-and-scoped-application.md
@@ -1,0 +1,180 @@
+# Template creation and scoped Template application
+
+Date: 2026-08-09
+
+Status: Proposed
+
+Tracking issue: [#710 — Separate Template creation from scoped Template application](https://github.com/klum-dsl/klum-ast/issues/710)
+
+Implementation plan: [ADR 0016 implementation plan](../implementation/adr-0016-template-creation-and-scoped-application.md)
+
+Parent decisions: [ADR 0003 — Builder-first materialization](0003-builder-first-materialization.md),
+[ADR 0004 — `AsBuilder` composition](0004-asbuilder-composition-protocol.md),
+[ADR 0005 — generated DSL support API](0005-generated-dsl-support-api.md), and
+[ADR 0015 — generated-schema runtime linkage](0015-generated-schema-runtime-linkage.md).
+
+## Context
+
+Templates are completed DSL Objects with persistent Template identity and a serializable recipe. They are created by a
+root lifecycle, then applied as recipes into fresh Builder graphs. ADR 0004 deliberately establishes those semantics; it
+does not select a single public language for entering them.
+
+The current generated surface has two equivalent creation routes and one mixed-purpose handler:
+
+```groovy
+Service.Create.Template { region 'eu-central' }       // inherited Factory method
+Service.Template.Create { region 'eu-central' }       // generated Template handler
+Service.Template.With(template) { /* create models */ } // scoped application
+```
+
+`Service.Create` is a `Service_DSL.Factory`, but its generated contract mirrors the inherited `KlumFactory.Template(...)`
+and `TemplateFrom(...)` methods. `Service.Template` is a final field of type `Service_DSL.Template`; that interface exposes
+both `With`/`WithAll` application and `Create`/`CreateFrom` creation methods. The user guide teaches the latter creation
+route, while migration and phase guidance still show the former. There is no `Service.Template.From` method: the existing
+source-input spelling is `CreateFrom`.
+
+This ambiguity is small in implementation terms but freezes two incompatible stories at the 4.0 public-contract boundary.
+In particular, a final `Create.Template` property cannot coexist truthfully with the inherited `Template(...)` method
+family: Groovy property/method resolution would make the resulting language and static surface ambiguous.
+
+## Decision
+
+### `Create` owns root creation modes
+
+Every root-creation mode is grouped below `Create`. Ordinary root construction remains unchanged; Template root
+construction receives a generated final property:
+
+```groovy
+@DSL
+class ServiceConfiguration {
+    String region
+}
+
+def template = ServiceConfiguration.Create.Template.With {
+    region 'eu-central'
+}
+
+def fromFile = ServiceConfiguration.Create.Template.From(new File('service-template.groovy'))
+
+ServiceConfiguration.Template.With(template) {
+    ServiceConfiguration.Create.With { }
+}
+```
+
+`Create.Template` is a generated final Factory property, not a method inherited from `KlumFactory`. Its generated,
+nameable type is `ServiceConfiguration_DSL.Factory.Template`; Java reaches the same property through
+`ServiceConfiguration.Create.getTemplate()`.
+
+The nested Template-creation interface has the same root input families as the current Template creation methods:
+
+```java
+interface ServiceConfiguration_DSL {
+    interface Factory {
+        Template getTemplate();
+
+        interface Template {
+            ServiceConfiguration With();
+            ServiceConfiguration With(Map<String, ?> values);
+            ServiceConfiguration With(Closure<?> configuration);
+            ServiceConfiguration With(Map<String, ?> values, Closure<?> configuration);
+            ServiceConfiguration From(File source);
+            ServiceConfiguration From(File source, ClassLoader loader);
+            ServiceConfiguration From(URL source);
+            ServiceConfiguration From(URL source, ClassLoader loader);
+        }
+    }
+}
+```
+
+The closure overloads retain `@DelegatesTo(ServiceConfiguration_DSL.Builder)` and `DELEGATE_ONLY`. A return value is the
+same completed, marked Template model as today. This is a root lifecycle, not `Create.AsBuilder`: it creates no unsealed
+Builder and does not require an active `ConstructionSession`.
+
+### `Template` owns scoped application
+
+`ServiceConfiguration.Template.With` and `WithAll` retain their existing scope, nesting, thread-local restoration, and
+return-value contracts. Their public generated type remains `ServiceConfiguration_DSL.Template`. The map overload of
+`With` remains an anonymous *scoped application* convenience: it creates an implementation-local temporary recipe and
+returns the body result, not a Template creation entrypoint for callers to retain.
+
+Consequently, current documentation calls `Template` the scoped application handler. It must not present it as the
+canonical way to create a reusable Template.
+
+### Compatibility disposition
+
+The inherited `KlumFactory.Template(...)` and `TemplateFrom(...)` methods are removed. Generated Factory
+implementations must not override or reintroduce them. Therefore the current `Foo.Create.Template(...)` and
+`Foo.Create.TemplateFrom(...)` routes disappear before the `Foo.Create.Template` property is generated; source and
+binary compatibility for those methods cannot be retained without reintroducing the ambiguity this decision removes.
+
+`Foo.Template.Create(...)` and `CreateFrom(...)` remain on `Foo_DSL.Template` and its generated adapter as deprecated,
+forwarding 4.x aliases. They retain all current overloads and semantics, and their deprecation text names the matching
+`Foo.Create.Template.With(...)` or `From(...)` route. They are compatibility bridges, not a second canonical interface;
+new generated documentation, source mirrors, GDSL, examples, and migration guidance use only `Create.Template` for
+creation. The aliases may be removed only by a future explicit major-version compatibility decision.
+
+This keeps existing documented 4.0 RC schema code recompilable while making the one unavoidable breaking route
+(`Create.Template(...)`) deliberate, discoverable, and mechanically rejected rather than dynamically shadowed.
+
+The Builder-first migration helper may offer only direct, unambiguous rewrites for this decision: known type-qualified
+`Foo.Create.Template*` and `Foo.Template.Create*` calls become the corresponding `Foo.Create.Template.With` or `From`
+calls. It must run from a schema-module directory in a clean, version-controlled worktree, show its diff for review, and
+leave the source to the migration checklist and compiler. It does not rewrite scoped `Foo.Template.With`/`WithAll`,
+receiver variables, custom expressions, or dynamic construction calls.
+
+### Preserve Template semantics and linkage discipline
+
+This decision changes entrypoints only. It does not alter Template identity, synthetic abstract implementations, omitted
+lifecycle callbacks, key/owner treatment, recipe capture/replay, copy-source behavior, ownership/adoption, serialization,
+Jackson rejection, or scoped restoration from ADR 0004. The new Factory adapter uses the existing template root-creation
+path; it never exposes `TemplateManager`, Builder state, `FactoryHelper`, or other runtime internals.
+
+The generated implementation may link a narrow `runtime.generated` bridge under ADR 0015, but all schema/client
+descriptors must name only `Foo_DSL.Factory.Template`, `Foo_DSL.Template`, ordinary public runtime types, and model types.
+`Foo_DSL.Factory.Template` is a supported generated hook: callers may name it as a receiver/parameter/return type but
+must not implement or subclass it.
+
+## Alternatives considered
+
+### Keep `Foo.Template.Create` as the canonical creation route
+
+This retains source compatibility but leaves the public `Template` handler with two unrelated responsibilities. A caller
+must learn whether a method creates a Template or scopes one from the operation name, rather than from its locality. It
+also leaves the inherited `Foo.Create.Template(...)` route unexplained. The interface is shallow: creation and scope
+rules remain spread across the handler and the Factory.
+
+### Add `Foo.Create.AsTemplate.With` instead
+
+`AsTemplate` resembles `AsBuilder`, but the analogy is misleading. `AsBuilder` returns an unsealed child Builder only in
+an already-active session; Template creation is a root factory that materializes a completed recipe. It would also revive
+the historical `Create.AsTemplate` vocabulary that current migration guidance deliberately moved away from. `Create.Template`
+places the mode beside root creation without borrowing active-session semantics.
+
+### Remove every legacy Template creation route immediately
+
+Removing `Foo.Template.Create/CreateFrom` would give the smallest final surface, but the documented spelling is common
+in current schemas and its removal provides little additional depth once it is clearly deprecated. Keeping forwarding
+aliases concentrates compatibility in one small adapter while new callers learn one interface. The conflicting
+`Foo.Create.Template*` method family cannot receive the same treatment because the property uses its name.
+
+## Consequences
+
+- Schema Developers see one canonical root-creation tree and one application tree, with clear IDE completion from their
+  first segment.
+- Java and static Groovy can name truthful nested generated types; the closure delegate remains a concrete public Builder.
+- 4.0 RC users of `Foo.Create.Template(...)` migrate to `Foo.Create.Template.With(...)`; users of the documented
+  `Foo.Template.Create(...)` spelling receive a deprecation path rather than an immediate rewrite requirement.
+- `Foo_DSL.Template` remains a supported generated type but has a deliberately narrow canonical role. Its deprecated
+  aliases are compatibility members, not an invitation to add future creation operations there.
+- The Factory template adapter is a deep module: the public nested interface expresses creation inputs while the
+  existing root lifecycle, Template companion, recipe, and serialization mechanics remain behind its seam.
+- The generated public-surface inventory, source mirrors, GDSL completion, generated Javadocs, and user docs must change
+  together. A bytecode-only implementation is insufficient because it would leave Java and IDE users with different
+  interfaces.
+
+## Acceptance boundary
+
+This proposed decision is ready to implement only after explicit maintainer acceptance. The implementation must prove
+the descriptors, Java and static Groovy 3/4/5 consumption, recipe/ownership/serialization preservation, deprecated alias
+behavior, absence of the former Factory methods, mirror/GDSL parity, and the documentation/migration/public-inventory
+updates listed in the implementation plan.

--- a/docs/adr/0016-template-creation-and-scoped-application.md
+++ b/docs/adr/0016-template-creation-and-scoped-application.md
@@ -61,16 +61,17 @@ ServiceConfiguration.Template.With(template) {
 }
 ```
 
-`Create.Template` is a generated final Factory property, not a method inherited from `KlumFactory`. Its generated,
-nameable type is `ServiceConfiguration_DSL.Factory.Template`; Java reaches the same property through
-`ServiceConfiguration.Create.getTemplate()`.
+`Create.Template` is a generated public static final Factory field, not a method inherited from `KlumFactory`. Its
+generated, nameable type is `ServiceConfiguration_DSL.Factory.Template`. Java and Groovy both retain the DSL spelling:
+`ServiceConfiguration.Create.Template.From(...)`. This deliberately follows the existing `Create` field's upper-case
+language rather than introducing a JavaBean-style lower-case `template` property.
 
 The nested Template-creation interface has the same root input families as the current Template creation methods:
 
 ```java
 interface ServiceConfiguration_DSL {
     interface Factory {
-        Template getTemplate();
+        Template Template = /* generated model-specific Template factory */;
 
         interface Template {
             ServiceConfiguration With();
@@ -103,9 +104,11 @@ canonical way to create a reusable Template.
 ### Compatibility disposition
 
 The inherited `KlumFactory.Template(...)` and `TemplateFrom(...)` methods are removed. Generated Factory
-implementations must not override or reintroduce them. Therefore the current `Foo.Create.Template(...)` and
-`Foo.Create.TemplateFrom(...)` routes disappear before the `Foo.Create.Template` property is generated; source and
-binary compatibility for those methods cannot be retained without reintroducing the ambiguity this decision removes.
+implementations must not override or reintroduce them. The model-specific `Foo_DSL.Factory` interface instead defines
+the public static final `Template` field, initialized by a generated-only bridge bound to `Foo`. Therefore the current
+`Foo.Create.Template(...)` and `Foo.Create.TemplateFrom(...)` routes disappear before the `Foo.Create.Template` field is
+generated; source and binary compatibility for those methods cannot be retained without reintroducing the ambiguity this
+decision removes.
 
 `Foo.Template.Create(...)` and `CreateFrom(...)` remain on `Foo_DSL.Template` and its generated adapter as deprecated,
 forwarding 4.x aliases. They retain all current overloads and semantics, and their deprecation text names the matching
@@ -161,7 +164,8 @@ aliases concentrates compatibility in one small adapter while new callers learn 
 
 - Schema Developers see one canonical root-creation tree and one application tree, with clear IDE completion from their
   first segment.
-- Java and static Groovy can name truthful nested generated types; the closure delegate remains a concrete public Builder.
+- Java and static Groovy can name truthful nested generated types and use the same `Foo.Create.Template` field chain; the
+  closure delegate remains a concrete public Builder.
 - 4.0 RC users of `Foo.Create.Template(...)` migrate to `Foo.Create.Template.With(...)`; users of the documented
   `Foo.Template.Create(...)` spelling receive a deprecation path rather than an immediate rewrite requirement.
 - `Foo_DSL.Template` remains a supported generated type but has a deliberately narrow canonical role. Its deprecated

--- a/docs/implementation/adr-0016-template-creation-and-scoped-application.md
+++ b/docs/implementation/adr-0016-template-creation-and-scoped-application.md
@@ -1,0 +1,199 @@
+# ADR 0016 implementation plan: Template creation and scoped application
+
+This plan implements proposed [ADR 0016](../adr/0016-template-creation-and-scoped-application.md) for
+[#710](https://github.com/klum-dsl/klum-ast/issues/710). It is a public 4.0 generated-contract change, not a change to
+the Template recipe/materialization protocol in ADR 0004.
+
+## Confirmed current surface and failure path
+
+| Receiver | Current public members | Current role | Problem |
+| --- | --- | --- | --- |
+| `Foo.Create : Foo_DSL.Factory` | inherited/projected `Template()` / `Template(Map, Closure)` / `Template(Closure)` / `Template(Map)` and `TemplateFrom(File/URL[, ClassLoader])` | root Template creation | It occupies the name required by the proposed final `Template` property. |
+| `Foo.Template : Foo_DSL.Template` | `With(template, body)`, `With(map, body)`, `WithAll(map/list, body)`, `Create(...)`, `CreateFrom(File/URL[, ClassLoader])` | both scope application and root Template creation | One generated interface presents two distinct interfaces to callers. |
+| `Foo_DSL.Template` | public interface implemented by `Foo$_Template` through `GeneratedTemplateSupport` | nameable generated contract | It must retain scope methods and may retain only deprecated creation aliases. |
+
+`TemplateMethods` creates `Foo.Template`, its adapter, and every member of `Foo_DSL.Template`. `GeneratedDslSupport`
+creates the namespace/interface and projects factory implementation members to `Foo_DSL.Factory`. `KlumFactory` supplies
+the inherited `Template*` methods, while `BoundTemplateHandler`, `GeneratedTemplateSupport`, and `FactoryHelper` execute
+the current Template creation/application paths. `FactoryHelper.createAsTemplate` is the semantic authority for marked
+Template root construction.
+
+The user documentation mostly teaches `Foo.Template.Create` and `CreateFrom`, but `Model-Phases.md`, `Migration.md`,
+and historical changelog material still contain `Foo.Create.Template` or older spellings. Existing focused behavior is
+distributed through `TemplatesSpec`, `BoundTemplatesSpec`, `TemplateCompanionSpec`, copy-source coverage, and
+`TemplatesDocumentaryTest`; generated descriptor/Java/static-Groovy coverage is in `GeneratedDslSupportSpec`.
+
+## Target contract
+
+```groovy
+@DSL
+class ServiceConfiguration {
+    String region
+}
+
+def baseline = ServiceConfiguration.Create.Template.With {
+    region 'eu-central'
+}
+
+ServiceConfiguration.Template.With(baseline) {
+    ServiceConfiguration.Create.With { }
+}
+```
+
+The exact public descriptor intent is:
+
+```text
+ServiceConfiguration.Create                        : ServiceConfiguration_DSL.Factory
+ServiceConfiguration.Create.getTemplate()          : ServiceConfiguration_DSL.Factory.Template
+ServiceConfiguration_DSL.Factory.Template.With(...) : ServiceConfiguration
+ServiceConfiguration_DSL.Factory.Template.From(...) : ServiceConfiguration
+ServiceConfiguration.Template                      : ServiceConfiguration_DSL.Template
+ServiceConfiguration_DSL.Template.With/WithAll     : body result
+ServiceConfiguration_DSL.Template.Create/CreateFrom: deprecated compatibility aliases
+```
+
+The Template-creation `With` closure carries `@DelegatesTo(ServiceConfiguration_DSL.Builder)` and
+`Closure.DELEGATE_ONLY`. The scoped `With` closure preserves its existing generic body result and does not gain a Builder
+delegate. For Java, the canonical call is `ServiceConfiguration.Create.getTemplate().With(...)`; for `@CompileStatic`
+Groovy 3, 4, and 5 it is `ServiceConfiguration.Create.Template.With { ... }`.
+
+`Foo.Create.Template(...)` and `Foo.Create.TemplateFrom(...)` must be absent—not merely deprecated—so the Factory
+property cannot be shadowed. `Foo.Template.From` is not a current member and must not be invented as an alias.
+
+## Compatibility and migration matrix
+
+| Current spelling | 4.0 target | Compatibility action |
+| --- | --- | --- |
+| `Foo.Create.With(...)`, `Foo.Create.From(...)` | unchanged | no migration |
+| `Foo.Create.Template(...)` | `Foo.Create.Template.With(...)` | remove Factory method; document source/binary break and compiler absence |
+| `Foo.Create.TemplateFrom(source)` | `Foo.Create.Template.From(source)` | remove Factory method; document source/binary break |
+| `Foo.Template.Create(...)` | `Foo.Create.Template.With(...)` | retain deprecated forwarding alias throughout 4.x |
+| `Foo.Template.CreateFrom(source)` | `Foo.Create.Template.From(source)` | retain deprecated forwarding alias throughout 4.x |
+| `Foo.Template.With(template/map) { ... }` and `WithAll(...)` | unchanged | application remains source/binary compatible |
+
+The deprecated aliases preserve all currently supported map/closure and File/URL/ClassLoader overloads. Deprecation
+documentation must state the one exact replacement for each overload.
+
+## Builder-first migration-helper candidate
+
+This design admits a convenience-only migration-helper stage, not an automated migration guarantee. It may make only the
+following direct rewrites when the receiver is a statically written DSL type name:
+
+| Direct established form | Mechanical result |
+| --- | --- |
+| `Foo.Create.Template(...)` or `Foo.Create.Template { ... }` | `Foo.Create.Template.With(...)` or `Foo.Create.Template.With { ... }` |
+| `Foo.Create.TemplateFrom(source)` | `Foo.Create.Template.From(source)` |
+| `Foo.Template.Create(...)` or `Foo.Template.Create { ... }` | `Foo.Create.Template.With(...)` or `Foo.Create.Template.With { ... }` |
+| `Foo.Template.CreateFrom(source)` | `Foo.Create.Template.From(source)` |
+
+The helper must preserve map/closure argument text and every other surrounding expression. It must not touch
+`Foo.Template.With` or `WithAll`, anonymous scoped-map application, a receiver variable such as `type.Template.Create`,
+method pointers, reflection, string/script content, custom factory expressions, or any syntax it cannot recognize
+unambiguously. Those cases stay for the migration checklist and compiler diagnostics.
+
+The published script is as-is convenience text, not a build tool. Its instructions require a clean, version-controlled
+worktree and explicitly say to run it from the **schema module directory**, never the project root. The prescribed order
+is: update to the target KlumAST version; run the script; inspect and commit/revert its diff; follow the Builder-first
+migration checklist; then compile and repair remaining errors. A partially migrated, non-compilable source tree is an
+expected intermediate state. The implementation must add an executable migration-helper fixture that runs the script in
+a copied schema-module tree, proves these four direct forms change, and proves scoped application and excluded forms do
+not change. It also needs a short `Builder-First-Migration.md` section that links to the canonical Template migration
+guidance and the new Template documentary example.
+
+## Modules and seams
+
+| Area | Owner/seam | Required change |
+| --- | --- | --- |
+| Root creation | `klum-ast-runtime`: `KlumFactory`, `FactoryHelper` | Remove public `Template*` root methods from `KlumFactory`; retain the internal/root `createAsTemplate` mechanics. Add or extract a narrow generated-only Template-creation adapter rather than exposing `FactoryHelper`. |
+| Scoped application and aliases | `klum-ast-runtime`: `BoundTemplateHandler`, `GeneratedTemplateSupport` | Keep `With`/`WithAll`; make `Create`/`CreateFrom` deprecated forwarders to the one root creation implementation. Keep no raw `TemplateManager` public seam. |
+| Generated Factory property | `klum-ast`: `TemplateMethods`, factory-generation seam, `GeneratedDslSupport` | Generate a final `Template` field/getter on the hidden factory implementation, link it to a new nested public `Foo_DSL.Factory.Template` interface, and project only truthful public members. |
+| Existing Template handler | `klum-ast`: `TemplateMethods` | Keep the static `Foo.Template` field and `Foo_DSL.Template` scope methods; retain creation members only as explicitly deprecated aliases. |
+| Generated linkage | `runtime.generated` under ADR 0015 | If a runtime bridge is needed, keep it generated-only and descriptor-minimal. No schema descriptor names `BoundTemplateHandler`, `FactoryHelper`, or `TemplateManager`. |
+| IDE surfaces | source-mirror task, AnnoDocimal projection, #703 GDSL work | Mirrors must include `Factory.Template`, `getTemplate`, `With`, and `From` with the real nested type; GDSL must expose the property consistently with bytecode. Do not duplicate the mirror into compilation. |
+| Contract inventory | #468 public inventory | Refresh the generated factory/template row and artifact comparison; classify nested `Factory.Template` as generated hook and aliases as deprecated compatibility members. |
+
+## Thin vertical slices and commit boundaries
+
+### TC-1 — Establish the generated Factory Template type and property
+
+Add `Foo_DSL.Factory.Template`, create a final generated Factory field/getter typed to it, and supply the narrow bridge
+that exposes the current Template root creation inputs. Remove `Template*` from the inherited/projected Factory surface
+in the same commit; do not rely on Groovy dispatch to choose between a field and a method.
+
+**Acceptance:** reflection sees `Foo.Create.getTemplate()` returning `Foo_DSL.Factory.Template`; Java and static Groovy
+call `With` and `From`; no public Factory `Template(...)` or `TemplateFrom(...)` method exists; closure delegate metadata
+is the concrete public Builder; all produced objects are `TemplateManager.isTemplate`-true.
+
+**Commit boundary:** runtime adapter plus AST/property generation plus one focused descriptor/behavior test are one vertical
+commit. Do not move scope behavior or unrelated Template semantics in this slice.
+
+### TC-2 — Preserve scoped application and introduce deprecated aliases
+
+Narrow `Foo_DSL.Template` to its application contract in new documentation while retaining `Create` and `CreateFrom` as
+deprecated forwarding methods. Ensure the generated adapter, generated-runtime bridge, and abstract-Template path all
+delegate to the same Template root creation mechanism.
+
+**Acceptance:** `With`/`WithAll` nesting and restoration stay byte-for-byte behaviorally covered; existing `Create` and
+`CreateFrom` calls compile with deprecation and return the same marked recipe; abstract Template creation, `copyFrom`,
+ownership rejection, recipe replay, and Java serialization retain their established outcomes.
+
+**Commit boundary:** adapter/runtime deprecation work and focused compatibility/Template-companion tests. A follow-up
+commit is acceptable only for mechanical Javadoc deprecation text if implementation/test review keeps TC-2 clearer.
+
+### TC-3 — Prove full public and IDE contract parity
+
+Extend the generated public-interface fixture to inspect both nested Template interfaces and all descriptor absences.
+Add Java and `@CompileStatic` Groovy consumer fixtures, then run the existing fixture in Groovy 3/4/5 lanes. Refresh the
+IDE source mirror assertion and the GDSL contributor/fixture if #703 has landed; otherwise state and coordinate that
+dependency rather than duplicating its work.
+
+**Acceptance:** Java names `Foo_DSL.Factory.Template` and uses `Foo.Create.getTemplate()`; static Groovy uses property
+syntax and catches a deliberate old Factory-method compile failure; mirrors contain the nested type and neither source
+mirror nor GDSL advertises the removed methods. The public-inventory comparison records no internal runtime descriptor.
+
+**Commit boundary:** public-surface fixture/inventory assertion first; source-mirror/GDSL parity in a dependent commit only
+when its implementation owner permits it.
+
+### TC-4 — Publish the migration language
+
+Rewrite `Templates.md` so creation uses `Create.Template.With/From` and application uses `Template.With/WithAll`; retain
+a concise deprecated-alias note. Update `Migration.md`, `Model-Phases.md`, `Copy-Strategies.md` examples where necessary,
+`CHANGES.md`, generated Javadocs, navigation if headings move, and the #468 inventory. Add a #710 documentary example
+whose code is the canonical three-line target example.
+
+**Acceptance:** repository search finds no canonical/documented `Create.Template(...)` method calls and no invented
+`Template.From`; the documentary test has `@Issue("710")`, `@Tag("documentary")`, and `@See`; the migration-helper
+fixture demonstrates only the approved direct rewrites; render/link checks pass.
+
+**Commit boundary:** executable documentation test and user/migration/changelog/inventory update together. Do not
+retrofit unrelated Template examples beyond the entrypoint spelling.
+
+## Executable test map
+
+| Contract | Primary seam | Required proof |
+| --- | --- | --- |
+| Generated descriptor/property | `GeneratedDslSupportSpec` or a new focused `TemplateEntrypointTest` | reflection for `getTemplate`, nested `Factory.Template`, final generated field, and absence of Factory `Template*` methods |
+| Java/static Groovy language | generated consumer compilation helpers | Java `getTemplate().With/From`; `@CompileStatic` Groovy 3/4/5 property access and Builder closure delegation |
+| Deprecated compatibility | Template adapter/handler tests | each `Template.Create*` overload remains callable and annotated `@Deprecated` |
+| Root Template semantics | `TemplatesSpec`, `TemplateCompanionSpec`, `TemplatesDocumentaryTest` | marked identity, abstract synthetic implementation, lifecycle omissions, recipe replay, copy/serialization/ownership boundaries unchanged |
+| Scoped application | `BoundTemplatesSpec` | single/map/list scopes, nesting/restoration, body result and anonymous map behavior unchanged |
+| Generated/IDE surface | source-mirror and GDSL tests | source mirror emits both nested public interfaces and correct property; completion does not offer removed Factory methods |
+| Public release surface | #468 inventory fixture | new generated hook classified and no internal generated descriptor leak |
+
+New executable tests carry `@Issue("710")`; the canonical user-facing happy path is marked `@Tag("documentary")` and
+links back to the final Templates page as required by `docs/agents/testing.md`.
+
+## Risks, rollback, and open choices
+
+| Risk or question | Control |
+| --- | --- |
+| A Factory method survives through inheritance and shadows the property. | Remove the `KlumFactory.Template*` family before generating the property; assert absence by reflection and negative static compilation. |
+| A nested type collides with `Foo_DSL.Template`. | Use the distinct binary names `Foo_DSL$Factory$Template` and `Foo_DSL$Template`; assert both in bytecode and mirrors. |
+| Aliases become a permanent second documented route. | Deprecate every creation alias, keep `Foo.Template` application-only in user docs, and prohibit new creation methods on the handler in review. |
+| Moving adapters changes recipe/materialization behavior. | Delegate every route to existing `FactoryHelper.createAsTemplate`; retain ADR 0004 behavioral suite before refactoring implementation. |
+| Generated bridge expands into a handwritten runtime API. | Use only generated-runtime linkage permitted by ADR 0015 and inspect public descriptors/inventory. |
+| GDSL work has not landed when the core contract is ready. | Land bytecode/mirror truth first; coordinate the additive GDSL completion change with #703 rather than creating a parallel completion contract. |
+| A release-candidate adopter depends on `Foo.Create.Template(...)`. | The explicit migration row and compile failure give a mechanical replacement. If release timing makes this unacceptable, defer #710 rather than retaining property/method ambiguity. |
+
+The only maintainer decision still required is whether to accept ADR 0016 for 4.0. With that acceptance, TC-1 through TC-4
+are implementation-authorized in order; no additional product choice is required.

--- a/docs/implementation/adr-0016-template-creation-and-scoped-application.md
+++ b/docs/implementation/adr-0016-template-creation-and-scoped-application.md
@@ -44,7 +44,8 @@ The exact public descriptor intent is:
 
 ```text
 ServiceConfiguration.Create                        : ServiceConfiguration_DSL.Factory
-ServiceConfiguration.Create.getTemplate()          : ServiceConfiguration_DSL.Factory.Template
+ServiceConfiguration_DSL.Factory.Template          : public static final ServiceConfiguration_DSL.Factory.Template field
+ServiceConfiguration.Create.Template                : same generated field, selected through the Factory contract
 ServiceConfiguration_DSL.Factory.Template.With(...) : ServiceConfiguration
 ServiceConfiguration_DSL.Factory.Template.From(...) : ServiceConfiguration
 ServiceConfiguration.Template                      : ServiceConfiguration_DSL.Template
@@ -54,8 +55,9 @@ ServiceConfiguration_DSL.Template.Create/CreateFrom: deprecated compatibility al
 
 The Template-creation `With` closure carries `@DelegatesTo(ServiceConfiguration_DSL.Builder)` and
 `Closure.DELEGATE_ONLY`. The scoped `With` closure preserves its existing generic body result and does not gain a Builder
-delegate. For Java, the canonical call is `ServiceConfiguration.Create.getTemplate().With(...)`; for `@CompileStatic`
-Groovy 3, 4, and 5 it is `ServiceConfiguration.Create.Template.With { ... }`.
+delegate. For Java and `@CompileStatic` Groovy 3, 4, and 5, the canonical chain is
+`ServiceConfiguration.Create.Template.With(...)`. The upper-case spelling is intentional: it is a generated public
+static final field on each model-specific Factory interface, matching `Foo.Create`, not a JavaBean getter.
 
 `Foo.Create.Template(...)` and `Foo.Create.TemplateFrom(...)` must be absent—not merely deprecated—so the Factory
 property cannot be shadowed. `Foo.Template.From` is not a current member and must not be invented as an alias.
@@ -106,23 +108,25 @@ guidance and the new Template documentary example.
 | --- | --- | --- |
 | Root creation | `klum-ast-runtime`: `KlumFactory`, `FactoryHelper` | Remove public `Template*` root methods from `KlumFactory`; retain the internal/root `createAsTemplate` mechanics. Add or extract a narrow generated-only Template-creation adapter rather than exposing `FactoryHelper`. |
 | Scoped application and aliases | `klum-ast-runtime`: `BoundTemplateHandler`, `GeneratedTemplateSupport` | Keep `With`/`WithAll`; make `Create`/`CreateFrom` deprecated forwarders to the one root creation implementation. Keep no raw `TemplateManager` public seam. |
-| Generated Factory property | `klum-ast`: `TemplateMethods`, factory-generation seam, `GeneratedDslSupport` | Generate a final `Template` field/getter on the hidden factory implementation, link it to a new nested public `Foo_DSL.Factory.Template` interface, and project only truthful public members. |
+| Generated Factory property | `klum-ast`: `TemplateMethods`, factory-generation seam, `GeneratedDslSupport` | Generate a model-specific public static final `Template` field on `Foo_DSL.Factory`, initialized through a generated-only bridge and typed as new nested public `Foo_DSL.Factory.Template`. Do not add a JavaBean getter or hide the field on the implementation. |
 | Existing Template handler | `klum-ast`: `TemplateMethods` | Keep the static `Foo.Template` field and `Foo_DSL.Template` scope methods; retain creation members only as explicitly deprecated aliases. |
 | Generated linkage | `runtime.generated` under ADR 0015 | If a runtime bridge is needed, keep it generated-only and descriptor-minimal. No schema descriptor names `BoundTemplateHandler`, `FactoryHelper`, or `TemplateManager`. |
-| IDE surfaces | source-mirror task, AnnoDocimal projection, #703 GDSL work | Mirrors must include `Factory.Template`, `getTemplate`, `With`, and `From` with the real nested type; GDSL must expose the property consistently with bytecode. Do not duplicate the mirror into compilation. |
+| IDE surfaces | source-mirror task, AnnoDocimal projection, #703 GDSL work | Mirrors must include the static `Factory.Template` field plus `With` and `From` with the real nested type; GDSL must expose the property consistently with bytecode. Do not duplicate the mirror into compilation. |
 | Contract inventory | #468 public inventory | Refresh the generated factory/template row and artifact comparison; classify nested `Factory.Template` as generated hook and aliases as deprecated compatibility members. |
 
 ## Thin vertical slices and commit boundaries
 
 ### TC-1 — Establish the generated Factory Template type and property
 
-Add `Foo_DSL.Factory.Template`, create a final generated Factory field/getter typed to it, and supply the narrow bridge
-that exposes the current Template root creation inputs. Remove `Template*` from the inherited/projected Factory surface
-in the same commit; do not rely on Groovy dispatch to choose between a field and a method.
+Add `Foo_DSL.Factory.Template`, create the model-specific public static final `Foo_DSL.Factory.Template` field, and
+supply the narrow bridge that exposes the current Template root creation inputs. Remove `Template*` from the
+inherited/projected Factory surface in the same commit; do not rely on Groovy dispatch to choose between a field and a
+method.
 
-**Acceptance:** reflection sees `Foo.Create.getTemplate()` returning `Foo_DSL.Factory.Template`; Java and static Groovy
-call `With` and `From`; no public Factory `Template(...)` or `TemplateFrom(...)` method exists; closure delegate metadata
-is the concrete public Builder; all produced objects are `TemplateManager.isTemplate`-true.
+**Acceptance:** reflection sees a public static final `Foo_DSL.Factory.Template` field of the nested public type; Java
+and static Groovy call `Foo.Create.Template.With/From`; no `getTemplate()` compatibility getter or public Factory
+`Template(...)`/`TemplateFrom(...)` method exists; closure delegate metadata is the concrete public Builder; all produced
+objects are `TemplateManager.isTemplate`-true.
 
 **Commit boundary:** runtime adapter plus AST/property generation plus one focused descriptor/behavior test are one vertical
 commit. Do not move scope behavior or unrelated Template semantics in this slice.
@@ -147,9 +151,10 @@ Add Java and `@CompileStatic` Groovy consumer fixtures, then run the existing fi
 IDE source mirror assertion and the GDSL contributor/fixture if #703 has landed; otherwise state and coordinate that
 dependency rather than duplicating its work.
 
-**Acceptance:** Java names `Foo_DSL.Factory.Template` and uses `Foo.Create.getTemplate()`; static Groovy uses property
-syntax and catches a deliberate old Factory-method compile failure; mirrors contain the nested type and neither source
-mirror nor GDSL advertises the removed methods. The public-inventory comparison records no internal runtime descriptor.
+**Acceptance:** Java names `Foo_DSL.Factory.Template` and uses `Foo.Create.Template`; static Groovy uses the same
+upper-case property syntax and catches a deliberate old Factory-method compile failure; mirrors contain the nested type
+and static field, and neither source mirror nor GDSL advertises the removed methods. The public-inventory comparison
+records no internal runtime descriptor.
 
 **Commit boundary:** public-surface fixture/inventory assertion first; source-mirror/GDSL parity in a dependent commit only
 when its implementation owner permits it.
@@ -172,8 +177,8 @@ retrofit unrelated Template examples beyond the entrypoint spelling.
 
 | Contract | Primary seam | Required proof |
 | --- | --- | --- |
-| Generated descriptor/property | `GeneratedDslSupportSpec` or a new focused `TemplateEntrypointTest` | reflection for `getTemplate`, nested `Factory.Template`, final generated field, and absence of Factory `Template*` methods |
-| Java/static Groovy language | generated consumer compilation helpers | Java `getTemplate().With/From`; `@CompileStatic` Groovy 3/4/5 property access and Builder closure delegation |
+| Generated descriptor/property | `GeneratedDslSupportSpec` or a new focused `TemplateEntrypointTest` | reflection for the public static final `Factory.Template` field, nested `Factory.Template` type, and absence of a `getTemplate` compatibility getter or Factory `Template*` methods |
+| Java/static Groovy language | generated consumer compilation helpers | Java and `@CompileStatic` Groovy 3/4/5 `Create.Template.With/From`, plus Builder closure delegation |
 | Deprecated compatibility | Template adapter/handler tests | each `Template.Create*` overload remains callable and annotated `@Deprecated` |
 | Root Template semantics | `TemplatesSpec`, `TemplateCompanionSpec`, `TemplatesDocumentaryTest` | marked identity, abstract synthetic implementation, lifecycle omissions, recipe replay, copy/serialization/ownership boundaries unchanged |
 | Scoped application | `BoundTemplatesSpec` | single/map/list scopes, nesting/restoration, body result and anonymous map behavior unchanged |
@@ -188,7 +193,7 @@ links back to the final Templates page as required by `docs/agents/testing.md`.
 | Risk or question | Control |
 | --- | --- |
 | A Factory method survives through inheritance and shadows the property. | Remove the `KlumFactory.Template*` family before generating the property; assert absence by reflection and negative static compilation. |
-| A nested type collides with `Foo_DSL.Template`. | Use the distinct binary names `Foo_DSL$Factory$Template` and `Foo_DSL$Template`; assert both in bytecode and mirrors. |
+| A nested type or static field collides with `Foo_DSL.Template`. | Use the distinct binary names `Foo_DSL$Factory$Template` and `Foo_DSL$Template`; assert both fields/types in bytecode and mirrors. |
 | Aliases become a permanent second documented route. | Deprecate every creation alias, keep `Foo.Template` application-only in user docs, and prohibit new creation methods on the handler in review. |
 | Moving adapters changes recipe/materialization behavior. | Delegate every route to existing `FactoryHelper.createAsTemplate`; retain ADR 0004 behavioral suite before refactoring implementation. |
 | Generated bridge expands into a handwritten runtime API. | Use only generated-runtime linkage permitted by ADR 0015 and inspect public descriptors/inventory. |


### PR DESCRIPTION
## Summary

- Add ADR 0016, recommending `Foo.Create.Template.With/From` as the canonical template-creation tree while retaining `Foo.Template.With/WithAll` solely for scoped application.
- Record the exact generated public contract: `Foo_DSL.Factory.Template` is a model-specific public static final field, so Java and Groovy both use `Foo.Create.Template.From(...)`.
- Provide thin implementation slices, public-surface/mirror/GDSL coverage, compatibility aliases, and safe migration-helper boundaries.

## Deliberately not implemented

This is a design/tracer PR only. It does not change the runtime, generated API, migration script, or user-facing Template documentation.

The design retains `Foo.Template.Create/CreateFrom` as deprecated 4.x compatibility aliases, removes the inherited `KlumFactory.Template*` factory-method route before the field exists, and leaves scoped `Foo.Template.With/WithAll` unchanged.

## Validation

- `git diff --check`
- Exact-revision `renderVersionedDocumentation` at `19a9f550b7468cacc8da68508dd9b3fad399f7df`

Related: #710