### PR TITLE
Fix REL-2 checkout ordering

### DIFF
--- a/.github/workflows/promote-public-documentation.yml
+++ b/.github/workflows/promote-public-documentation.yml
@@ -165,11 +165,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.sha }}
-          path: landing-writer
-          persist-credentials: false
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ needs.validate-proof.outputs.commit }}
@@ -182,6 +177,19 @@ jobs:
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
           git merge-base --is-ancestor "$EXPECTED_COMMIT" origin/master
           test -z "$(git status --porcelain=v1)"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: landing-writer
+          persist-credentials: false
+      - name: Prove the current landing writer is trusted
+        env:
+          EXPECTED_HELPER_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C landing-writer rev-parse HEAD)" = "$EXPECTED_HELPER_COMMIT"
+          test "$(git status --porcelain=v1)" = '?? landing-writer/'
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin

--- a/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/klum/ast/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -655,6 +655,15 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
                 'promotion must require matching immutable pending-stage evidence')
         assertContains(promotionWorkflow, 'documentationStatus=$public_status',
                 'promotion must re-render public status chrome rather than expose pending content')
+        int releaseSourceCheckout = promotionWorkflow.indexOf('          ref: ${{ needs.validate-proof.outputs.commit }}\n')
+        int landingWriterCheckout = promotionWorkflow.indexOf('          path: landing-writer\n')
+        int cleanSourceCheck = promotionWorkflow.indexOf('          test -z "$(git status --porcelain=v1)"\n')
+        assertTrue(releaseSourceCheckout >= 0 && cleanSourceCheck > releaseSourceCheckout && landingWriterCheckout > cleanSourceCheck,
+                'promotion must cleanly check out and verify the exact release source before the current landing writer')
+        assertContains(promotionWorkflow, 'test "$(git -C landing-writer rev-parse HEAD)" = "$EXPECTED_HELPER_COMMIT"',
+                'promotion must verify that the helper comes from the current trusted workflow revision')
+        assertContains(promotionWorkflow, 'test "$(git status --porcelain=v1)" = \'?? landing-writer/\'',
+                'the helper checkout must be the only source-worktree change allowed after source verification')
         int publicRenderStart = promotionWorkflow.indexOf('      - name: Render and verify the public exact-version tree\n')
         int pagesCheckout = promotionWorkflow.indexOf('          ref: gh-pages\n')
         int pendingEvidenceStart = promotionWorkflow.indexOf('      - name: Verify the immutable pending-stage evidence\n')


### PR DESCRIPTION
## Summary

- check out and verify the immutable release source before checking out the landing-page helper
- verify the helper uses the current trusted workflow revision and is the only expected post-checkout worktree change
- guard the cleanup-sensitive ordering in the existing release-documentation contract check

## Root cause

The default root checkout cleaned the previously created untracked `landing-writer` directory before its landing-page script ran.

## Scope

Rendered documentation remains bound to the exact release source; the landing helper remains bound to the current trusted workflow source. This does not change publication, tags, aliases, release ordering, proof eligibility, or recovery authorization.

## Validation

- YAML parsing for the affected release workflows
- `./gradlew verifyVersionedDocumentationRenderer`
- `./gradlew check` (including Groovy 3/4/5 lanes)
- `git diff --check`
- Standards review: no findings
- Spec review: no findings

Tracker impact: no GitHub issue was changed by this pull request.
