### PR TITLE
Document canonical Template creation migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,11 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Template root creation now lives below `Foo.Create.Template.With` and `From`; `Foo.Template.With` and `WithAll` are
+  reserved for scoped application. The conflicting `Foo.Create.Template(...)` and `TemplateFrom(...)` methods are
+  removed. The documented `Foo.Template.Create(...)` and `CreateFrom(...)` calls remain deprecated forwarding aliases
+  throughout 4.x. The Builder-first migration helper provides only direct, type-qualified starting rewrites; review its
+  diff and complete the migration checklist ([#710](https://github.com/klum-dsl/klum-ast/issues/710)).
 - Fixed cross-source `@Owner(root = true)` public Builder accessors to expose the target model's
   `Root_DSL.Builder<Root>` contract instead of the hidden `Root$Builder` implementation. Generated
   AnnoDocimal source mirrors now preserve that same public type ([#702](https://github.com/klum-dsl/klum-ast/issues/702)).

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -193,10 +193,30 @@ checklist below. Run it only from the **schema module directory**—the Gradle s
 **clean, disposable Git worktree**. Review its diff immediately, then compile, run a representative model, and fix the
 remaining compiler errors with this guide.
 
+Use this order: update the schema module to the target KlumAST version, run the script, inspect the diff, then commit it
+as a deliberate migration starting point or revert it. Continue with the [Template migration guidance](Migration.md#template-creation-and-scoped-application), this checklist, and compilation. The
+canonical creation/application example is executable in
+[`TemplatesDocumentaryTest#'applies one scoped template to multiple service configurations'`](../../klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesDocumentaryTest.groovy).
+
 It rewrites public schema-annotation imports, changes the deprecated `@DelegatesToRW` spelling to
 `@DelegatesToBuilder`, migrates Layer 3 annotation imports such as `@AutoCreate`, copy annotations such as `@Overwrite`,
-and `KlumModelException`/`KlumValidationException` imports. It also converts only current-target Groovy `Validator` reporting/suppression calls. It
-intentionally does **not** rewrite internal packages, `ValidatorBase`, validation result readers, explicit-target
+and `KlumModelException`/`KlumValidationException` imports. It also converts only current-target Groovy `Validator`
+reporting/suppression calls and direct type-qualified Template creation calls:
+
+| Established spelling | Mechanical starting point |
+| --- | --- |
+| `Foo.Create.Template(...)` | `Foo.Create.Template.With(...)` |
+| `Foo.Create.TemplateFrom(source)` | `Foo.Create.Template.From(source)` |
+| `Foo.Template.Create(...)` | `Foo.Create.Template.With(...)` |
+| `Foo.Template.CreateFrom(source)` | `Foo.Create.Template.From(source)` |
+
+The Template rewrites are intentionally narrow. The script leaves `Foo.Template.With` and `WithAll` scoped application,
+variables such as `type.Template.Create`, dynamic/custom calls such as `holder.Service.Template.Create`, method
+references, comments, and quoted/script content unchanged. It recognizes imported direct model names (and direct nested
+model names), not fully qualified types or expression/property chains. It preserves the argument text of a recognized
+direct call, but does not promise that the result compiles.
+
+It intentionally does **not** rewrite internal packages, `ValidatorBase`, validation result readers, explicit-target
 `Validator` calls, fully qualified type references, Builders, factories, relationships, lifecycle structure, or any other
 semantic migration.
 

--- a/docs/user/Copy-Strategies.md
+++ b/docs/user/Copy-Strategies.md
@@ -69,7 +69,7 @@ class Service {
 }
 
 when: // Model
-def baseline = Service.Template.Create {
+def baseline = Service.Create.Template.With {
     endpoint { host 'catalog.example.test' }
 }
 def service = Service.Create.With {
@@ -129,7 +129,7 @@ class Service {
 }
 
 when: // Model
-def baseline = Service.Template.Create {
+def baseline = Service.Create.Template.With {
     roles 'observer'
 }
 def service = Service.Create.With {
@@ -197,7 +197,7 @@ class Deployment {
 }
 
 when: // Model
-def baseline = Deployment.Template.Create {
+def baseline = Deployment.Create.Template.With {
     environment('production') { region 'eu-central' }
 }
 def deployment = Deployment.Create.With {
@@ -266,7 +266,7 @@ class Deployment {
 }
 
 when: // Model
-def baseline = Deployment.Template.Create {
+def baseline = Deployment.Create.Template.With {
     image 'catalog:2.0'
     arguments = []
     service('web') { port '8443' }

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -13,6 +13,28 @@ Validation callers must import and catch
 `com.blackbuild.klum.ast.runtime.KlumValidationException` type has been removed; this is an intentional 4.0 source and
 binary compatibility break.
 
+### Template creation and scoped application
+
+Create a reusable Template below `Create`, then apply it below `Template`:
+
+(See: `TemplatesDocumentaryTest#'applies one scoped template to multiple service configurations'`.)
+
+```groovy
+def baseline = ServiceConfiguration.Create.Template.With(region: 'eu-central')
+
+ServiceConfiguration.Template.With(baseline) {
+    ServiceConfiguration.Create.With { }
+}
+```
+
+`Foo.Create.Template(...)` and `Foo.Create.TemplateFrom(...)` have been removed so `Foo.Create.Template` can be the
+unambiguous generated Factory property. Migrate them to `Foo.Create.Template.With(...)` and
+`Foo.Create.Template.From(...)`. The older documented `Foo.Template.Create(...)` and `CreateFrom(...)` spellings remain
+deprecated 4.x aliases; move new code to the canonical `Create.Template` chain. The best-effort
+[Builder First migration helper](Builder-First-Migration.md#optional-mechanical-starting-point) recognizes only direct
+type-qualified occurrences. Run it in a clean, version-controlled schema-module worktree, inspect its diff, then compile
+and finish the checklist.
+
 For a foreign YAML/JSON migration, configure one caller-owned Jackson mapper, import one input into one Builder lifecycle,
 and treat the completed-model export as a separately owned external projection. Do not feed it back as Klum persistence or
 use repeated imports as a Jackson-specific merge/layering mechanism; [#304](https://github.com/klum-dsl/klum-ast/issues/304)

--- a/docs/user/Model-Phases.md
+++ b/docs/user/Model-Phases.md
@@ -148,10 +148,12 @@ Cannot schedule applyLater for phase 'instantiate' (40): deferred Builder action
 This guard is the materialization boundary. It does not add the broader past/current-phase checks tracked separately.
 This is especially useful for test cases, where the model needs specific, non-trivial values to be set (e.g., for validation), but these values are irrelevant for the actual test.
 
+(See: `TemplatesDocumentaryTest#'creates an unkeyed reusable template without lifecycle callbacks'`.)
+
 ```groovy
 class PersonText extends Specification {
 
-    def template = Person.Create.Template {
+    def template = Person.Create.Template.With {
         applyLater {
             // this closure will be executed for all objects created from this template
             street "Main Street " + name

--- a/docs/user/Templates.md
+++ b/docs/user/Templates.md
@@ -4,7 +4,7 @@ Templates are completed DSL Objects marked as reusable construction recipes. App
 non-empty values into a fresh Builder graph. Nested DSL Objects are rehydrated recursively, Collections are copied, and
 Simple Values are retained. A Template is never adopted directly as owned composition.
 
-Template identity is persistent and graph-wide. Every owned node created by `Template.Create` is marked as a Template and
+Template identity is persistent and graph-wide. Every owned node created by `Create.Template.With` is marked as a Template and
 keeps its breadcrumb and model path; a completed object supplied to a `FieldType.LINK` field remains the same ordinary
 model. Templates cannot be assigned directly to any relationship, including `LINK`: apply them through `Template.With`,
 `copyFrom`, or another Template/copy API so KlumAST can build a fresh owned graph.
@@ -14,11 +14,12 @@ closures are detached and their captured graph is checked when the Template mate
 non-serializable values are rejected. Template identity and recipe state survive Java serialization; Builders,
 Construction sessions, active Template scopes, and mutable recipe collections are not serialized.
 
-## Creating templates
+## Creating Templates
 
- Ignorable fields of the template (key, owner, transient or marked as `FieldType.Ignore`) are never copied over. To make creating
- templates easier, the `Template.Create` and `Template.CreateFrom` methods are provided, which behave like normal factory methods
- with the following differences:
+Ignorable fields of the template (key, owner, transient, or marked as `FieldType.Ignore`) are never copied over. Root
+creation lives below `Create`: use `Create.Template.With` for a map and/or configuration closure, and
+`Create.Template.From` for a DelegatingScript file or URL. The result behaves like a normal factory result with these
+differences:
  
  - the result is always unkeyed (setting the key to null in case of a keyed class)
  - Lifecycle methods (`@PostApply`, `@PostCreate`) are not called
@@ -34,7 +35,7 @@ class ServiceConfiguration {
     String region
 }
 
-def template = ServiceConfiguration.Template.Create {
+def template = ServiceConfiguration.Create.Template.With {
     region 'eu-central'
 }
 
@@ -45,16 +46,15 @@ Templates are also correctly applied when using inheritance: a template defined 
 creating child-class instances, and child template values can override parent templates. The focused regression coverage
 is in `BoundTemplatesSpec.groovy`.
 
-Template specific methods are pooled in the `Template` field of each DSL class, which points to an instance of `BoundTemplateHandler` - so similar to Type.Create.* methods, there are Type.Template.* methods described below.
-
-As with normal factory methods, templates can be created using the `Template.Create` method by applying a map and/or configuration
-closure, or by using the `Template.CreateFrom` method, which takes a file or URL that is parsed as a DelegatingScript,
-similar to the `Create.From` methods.
+`Template` is the scoped-application handler. It does not create a retained recipe: `Template.With` and `Template.WithAll`
+apply one or more recipes while the supplied body creates ordinary models. The deprecated 4.x compatibility aliases
+`Template.Create` and `Template.CreateFrom` still forward to the canonical creation operations, but new code must use
+`Create.Template.With` and `Create.Template.From`.
 
 (See: `TemplatesDocumentaryTest#'creates a template from a DelegatingScript file'`.)
 
 ```groovy
-def template = ServiceConfiguration.Template.CreateFrom(new File('service-template.groovy'))
+def template = ServiceConfiguration.Create.Template.From(new File('service-template.groovy'))
 ```
 
 There are currently four options to apply templates; all examples use the following class and template:
@@ -66,7 +66,7 @@ class Config {
     List<String> roles
 }
 
-def template = Config.Template.Create {
+def template = Config.Create.Template.With {
     url "http://x.y"
     roles "developer", "guest"
 }
@@ -104,7 +104,7 @@ Usage:
 (See: `TemplatesDocumentaryTest#'applies one scoped template to multiple service configurations'`.)
 
 ```groovy
-def template = Config.Template.Create {
+def template = Config.Create.Template.With {
     url "http://x.y"
     roles "developer", "guest"
 }
@@ -128,7 +128,7 @@ assert d.roles == [ "developer", "guest", "scrummaster" ]
 `Template.With` can also be called using only named parameters, creating a temporary, anonymous template:
 
 ```groovy
-Config.Template.With(Config.Template.Create(url: "http://x.y")) {
+Config.Template.With(Config.Create.Template.With(url: "http://x.y")) {
     c = Config.Create.With {
         roles "productowner"
     }
@@ -246,7 +246,7 @@ abstract class RetryPolicy {
     abstract int retries()
 }
 
-def template = RetryPolicy.Template.Create {
+def template = RetryPolicy.Create.Template.With {
     name 'resilient'
 }
 ```
@@ -277,11 +277,11 @@ class Parent {
 class Child extends Parent {
 }
 
-def parentTemplate = Parent.Template.Create {
+def parentTemplate = Parent.Create.Template.With {
     name "parent-template" // overrides default value
 }
 
-def childTemplate = Child.Template.Create {
+def childTemplate = Child.Create.Template.With {
     name "child-template" // overrides parent template value
 }
 
@@ -315,11 +315,11 @@ class Parent {
 class Child extends Parent {
 }
 
-def parentTemplate = Parent.Template.Create {
+def parentTemplate = Parent.Create.Template.With {
     names "parent" // replaces default value
 }
 
-def childTemplate = Child.Template.Create {
+def childTemplate = Child.Create.Template.With {
     names = ["child"] // replaces parent template values
 }
 
@@ -342,7 +342,7 @@ must be serializable so the Template recipe remains serializable with its compan
 (See: `TemplatesDocumentaryTest#'replays a template applyLater recipe for each completed configuration'`.)
 
 ```groovy
-def template = ServiceConfiguration.Template.Create {
+def template = ServiceConfiguration.Create.Template.With {
     applyLater {
         identifier name.toUpperCase()
     }

--- a/docs/user/assets/migrate-3x-to-4x-builder-first.sh
+++ b/docs/user/assets/migrate-3x-to-4x-builder-first.sh
@@ -22,6 +22,74 @@ done
   exit 1
 }
 
+# Template creation has moved below Create. Restrict this to direct, type-qualified
+# calls and leave comments and quoted/script content untouched. The scanner is
+# deliberately conservative: an unfamiliar slash expression is treated as opaque.
+rewrite_template_entrypoints() {
+  perl -0pi -e '
+    sub rewrite_code {
+      my ($code) = @_;
+      $code =~ s{(?<![\w\$\.])([A-Z]\w*(?:\.[A-Z]\w*)*)\.Create\.TemplateFrom(\s*\()}{${1}.Create.Template.From$2}g;
+      $code =~ s{(?<![\w\$\.])([A-Z]\w*(?:\.[A-Z]\w*)*)\.Create\.Template(\s*[\(\{])}{${1}.Create.Template.With$2}g;
+      $code =~ s{(?<![\w\$\.])([A-Z]\w*(?:\.[A-Z]\w*)*)\.Template\.CreateFrom(\s*\()}{${1}.Create.Template.From$2}g;
+      $code =~ s{(?<![\w\$\.])([A-Z]\w*(?:\.[A-Z]\w*)*)\.Template\.Create(\s*[\(\{])}{${1}.Create.Template.With$2}g;
+      return $code;
+    }
+
+    sub quoted_end {
+      my ($text, $start, $quote) = @_;
+      my $length = length $text;
+      my $index = $start + 1;
+      while ($index < $length) {
+        return $index + 1 if substr($text, $index, 1) eq $quote;
+        $index += substr($text, $index, 1) eq q{\\} ? 2 : 1;
+      }
+      return $length;
+    }
+
+    my $text = $_;
+    my $triple_single = chr(39) x 3;
+    my $triple_double = chr(34) x 3;
+    my ($out, $code) = (q{}, q{});
+    my ($index, $length) = (0, length $text);
+    while ($index < $length) {
+      my $tail = substr($text, $index);
+      my ($delimiter, $end);
+      if ($tail =~ m{\A//}) {
+        $delimiter = "\n";
+        $end = index($text, $delimiter, $index + 2);
+        $end = $length if $end < 0;
+        $end++ if $end < $length;
+      } elsif ($tail =~ m{\A/\*}) {
+        $end = index($text, "*/", $index + 2);
+        $end = $length if $end < 0;
+        $end += 2 if $end < $length;
+      } elsif ($tail =~ m{\A\$/}) {
+        $end = index($text, "/\$", $index + 2);
+        $end = $length if $end < 0;
+        $end += 2 if $end < $length;
+      } elsif (substr($text, $index, 3) eq $triple_single || substr($text, $index, 3) eq $triple_double) {
+        $delimiter = substr($text, $index, 3);
+        $end = index($text, $delimiter, $index + 3);
+        $end = $length if $end < 0;
+        $end += 3 if $end < $length;
+      } elsif ($tail =~ m{\A[\x27\x22\x60]}) {
+        $end = quoted_end($text, $index, substr($text, $index, 1));
+      } elsif ($tail =~ m{\A/}) {
+        $end = quoted_end($text, $index, "/");
+      } else {
+        $code .= substr($text, $index, 1);
+        $index++;
+        next;
+      }
+      $out .= rewrite_code($code) . substr($text, $index, $end - $index);
+      $code = q{};
+      $index = $end;
+    }
+    $_ = $out . rewrite_code($code);
+  ' "$1"
+}
+
 # Known public annotation moves, exception imports, and canonical deprecated annotation spelling.
 while IFS= read -r -d '' file; do
   perl -0pi -e '
@@ -33,6 +101,12 @@ while IFS= read -r -d '' file; do
     s{^(\s*import\s+)(com\.blackbuild\.klum\.ast\.runtime\.KlumValidationException\b)}{$1com.blackbuild.klum.ast.runtime.validation.KlumValidationException}mg;
     s{\bDelegatesToRW\b}{DelegatesToBuilder}g;
   ' "$file"
+done < <(find "${roots[@]}" -type f \( -name '*.groovy' -o -name '*.java' \) -print0)
+
+# Known Template creation entrypoints. This leaves scoped Template.With/WithAll,
+# variables, dynamic calls, method references, comments, and script text alone.
+while IFS= read -r -d '' file; do
+  rewrite_template_entrypoints "$file"
 done < <(find "${roots[@]}" -type f \( -name '*.groovy' -o -name '*.java' \) -print0)
 
 # Current-target Groovy Validator calls only. Explicit-target calls, ValidatorBase,

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesDocumentaryTest.groovy
@@ -34,7 +34,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
 
     @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
 
-    @Issue("491")
+    @Issue("710")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#creating-templates")
     def "creates an unkeyed reusable template without lifecycle callbacks"() {
         given:
@@ -61,7 +61,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
 
         when:
-        def template = clazz.Template.Create {
+        def template = clazz.Create.Template.With {
             region 'eu-central'
         }
 
@@ -72,7 +72,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         !template.postCreateCalled
     }
 
-    @Issue("322")
+    @Issue("710")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#creating-templates")
     def "creates a template from a DelegatingScript file"() {
         given:
@@ -92,14 +92,14 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
 
         when:
-        def template = clazz.Template.CreateFrom(templateFile)
+        def template = clazz.Create.Template.From(templateFile)
 
         then:
         template.url == 'https://config.example.test'
         template.region == 'eu-central'
     }
 
-    @Issue("491")
+    @Issue("710")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#copyfrom")
     def "copies a template into one completed service configuration"() {
         given:
@@ -112,7 +112,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
                 List<String> roles
             }
         '''
-        def template = clazz.Template.Create {
+        def template = clazz.Create.Template.With {
             url 'https://config.example.test'
             roles 'developer', 'guest'
         }
@@ -128,7 +128,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         service.roles == ['developer', 'guest']
     }
 
-    @Issue("376")
+    @Issue("710")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#templatewith")
     def "applies one scoped template to multiple service configurations"() {
         given:
@@ -143,7 +143,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
 
         and:
-        def template = clazz.Template.Create {
+        def template = clazz.Create.Template.With {
             url 'https://config.example.test'
             roles 'developer', 'guest'
         }
@@ -251,8 +251,8 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
         def serviceType = getClass('pk.Service')
         def databaseType = getClass('pk.Database')
-        def serviceTemplate = serviceType.Template.Create { tier 'application' }
-        def databaseTemplate = databaseType.Template.Create { engine 'postgresql' }
+        def serviceTemplate = serviceType.Create.Template.With { tier 'application' }
+        def databaseTemplate = databaseType.Create.Template.With { engine 'postgresql' }
 
         when:
         def deployment
@@ -284,7 +284,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
 
         when:
-        def template = clazz.Template.Create {
+        def template = clazz.Create.Template.With {
             name 'resilient'
         }
 
@@ -311,8 +311,8 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
         def parentType = getClass('pk.ParentConfiguration')
         def serviceType = getClass('pk.ServiceConfiguration')
-        def parentTemplate = parentType.Template.Create { environment 'shared' }
-        def serviceTemplate = serviceType.Template.Create { environment 'production' }
+        def parentTemplate = parentType.Create.Template.With { environment 'shared' }
+        def serviceTemplate = serviceType.Create.Template.With { environment 'production' }
 
         when:
         def fromTemplates
@@ -347,8 +347,8 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         '''
         def parentType = getClass('pk.ParentConfiguration')
         def serviceType = getClass('pk.ServiceConfiguration')
-        def parentTemplate = parentType.Template.Create { regions 'shared' }
-        def serviceTemplate = serviceType.Template.Create { regions 'production' }
+        def parentTemplate = parentType.Create.Template.With { regions 'shared' }
+        def serviceTemplate = serviceType.Create.Template.With { regions 'production' }
 
         when:
         def explicit
@@ -375,7 +375,7 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
                 String identifier
             }
         '''
-        def template = clazz.Template.Create {
+        def template = clazz.Create.Template.With {
             applyLater {
                 identifier name.toUpperCase()
             }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationScriptTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/BuilderFirstMigrationScriptTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+@Issue("710")
+class BuilderFirstMigrationScriptTest extends Specification {
+
+    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "rewrites only direct type-qualified Template creation calls"() {
+        given:
+        Path schemaModule = temporaryFolder.newFolder('schema-module').toPath()
+        Path source = schemaModule.resolve('src/main/groovy/TemplateMigration.groovy')
+        Files.createDirectories(source.parent)
+        Files.writeString(source, '''
+            class TemplateMigration {
+                void configure() {
+                    Service.Create.Template(name: "catalog")
+                    Service.Create.Template { region "eu-central" }
+                    Service.Create.TemplateFrom(file)
+                    Service.Template.Create(name: "billing")
+                    Service.Template.Create { region "us-east" }
+                    Service.Template.CreateFrom(file)
+
+                    Service.Template.With(template) { }
+                    Service.Template.WithAll([template]) { }
+                    type.Template.Create { }
+                    custom().Template.Create { }
+                    holder.Service.Template.Create { }
+                    def reference = Service.Template.&Create
+                    def literal = "Service.Template.Create { }"
+                    def script = """Service.Create.Template { }"""
+                    // Service.Create.Template { }
+                    /* Service.Template.CreateFrom(file) */
+                }
+            }
+        '''.stripIndent())
+        git(schemaModule, 'init', '-q')
+        git(schemaModule, 'config', 'user.email', 'migration-test@example.invalid')
+        git(schemaModule, 'config', 'user.name', 'Migration Test')
+        git(schemaModule, 'add', '.')
+        git(schemaModule, 'commit', '-qm', 'fixture')
+
+        when:
+        ProcessResult result = run(schemaModule, 'bash', migrationScript().toString())
+
+        then:
+        result.exitCode == 0
+        result.output.contains('Starter edits applied')
+        Files.readString(source).stripIndent() == '''
+            class TemplateMigration {
+                void configure() {
+                    Service.Create.Template.With(name: "catalog")
+                    Service.Create.Template.With { region "eu-central" }
+                    Service.Create.Template.From(file)
+                    Service.Create.Template.With(name: "billing")
+                    Service.Create.Template.With { region "us-east" }
+                    Service.Create.Template.From(file)
+
+                    Service.Template.With(template) { }
+                    Service.Template.WithAll([template]) { }
+                    type.Template.Create { }
+                    custom().Template.Create { }
+                    holder.Service.Template.Create { }
+                    def reference = Service.Template.&Create
+                    def literal = "Service.Template.Create { }"
+                    def script = """Service.Create.Template { }"""
+                    // Service.Create.Template { }
+                    /* Service.Template.CreateFrom(file) */
+                }
+            }
+        '''.stripIndent()
+    }
+
+    private static Path migrationScript() {
+        Path directory = Path.of('').toAbsolutePath()
+        while (directory != null) {
+            Path candidate = directory.resolve('docs/user/assets/migrate-3x-to-4x-builder-first.sh')
+            if (Files.exists(candidate))
+                return candidate
+            directory = directory.parent
+        }
+        throw new IllegalStateException('Cannot locate the Builder-first migration helper asset.')
+    }
+
+    private static void git(Path directory, String... arguments) {
+        ProcessResult result = run(directory, 'git', *arguments)
+        assert result.exitCode == 0 : result.output
+    }
+
+    private static ProcessResult run(Path directory, String... command) {
+        Process process = new ProcessBuilder(command)
+                .directory(directory.toFile())
+                .redirectErrorStream(true)
+                .start()
+        new ProcessResult(process.waitFor(), process.inputStream.text)
+    }
+
+    private static class ProcessResult {
+
+        final int exitCode
+        final String output
+
+        ProcessResult(int exitCode, String output) {
+            this.exitCode = exitCode
+            this.output = output
+        }
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CopyStrategiesDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/CopyStrategiesDocumentaryTest.groovy
@@ -53,7 +53,7 @@ class CopyStrategiesDocumentaryTest extends AbstractDSLSpec {
             }
         '''
         def serviceType = getClass('pk.Service')
-        def baseline = serviceType.Template.Create {
+        def baseline = serviceType.Create.Template.With {
             endpoint {
                 host 'catalog.example.test'
             }
@@ -88,7 +88,7 @@ class CopyStrategiesDocumentaryTest extends AbstractDSLSpec {
                 List<String> roles
             }
         '''
-        def baseline = clazz.Template.Create {
+        def baseline = clazz.Create.Template.With {
             roles 'observer'
         }
 
@@ -126,7 +126,7 @@ class CopyStrategiesDocumentaryTest extends AbstractDSLSpec {
             }
         '''
         def deploymentType = getClass('pk.Deployment')
-        def baseline = deploymentType.Template.Create {
+        def baseline = deploymentType.Create.Template.With {
             environment('production') {
                 region 'eu-central'
             }
@@ -170,7 +170,7 @@ class CopyStrategiesDocumentaryTest extends AbstractDSLSpec {
             }
         '''
         def deploymentType = getClass('pk.Deployment')
-        def baseline = deploymentType.Template.Create {
+        def baseline = deploymentType.Create.Template.With {
             image 'catalog:2.0'
             arguments = []
             service('web') {


### PR DESCRIPTION
## Summary

- documents `Create.Template.With` / `From` as the canonical Template-creation path and reserves `Template.With` / `WithAll` for scoped application
- adds a conservative, tested Builder-first migration-helper rewrite stage and explicit schema-module worktree guidance
- aligns executable documentary coverage, migration language, and release notes

Related: #710

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.BuilderFirstMigrationScriptTest --tests com.blackbuild.groovy.configdsl.transform.TemplatesDocumentaryTest --tests com.blackbuild.klum.ast.CopyStrategiesDocumentaryTest --console=plain`
- `./gradlew :klum-ast:groovy4Tests :klum-ast:groovy5Tests --console=plain`
- `./gradlew verifyVersionedDocumentationRenderer --console=plain`
- `git diff --check origin/master...HEAD`

This PR contains only TC-4. TC-1 through TC-3 are merged to `master`; its CI/SonarCloud results are independent of the prior cumulative-stack run.