### PR TITLE
Preserve deprecated Template creation aliases

### DIFF
--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedTemplateSupport.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/generated/GeneratedTemplateSupport.java
@@ -42,57 +42,91 @@ import java.util.Map;
 @SuppressWarnings("java:S100")
 public class GeneratedTemplateSupport<T> {
 
-    private final BoundTemplateHandler<T> delegate;
+    private final BoundTemplateHandler<T> templateHandler;
+    private final GeneratedTemplateFactorySupport<T> templateFactory;
 
     public GeneratedTemplateSupport(Class<T> type) {
-        delegate = new BoundTemplateHandler<>(type);
+        templateHandler = new BoundTemplateHandler<>(type);
+        templateFactory = new GeneratedTemplateFactorySupport<>(type);
     }
 
     public <C> C With(T template, Closure<C> body) {
-        return delegate.With(template, body);
+        return templateHandler.With(template, body);
     }
 
     public <C> C With(Map<String, ?> template, Closure<C> body) {
-        return delegate.With(template, body);
+        return templateHandler.With(template, body);
     }
 
     public <C> C WithAll(Map<Class<?>, Map<String, ?>> newTemplates, Closure<C> body) {
-        return delegate.WithAll(newTemplates, body);
+        return templateHandler.WithAll(newTemplates, body);
     }
 
     public <C> C WithAll(List<Object> newTemplates, Closure<C> body) {
-        return delegate.WithAll(newTemplates, body);
+        return templateHandler.WithAll(newTemplates, body);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.With()} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T Create() {
-        return delegate.Create();
+        return templateFactory.With();
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.With(configMap, configuration)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T Create(Map<String, ?> configMap, Closure<?> configuration) {
-        return delegate.Create(configMap, configuration);
+        return templateFactory.With(configMap, configuration);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.With(configuration)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T Create(Closure<?> configuration) {
-        return delegate.Create(configuration);
+        return templateFactory.With(configuration);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.With(configMap)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T Create(Map<String, ?> configMap) {
-        return delegate.Create(configMap);
+        return templateFactory.With(configMap);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.From(scriptFile)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T CreateFrom(File scriptFile) {
-        return delegate.CreateFrom(scriptFile);
+        return templateFactory.From(scriptFile);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.From(scriptFile, loader)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T CreateFrom(File scriptFile, ClassLoader loader) {
-        return delegate.CreateFrom(scriptFile, loader);
+        return templateFactory.From(scriptFile, loader);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.From(scriptUrl)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T CreateFrom(URL scriptUrl) {
-        return delegate.CreateFrom(scriptUrl);
+        return templateFactory.From(scriptUrl);
     }
 
+    /**
+     * @deprecated Use {@code Foo.Create.Template.From(scriptUrl, loader)} for the matching DSL model type.
+     */
+    @Deprecated(since = "4.0")
     public T CreateFrom(URL scriptUrl, ClassLoader loader) {
-        return delegate.CreateFrom(scriptUrl, loader);
+        return templateFactory.From(scriptUrl, loader);
     }
 }

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/BoundTemplateHandler.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/BoundTemplateHandler.java
@@ -22,18 +22,13 @@
  * SOFTWARE.
  */
 package com.blackbuild.klum.ast.runtime.internal;
-import com.blackbuild.klum.ast.runtime.KlumFactory;
-
 import groovy.lang.Closure;
 
-import java.io.File;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
 /**
- * A typed wrapper for TemplateManager. Provides all relevant methods without the need to
- * specify the first class parameter.
+ * A typed wrapper for scoped TemplateManager application without the need to specify the first class parameter.
  *
  * @param <T> the type of the template being handled
  */
@@ -103,171 +98,5 @@ public class BoundTemplateHandler<T> {
     public <C> C WithAll(List<Object> newTemplates, Closure<C> body) {
         return TemplateManager.withTemplates(newTemplates, body);
     }
-
-    /**
-     * Creates a template instance of the model type.
-     * <p>
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @return a template instance of the model type.
-     * @see #Create(Map, Closure)
-     */
-    public T Create() {
-        return FactoryHelper.createAsTemplate(type, null, (Closure<?>) null);
-    }
-
-    /**
-     * Creates a template instance of the model type.
-     * <p>
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param configMap     The values to set on the template instance.
-     * @param configuration The closure to apply to the template instance.
-     * @return a template instance of the model type.
-     */
-    public T Create(Map<String, ?> configMap, Closure<?> configuration) {
-        return FactoryHelper.createAsTemplate(type, configMap, configuration);
-    }
-
-    /**
-     * Creates a template instance of the model type.
-     * <p>
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param configuration The closure to apply to the template instance.
-     * @return a template instance of the model type.
-     * @see #Create(Map, Closure)
-     */
-    public T Create(Closure<?> configuration) {
-        return FactoryHelper.createAsTemplate(type, null, configuration);
-    }
-
-    /**
-     * Creates a template instance of the model type.
-     * <p>
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param configMap The values to set on the template instance.
-     * @return a template instance of the model type.
-     * @see #Create(Map, Closure)
-     */
-    public T Create(Map<String, ?> configMap) {
-        return FactoryHelper.createAsTemplate(type, configMap, null);
-    }
-
-    /**
-     * Creates a template instance of the model type by applying the given text as configuration.
-     * <p>
-     * As with {@link KlumFactory#From(File)},
-     * the file is converted into a DelegatingScript which is then executed to create the model instance.
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param scriptFile The script to configure the template
-     * @return a template instance of the model type.
-     */
-    public T CreateFrom(File scriptFile) {
-        return FactoryHelper.createAsTemplate(type, scriptFile, null);
-    }
-
-    /**
-     * Creates a template instance of the model type by applying the given text as configuration.
-     * <p>
-     * As with {@link KlumFactory#From(File)},
-     * the file is converted into a DelegatingScript which is then executed to create the model instance.
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param scriptFile The script to configure the template
-     * @param loader     The classloader to use for compiling the configuration script.
-     * @return a template instance of the model type.
-     */
-    public T CreateFrom(File scriptFile, ClassLoader loader) {
-        return FactoryHelper.createAsTemplate(type, scriptFile, loader);
-    }
-
-    /**
-     * Creates a template instance of the model type by applying the given text as configuration.
-     * <p>
-     * As with {@link KlumFactory#From(File)},
-     * the file is converted into a DelegatingScript which is then executed to create the model instance.
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param scriptUrl The script to configure the template
-     * @return a template instance of the model type.
-     */
-    public T CreateFrom(URL scriptUrl) {
-        return FactoryHelper.createAsTemplate(type, scriptUrl, null);
-    }
-
-    /**
-     * Creates a template instance of the model type by applying the given text as configuration.
-     * <p>
-     * As with {@link KlumFactory#From(File)},
-     * the file is converted into a DelegatingScript which is then executed to create the model instance.
-     * Templates differ from regular instances in the following way:
-     * </p>
-     * <ul>
-     *     <li>Template instances can even be created for abstract model classes using a synthetic subclass</li>
-     *     <li>the key of a template model is always null</li>
-     *     <li>owner fields are not set</li>
-     *     <li>post-apply methods are not called</li>
-     * </ul>
-     *
-     * @param scriptUrl The script to configure the template
-     * @param loader    The classloader to use for compiling the configuration script.
-     * @return a template instance of the model type.
-     */
-    public T CreateFrom(URL scriptUrl, ClassLoader loader) {
-        return FactoryHelper.createAsTemplate(type, scriptUrl, loader);
-    }
-
 
 }

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -102,7 +102,8 @@ public final class GeneratedDslSupport {
         templateFactoryInterface = createNestedInterface(factoryInterface, "Template",
                 "The public Template creation contract for " + model.getName() + ".");
         builderInterface = createNestedInterface(namespace, "Builder", "The public Builder contract for " + model.getName() + ".");
-        templateInterface = createNestedInterface(namespace, "Template", "The public Template contract for " + model.getName() + ".");
+        templateInterface = createNestedInterface(namespace, "Template",
+                "The public scoped Template application contract for " + model.getName() + ".");
         ClassNode builderPlaceholder = model.redirect().getNodeMetaData(BUILDER_PLACEHOLDER_METADATA_KEY);
         if (builderPlaceholder != null)
             builderPlaceholder.setRedirect(builderInterface);

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.createGeneratedAnnotation;
 import static com.blackbuild.klum.ast.compiler.internal.ast.DslAstHelper.copyAnnotationsFromSourceToTarget;
@@ -87,7 +88,7 @@ class TemplateMethods {
                 ctorX(templateAdapter)
         );
 
-        AstDocumentation.attachText(templateField, "Assign templates to new objects.");
+        AstDocumentation.attachText(templateField, "Apply Templates while creating new objects.");
         templateField.addAnnotation(createGeneratedAnnotation(DSLASTTransformation.class));
         annotatedClass.addField(templateField);
     }
@@ -214,12 +215,16 @@ class TemplateMethods {
         templateAdapter.addMethod(adapterMethod);
     }
 
-    private static void markAsDeprecatedTemplateCreationAlias(MethodNode method, String name) {
+    private void markAsDeprecatedTemplateCreationAlias(MethodNode method, String name) {
         AnnotationNode deprecated = new AnnotationNode(make(Deprecated.class));
         deprecated.setMember("since", constX("4.0"));
         method.addAnnotation(deprecated);
-        String replacement = name.equals("Create") ? "Foo.Create.Template.With" : "Foo.Create.Template.From";
-        AstDocumentation.attachText(method, "Deprecated Template creation alias.\n\n@deprecated Use {@code " + replacement + "(...)} instead.");
+        String operation = name.equals("Create") ? "With" : "From";
+        String arguments = Arrays.stream(method.getParameters())
+                .map(Parameter::getName)
+                .collect(Collectors.joining(", "));
+        String replacement = annotatedClass.getNameWithoutPackage() + ".Create.Template." + operation + "(" + arguments + ")";
+        AstDocumentation.attachText(method, "Deprecated Template creation alias.\n\n@deprecated Use {@code " + replacement + "} instead.");
     }
 
     private void addTemplateFactoryMethod(String name, Parameter[] parameters, FieldNode support) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
@@ -196,11 +196,15 @@ class TemplateMethods {
         MethodNode publicMethod = correctToGenericsSpec(Collections.singletonMap("T", bridgeModelType), bridgeMethod);
         publicMethod.setModifiers(ACC_PUBLIC | ACC_ABSTRACT);
         publicMethod.setCode(EmptyStatement.INSTANCE);
+        if (name.startsWith("Create"))
+            markAsDeprecatedTemplateCreationAlias(publicMethod, name);
         for (int index = 0; index < parameters.length; index++)
             copyAnnotationsFromSourceToTarget(parameters[index], publicMethod.getParameters()[index], Collections.emptyList());
         GeneratedDslSupport.of(annotatedClass).getTemplateInterface().addMethod(publicMethod);
         MethodNode adapterMethod = correctToGenericsSpec(Collections.singletonMap("T", bridgeModelType), bridgeMethod);
         adapterMethod.setModifiers(ACC_PUBLIC);
+        if (name.startsWith("Create"))
+            markAsDeprecatedTemplateCreationAlias(adapterMethod, name);
         Expression[] arguments = Arrays.stream(adapterMethod.getParameters())
                 .map(parameter -> (Expression) varX(parameter))
                 .toArray(Expression[]::new);
@@ -208,6 +212,14 @@ class TemplateMethods {
         bridgeCall.setMethodTarget(bridgeMethod);
         adapterMethod.setCode(returnS(bridgeCall));
         templateAdapter.addMethod(adapterMethod);
+    }
+
+    private static void markAsDeprecatedTemplateCreationAlias(MethodNode method, String name) {
+        AnnotationNode deprecated = new AnnotationNode(make(Deprecated.class));
+        deprecated.setMember("since", constX("4.0"));
+        method.addAnnotation(deprecated);
+        String replacement = name.equals("Create") ? "Foo.Create.Template.With" : "Foo.Create.Template.From";
+        AstDocumentation.attachText(method, "Deprecated Template creation alias.\n\n@deprecated Use {@code " + replacement + "(...)} instead.");
     }
 
     private void addTemplateFactoryMethod(String name, Parameter[] parameters, FieldNode support) {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -350,6 +350,35 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
     }
 
     @Issue('710')
+    def "Template handler retains deprecated creation aliases that forward to the Factory property"() {
+        given:
+        Class<?> foo = getClass('sample.Foo')
+        Class<?> template = getClass('sample.Foo_DSL$Template')
+
+        expect: 'scope application stays on the Template handler while every legacy creator is explicitly deprecated'
+        template.getMethod('With', getClass('sample.Base'), Closure)
+        template.getMethod('WithAll', Map, Closure)
+        template.getMethod('WithAll', List, Closure)
+        [
+                template.getMethod('Create'),
+                template.getMethod('Create', Map, Closure),
+                template.getMethod('Create', Closure),
+                template.getMethod('Create', Map),
+                template.getMethod('CreateFrom', File),
+                template.getMethod('CreateFrom', File, ClassLoader),
+                template.getMethod('CreateFrom', URL),
+                template.getMethod('CreateFrom', URL, ClassLoader)
+        ].every { it.getAnnotation(Deprecated)?.since() == '4.0' }
+
+        when: 'the documented compatibility spelling is used'
+        def legacyTemplate = foo.Template.Create(label: 'legacy')
+
+        then: 'it still creates the same marked root Template as the canonical Factory property'
+        legacyTemplate.label == 'legacy'
+        TemplateManager.isTemplate(legacyTemplate)
+    }
+
+    @Issue('710')
     def "Java and statically compiled Groovy consume only the public namespace"() {
         when:
         compileJavaConsumer('''

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -355,11 +355,8 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         Class<?> foo = getClass('sample.Foo')
         Class<?> template = getClass('sample.Foo_DSL$Template')
 
-        expect: 'scope application stays on the Template handler while every legacy creator is explicitly deprecated'
-        template.getMethod('With', getClass('sample.Base'), Closure)
-        template.getMethod('WithAll', Map, Closure)
-        template.getMethod('WithAll', List, Closure)
-        [
+        when: 'the documented compatibility spelling is used'
+        def creationAliases = [
                 template.getMethod('Create'),
                 template.getMethod('Create', Map, Closure),
                 template.getMethod('Create', Closure),
@@ -368,12 +365,16 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
                 template.getMethod('CreateFrom', File, ClassLoader),
                 template.getMethod('CreateFrom', URL),
                 template.getMethod('CreateFrom', URL, ClassLoader)
-        ].every { it.getAnnotation(Deprecated)?.since() == '4.0' }
-
-        when: 'the documented compatibility spelling is used'
+        ]
         def legacyTemplate = foo.Template.Create(label: 'legacy')
 
-        then: 'it still creates the same marked root Template as the canonical Factory property'
+        then: 'scope application stays on the Template handler while every legacy creator is explicitly deprecated'
+        template.getMethod('With', getClass('sample.Base'), Closure)
+        template.getMethod('WithAll', Map, Closure)
+        template.getMethod('WithAll', List, Closure)
+        creationAliases.every { it.getAnnotation(Deprecated)?.since() == '4.0' }
+
+        and: 'it still creates the same marked root Template as the canonical Factory property'
         legacyTemplate.label == 'legacy'
         TemplateManager.isTemplate(legacyTemplate)
     }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -372,7 +372,12 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         template.getMethod('With', getClass('sample.Base'), Closure)
         template.getMethod('WithAll', Map, Closure)
         template.getMethod('WithAll', List, Closure)
+        template.getAnnotation(AnnoDoc).value().contains('scoped Template application contract')
         creationAliases.every { it.getAnnotation(Deprecated)?.since() == '4.0' }
+        template.getMethod('Create', Map, Closure).getAnnotation(AnnoDoc).value().contains(
+                '@deprecated Use {@code Foo.Create.Template.With(configMap, configuration)} instead.')
+        template.getMethod('CreateFrom', URL, ClassLoader).getAnnotation(AnnoDoc).value().contains(
+                '@deprecated Use {@code Foo.Create.Template.From(scriptUrl, loader)} instead.')
 
         and: 'it still creates the same marked root Template as the canonical Factory property'
         legacyTemplate.label == 'legacy'


### PR DESCRIPTION
## Summary

- retains Foo.Template.Create and CreateFrom as deprecated 4.x compatibility aliases
- forwards every alias through the canonical generated Template Factory support
- narrows the handler implementation to scoped With and WithAll application and records exact generated replacements

Related: #710

## Stack

This speculative draft depends on codex/710-template-factory-property (TC-1). It must be rebased if that predecessor receives follow-up CI or review commits.

## Validation

- focused GeneratedDslSupportSpec with rerun tasks
- Template behavior suite: TemplatesSpec, BoundTemplatesSpec, TemplateCompanionSpec, TemplatesDocumentaryTest
- klum-ast Groovy 3, 4, and 5 lanes
- root check
- local Standards and Spec reviews; git diff --check

## Deliberately deferred

TC-3 owns public inventory and IDE-surface parity. TC-4 owns user documentation, CHANGES.md, and the migration helper.