### PR TITLE
Project optional Builder closure overloads into public contracts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Public `Foo_DSL.Builder` contracts and their IDEA-only AnnoDocimal mirrors now explicitly expose supported generated
+  relationship-creator overloads that omit the optional trailing configuration closure. This is an additive 4.0 API
+  correction; existing lifecycle, relationship, Factory, and source-DSL behavior is unchanged ([#719](https://github.com/klum-dsl/klum-ast/issues/719)).
+
 - Template root creation now lives below `Foo.Create.Template.With` and `From`; `Foo.Template.With` and `WithAll` are
   reserved for scoped application. The conflicting `Foo.Create.Template(...)` and `TemplateFrom(...)` methods are
   removed. The documented `Foo.Template.Create(...)` and `CreateFrom(...)` calls remain deprecated forwarding aliases

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -63,6 +63,25 @@ class Root {}
 
 In generated signatures and IDE source mirrors, `Child_DSL.Builder` uses `Root_DSL.Builder<Root>` for `root`.
 
+#### Relationship creator overloads
+
+Generated owned-relationship creators accept their named-value map without a configuration closure. This applies when a
+Schema Developer or Builder-first extension statically types the receiver as the public `Foo_DSL.Builder` contract; the
+same overloads appear in IDEA-only source mirrors. Keyed, dynamic-`Class`, typed-`Create` Factory, collection, and map
+relationship creators retain their established return types and type metadata.
+
+(See: `BuilderProjectionDocumentaryTest#'configures an owned relationship through a public Builder without an empty closure'`.)
+
+```groovy
+@CompileStatic
+static void configure(Workspace_DSL.Builder<Workspace> workspace) {
+    workspace.repository([url: 'ssh://git@example.test/catalog.git'])
+}
+```
+
+Use the closure-taking form only when further child configuration is needed; omitting it is equivalent to passing an
+empty configuration closure.
+
 ### Builder-phase Type Checks
 
 Relationships are Builders until the graph materializes. A completed-model `instanceof` check therefore belongs in a

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1047,6 +1047,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             if (isInstantiable(defaultImpl)) {
                 createProxyMethod(methodName, InternalKlumBuilder.ADD_NEW_DSL_ELEMENT_TO_COLLECTION)
                         .optional()
+                        .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                         .mod(visibility)
                         .linkToField(fieldNode)
                         .returning(elementBuilderType, NEW_BUILDER_RETURN_DOCUMENTATION)
@@ -1067,6 +1068,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             if (!isFinal(elementType)) {
                 createProxyMethod(methodName, InternalKlumBuilder.ADD_NEW_DSL_ELEMENT_TO_COLLECTION)
                         .optional()
+                        .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                         .mod(visibility)
                         .linkToField(fieldNode)
                         .returning(elementBuilderType, NEW_BUILDER_RETURN_DOCUMENTATION)
@@ -1252,6 +1254,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             if (isInstantiable(defaultImpl)) {
                 createProxyMethod(methodName, ADD_NEW_DSL_ELEMENT_TO_MAP)
                         .optional()
+                        .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                         .mod(visibility)
                         .linkToField(fieldNode)
                         .returning(elementBuilderType, NEW_BUILDER_RETURN_DOCUMENTATION)
@@ -1272,6 +1275,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             if (!isFinal(elementType)) {
                 createProxyMethod(methodName, ADD_NEW_DSL_ELEMENT_TO_MAP)
                         .optional()
+                        .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                         .mod(visibility)
                         .linkToField(fieldNode)
                         .returning(elementBuilderType, NEW_BUILDER_RETURN_DOCUMENTATION)
@@ -1387,6 +1391,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         if (isInstantiable(defaultImpl)) {
             createProxyMethod(fieldName, CREATE_SINGLE_CHILD)
                     .optional()
+                    .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                     .mod(visibility)
                     .linkToField(fieldNode)
                     .returning(targetBuilderType)
@@ -1402,6 +1407,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         if (!isFinal(targetFieldType)) {
             createProxyMethod(fieldName, CREATE_SINGLE_CHILD)
                     .optional()
+                    .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                     .mod(visibility)
                     .linkToField(fieldNode)
                     .returning(targetBuilderType)
@@ -1432,6 +1438,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         GenericFactoryMethodTypes types = genericFactoryMethodTypes(dslBaseType);
         createProxyMethod(methodName, runtimeMethod)
                 .optional()
+                .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                 .mod(DslAstHelper.isProtected(fieldNode) ? ACC_PROTECTED : ACC_PUBLIC)
                 .linkToField(fieldNode)
                 .setGenericsTypes(types.methodTypeParameters())

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -28,6 +28,7 @@ import com.blackbuild.klum.ast.KlumGenerated;
 import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactoryProvider;
+import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
@@ -370,6 +371,40 @@ public final class GeneratedDslSupport {
         copyAnnotationsFromSourceToTarget(implementationMethod, apiMethod, Collections.emptyList());
         publicInterface.addMethod(apiMethod);
         implementationMethod.setNodeMetaData(API_METHOD_METADATA_KEY, apiMethod);
+        addProjectedRelationshipClosureOmission(publicInterface, apiMethod);
+    }
+
+    /**
+     * Groovy synthesizes this overload on the hidden Builder implementation only after this public contract is projected.
+     * Declare the same supported omission explicitly so static clients and AnnoDocimal see the actual relationship API.
+     */
+    private void addProjectedRelationshipClosureOmission(ClassNode publicInterface, MethodNode projectedMethod) {
+        Parameter[] projectedParameters = projectedMethod.getParameters();
+        if (!isBuilderRelationshipContract(publicInterface) || projectedParameters.length == 0) return;
+
+        Parameter closure = projectedParameters[projectedParameters.length - 1];
+        if (!closure.getOriginType().equals(ClassHelper.CLOSURE_TYPE) || !closure.hasInitialExpression()) return;
+
+        Parameter[] parameters = cloneParameters(Arrays.copyOf(projectedParameters, projectedParameters.length - 1));
+        if (publicInterface.getDeclaredMethod(projectedMethod.getName(), parameters) != null) return;
+
+        MethodNode apiMethod = new MethodNode(
+                projectedMethod.getName(),
+                ACC_PUBLIC | ACC_ABSTRACT,
+                projectedMethod.getReturnType(),
+                parameters,
+                projectedMethod.getExceptions(),
+                EmptyStatement.INSTANCE
+        );
+        apiMethod.setGenericsTypes(projectedMethod.getGenericsTypes());
+        copyAnnotationsFromSourceToTarget(projectedMethod, apiMethod, Collections.emptyList());
+        publicInterface.addMethod(apiMethod);
+    }
+
+    private boolean isBuilderRelationshipContract(ClassNode publicInterface) {
+        String builderName = builderInterface.getName();
+        String interfaceName = publicInterface.getName();
+        return interfaceName.equals(builderName) || interfaceName.startsWith(builderName + "$");
     }
 
     private static void projectMethodSignature(MethodNode method) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -28,7 +28,6 @@ import com.blackbuild.klum.ast.KlumGenerated;
 import com.blackbuild.klum.ast.runtime.generated.GeneratedKlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactoryProvider;
-import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
@@ -576,7 +575,7 @@ public final class GeneratedDslSupport {
                     .map(ConstantExpression.class::cast)
                     .map(ConstantExpression::getText)
                     .anyMatch(tag::equals);
-        return tags instanceof ConstantExpression && Objects.equals(((ConstantExpression) tags).getText(), tag);
+        return tags instanceof ConstantExpression constantExpression && Objects.equals(constantExpression.getText(), tag);
     }
 
     private static String generatedLink(ClassNode implementation) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -68,9 +68,11 @@ public final class GeneratedDslSupport {
 
     public static final String SUPPORT_METADATA_KEY = GeneratedDslSupport.class.getName() + ".support";
     public static final String PUBLIC_INTERFACE_METADATA_KEY = GeneratedDslSupport.class.getName() + ".publicInterface";
+    static final String RELATIONSHIP_CREATOR_METADATA_KEY = GeneratedDslSupport.class.getName() + ".relationshipCreator";
     private static final String BUILDER_PLACEHOLDER_METADATA_KEY = GeneratedDslSupport.class.getName() + ".builderPlaceholder";
     private static final String API_METHOD_METADATA_KEY = GeneratedDslSupport.class.getName() + ".apiMethod";
     public static final String API_TAG = "dsl-support-api";
+    public static final String RELATIONSHIP_CREATOR_TAG = "dsl-support-relationship-creator";
     public static final String INTERFACE_LINK_TAG = "dsl-support-interface:";
 
     private static final ClassNode KLUM_GENERATED = ClassHelper.make(KlumGenerated.class);
@@ -193,6 +195,11 @@ public final class GeneratedDslSupport {
     public static void complete(ClassNode model) {
         GeneratedDslSupport support = of(model);
         support.implementations.forEach(support::projectImplementation);
+    }
+
+    static void markRelationshipCreator(MethodNode method) {
+        if (method != null)
+            method.setNodeMetaData(RELATIONSHIP_CREATOR_METADATA_KEY, Boolean.TRUE);
     }
 
     /** Resolves the public API type through an explicit generated {@code implements} link. */
@@ -371,16 +378,17 @@ public final class GeneratedDslSupport {
         copyAnnotationsFromSourceToTarget(implementationMethod, apiMethod, Collections.emptyList());
         publicInterface.addMethod(apiMethod);
         implementationMethod.setNodeMetaData(API_METHOD_METADATA_KEY, apiMethod);
-        addProjectedRelationshipClosureOmission(publicInterface, apiMethod);
+        addProjectedRelationshipClosureOmission(publicInterface, apiMethod, hasGeneratedRelationshipCreatorTag(implementationMethod));
     }
 
     /**
      * Groovy synthesizes this overload on the hidden Builder implementation only after this public contract is projected.
      * Declare the same supported omission explicitly so static clients and AnnoDocimal see the actual relationship API.
      */
-    private void addProjectedRelationshipClosureOmission(ClassNode publicInterface, MethodNode projectedMethod) {
+    private void addProjectedRelationshipClosureOmission(ClassNode publicInterface, MethodNode projectedMethod,
+                                                         boolean generatedRelationshipCreator) {
         Parameter[] projectedParameters = projectedMethod.getParameters();
-        if (!isBuilderRelationshipContract(publicInterface) || projectedParameters.length == 0) return;
+        if (!generatedRelationshipCreator || projectedParameters.length == 0) return;
 
         Parameter closure = projectedParameters[projectedParameters.length - 1];
         if (!closure.getOriginType().equals(ClassHelper.CLOSURE_TYPE) || !closure.hasInitialExpression()) return;
@@ -399,12 +407,6 @@ public final class GeneratedDslSupport {
         apiMethod.setGenericsTypes(projectedMethod.getGenericsTypes());
         copyAnnotationsFromSourceToTarget(projectedMethod, apiMethod, Collections.emptyList());
         publicInterface.addMethod(apiMethod);
-    }
-
-    private boolean isBuilderRelationshipContract(ClassNode publicInterface) {
-        String builderName = builderInterface.getName();
-        String interfaceName = publicInterface.getName();
-        return interfaceName.equals(builderName) || interfaceName.startsWith(builderName + "$");
     }
 
     private static void projectMethodSignature(MethodNode method) {
@@ -557,6 +559,14 @@ public final class GeneratedDslSupport {
     }
 
     private static boolean hasGeneratedApiTag(ClassNode candidate) {
+        return hasGeneratedTag(candidate, API_TAG);
+    }
+
+    private static boolean hasGeneratedRelationshipCreatorTag(MethodNode method) {
+        return Boolean.TRUE.equals(method.getNodeMetaData(RELATIONSHIP_CREATOR_METADATA_KEY));
+    }
+
+    private static boolean hasGeneratedTag(AnnotatedNode candidate, String tag) {
         AnnotationNode generated = getAnnotation(candidate, KLUM_GENERATED);
         if (generated == null) return false;
         Expression tags = generated.getMember("tags");
@@ -565,8 +575,8 @@ public final class GeneratedDslSupport {
                     .filter(ConstantExpression.class::isInstance)
                     .map(ConstantExpression.class::cast)
                     .map(ConstantExpression::getText)
-                    .anyMatch(API_TAG::equals);
-        return tags instanceof ConstantExpression && Objects.equals(((ConstantExpression) tags).getText(), API_TAG);
+                    .anyMatch(tag::equals);
+        return tags instanceof ConstantExpression && Objects.equals(((ConstantExpression) tags).getText(), tag);
     }
 
     private static String generatedLink(ClassNode implementation) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
@@ -284,10 +284,14 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
     @Override
     public MethodNode addTo(ClassNode target) {
         MethodNode result = super.addTo(target);
+        if (tags.contains(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG))
+            GeneratedDslSupport.markRelationshipCreator(result);
 
         if (namedParameterIndex != -1) {
             params.set(namedParameterIndex, new FixedExpressionArgument(new MapExpression()));
-            doAddTo(target);
+            MethodNode namedParameterOverload = doAddTo(target);
+            if (tags.contains(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG))
+                GeneratedDslSupport.markRelationshipCreator(namedParameterOverload);
         }
         return result;
     }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderProjectionDocumentaryTest.groovy
@@ -31,6 +31,41 @@ import spock.lang.Tag
 @Issue("642")
 class BuilderProjectionDocumentaryTest extends AbstractDSLSpec {
 
+    @Issue("719")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Builder-First-Migration.md#relationship-creator-overloads")
+    def "configures an owned relationship through a public Builder without an empty closure"() {
+        given:
+        createClass '''
+            @DSL class Workspace {
+                Repository repository
+            }
+
+            @DSL class Repository {
+                String url
+            }
+        '''
+
+        Class<?> consumer = createSecondaryClass('''
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class WorkspaceConfigurer {
+                static void configure(Workspace_DSL.Builder<Workspace> workspace) {
+                    workspace.repository([url: 'ssh://git@example.test/catalog.git'])
+                }
+
+                static Workspace create() {
+                    Workspace.Create.With {
+                        WorkspaceConfigurer.configure((Workspace_DSL.Builder<Workspace>) delegate)
+                    }
+                }
+            }
+        ''', 'WorkspaceConfigurer.groovy')
+
+        expect:
+        consumer.create().repository.url == 'ssh://git@example.test/catalog.git'
+    }
+
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Factory-Classes.md#creator-methods-and-collection-factories")
     def "uses an unqualified static converter chain in an owned relationship"() {
         given:

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -702,22 +702,39 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         Class<?> clusterFactory = getClass('sample.Foo_DSL$Builder$ClusterFactory_services')
         Class<?> deploymentBuilder = getClass('sample.Deployment_DSL$Builder')
 
-        expect: 'direct, collection, Cluster, keyed, dynamic-Class, and typed-Factory relationship creators omit only the optional closure'
-        fooBuilder.getMethod('primary', Map).returnType == childBuilder
-        collectionFactory.getMethod('kid', Map).returnType == childBuilder
-        clusterFactory.getMethod('primary', Map).returnType == childBuilder
-        deploymentBuilder.getMethod('endpoint', Map, Class).returnType ==
-                deploymentBuilder.getMethod('endpoint', Map, Class, Closure).returnType
-        deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider).genericReturnType.typeName == 'B'
+        when: 'the generated public contracts are inspected'
+        Method direct = fooBuilder.getMethod('primary', Map)
+        Method collection = collectionFactory.getMethod('kid', Map)
+        Method cluster = clusterFactory.getMethod('primary', Map)
+        Method dynamicWithoutClosure = deploymentBuilder.getMethod('endpoint', Map, Class)
+        Method dynamicWithClosure = deploymentBuilder.getMethod('endpoint', Map, Class, Closure)
+        Method factoryWithoutClosure = deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider)
+        Method factoryWithClosure = deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider, Closure)
+        Method deprecatedWithoutClosure = fooBuilder.getMethod('secondary', Map)
+        Method deprecatedWithClosure = fooBuilder.getMethod('secondary', Map, Closure)
         List<Method> keyedNoClosureMethods = deploymentBuilder.declaredMethods.findAll {
             it.name == 'keyedEndpoint' && !it.parameterTypes.contains(Closure)
         }
+
+        then: 'direct, collection, Cluster, keyed, dynamic-Class, and typed-Factory relationship creators omit only the optional closure'
+        direct.returnType == childBuilder
+        collection.returnType == childBuilder
+        cluster.returnType == childBuilder
+        dynamicWithoutClosure.returnType == dynamicWithClosure.returnType
+        factoryWithoutClosure.genericReturnType.typeName == 'B'
+        factoryWithoutClosure.typeParameters*.bounds*.typeName == factoryWithClosure.typeParameters*.bounds*.typeName
+        factoryWithoutClosure.getAnnotation(AnnoDoc).value() == factoryWithClosure.getAnnotation(AnnoDoc).value()
+        factoryWithoutClosure.parameters[1].isAnnotationPresent(DelegatesTo.Target)
+        Modifier.isPublic(factoryWithoutClosure.modifiers)
+        !factoryWithoutClosure.isAnnotationPresent(Deprecated)
+        deprecatedWithoutClosure.isAnnotationPresent(Deprecated)
+        deprecatedWithClosure.isAnnotationPresent(Deprecated)
+        deprecatedWithoutClosure.getAnnotation(AnnoDoc).value() == deprecatedWithClosure.getAnnotation(AnnoDoc).value()
         keyedNoClosureMethods.any { it.parameterTypes.contains(String) }
         keyedNoClosureMethods.any { it.parameterTypes.contains(Class) }
         keyedNoClosureMethods.any { it.parameterTypes.contains(BuilderFactoryProvider) && it.genericReturnType.typeName == 'B' }
 
         and: 'the closure-taking Factory form retains its exact generic delegate metadata'
-        Method factoryWithClosure = deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider, Closure)
         factoryWithClosure.typeParameters*.name == ['T', 'B']
         factoryWithClosure.parameters.last().getAnnotation(DelegatesTo).with {
             target() == 'factory' && genericTypeIndex() == 1 && strategy() == Closure.DELEGATE_ONLY
@@ -740,21 +757,36 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
                         StaticBuilderWithoutClosureConsumer.configure((Foo_DSL.Builder<Foo>) delegate)
                     }
                 }
+
+                static Foo createWithEmptyClosure() {
+                    Foo.Create.With {
+                        ((Foo_DSL.Builder<Foo>) delegate).primary([name: 'from public Builder']) {}
+                    }
+                }
             }
         ''', 'sample/StaticBuilderWithoutClosureConsumer.groovy')
 
         and: 'AnnoDocimal projects the same explicit public contract'
         File mirrorRoot = new File(tempFolder.root, 'issue-719-mirrors')
         File namespaceClass = new File(compilerConfiguration.targetDirectory, 'sample/Foo_DSL.class')
+        File deploymentNamespaceClass = new File(compilerConfiguration.targetDirectory, 'sample/Deployment_DSL.class')
         new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(deploymentNamespaceClass.toPath(), mirrorRoot.toPath())
         String mirror = new File(mirrorRoot, 'sample/Foo_DSL.java').text
+        String deploymentMirror = new File(mirrorRoot, 'sample/Deployment_DSL.java').text
 
         then: 'the runtime behavior remains equivalent to the closure-taking creation form'
         consumer.create().primary.name == 'from public Builder'
+        consumer.createWithEmptyClosure().primary.name == 'from public Builder'
 
-        and: 'the mirror lists the shorter direct and collection creator overloads'
+        and: 'the mirrors list the shorter direct, collection, map, keyed, dynamic-Class, and typed-Factory creator overloads'
         mirror.contains('Child_DSL.Builder<Child> primary(Map<String, ?> values)')
         mirror.contains('Child_DSL.Builder<Child> kid(Map<String, ?> values)')
+        mirror.readLines().any { it.contains(' primary(Map<String, ?> values)') && !it.contains('Closure') }
+        (deploymentMirror =~ /(?s)Endpoint\.Builder endpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends Endpoint> typeToCreate\);/).find()
+        (deploymentMirror =~ /(?s)B endpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target\("factory"\) KlumFactory\.BuilderFactoryProvider<T, B> factory\);/).find()
+        (deploymentMirror =~ /(?s)KeyedEndpoint\.Builder keyedEndpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends KeyedEndpoint> typeToCreate,?\s+String key\);/).find()
+        (deploymentMirror =~ /(?s)B keyedEndpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target\("factory"\) KlumFactory\.BuilderFactoryProvider<T, B> factory,*\s+String key\);/).find()
     }
 
     @Issue('710')
@@ -863,7 +895,7 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
             @DSL class Foo extends Base {
                 List<Child> kids
                 Child primary
-                Child secondary
+                @Deprecated Child secondary
                 OpaqueChild opaqueChild
                 @Cluster Map<String, Child> services
             }

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -693,6 +693,70 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         !dynamicEndpointMethod.isAnnotationPresent(Deprecated)
     }
 
+    @Issue('719')
+    def "public Builder contracts and source mirrors declare relationship creators without their optional closure"() {
+        given:
+        Class<?> fooBuilder = getClass('sample.Foo_DSL$Builder')
+        Class<?> childBuilder = getClass('sample.Child_DSL$Builder')
+        Class<?> collectionFactory = getClass('sample.Foo_DSL$Builder$CollectionFactory_kids')
+        Class<?> clusterFactory = getClass('sample.Foo_DSL$Builder$ClusterFactory_services')
+        Class<?> deploymentBuilder = getClass('sample.Deployment_DSL$Builder')
+
+        expect: 'direct, collection, Cluster, keyed, dynamic-Class, and typed-Factory relationship creators omit only the optional closure'
+        fooBuilder.getMethod('primary', Map).returnType == childBuilder
+        collectionFactory.getMethod('kid', Map).returnType == childBuilder
+        clusterFactory.getMethod('primary', Map).returnType == childBuilder
+        deploymentBuilder.getMethod('endpoint', Map, Class).returnType ==
+                deploymentBuilder.getMethod('endpoint', Map, Class, Closure).returnType
+        deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider).genericReturnType.typeName == 'B'
+        List<Method> keyedNoClosureMethods = deploymentBuilder.declaredMethods.findAll {
+            it.name == 'keyedEndpoint' && !it.parameterTypes.contains(Closure)
+        }
+        keyedNoClosureMethods.any { it.parameterTypes.contains(String) }
+        keyedNoClosureMethods.any { it.parameterTypes.contains(Class) }
+        keyedNoClosureMethods.any { it.parameterTypes.contains(BuilderFactoryProvider) && it.genericReturnType.typeName == 'B' }
+
+        and: 'the closure-taking Factory form retains its exact generic delegate metadata'
+        Method factoryWithClosure = deploymentBuilder.getMethod('endpoint', Map, BuilderFactoryProvider, Closure)
+        factoryWithClosure.typeParameters*.name == ['T', 'B']
+        factoryWithClosure.parameters.last().getAnnotation(DelegatesTo).with {
+            target() == 'factory' && genericTypeIndex() == 1 && strategy() == Closure.DELEGATE_ONLY
+        }
+
+        when: 'a statically compiled extension only knows the public Builder interface'
+        Class<?> consumer = createSecondaryClass('''
+            package sample
+
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticBuilderWithoutClosureConsumer {
+                static void configure(Foo_DSL.Builder<Foo> target) {
+                    target.primary([name: 'from public Builder'])
+                }
+
+                static Foo create() {
+                    Foo.Create.With {
+                        StaticBuilderWithoutClosureConsumer.configure((Foo_DSL.Builder<Foo>) delegate)
+                    }
+                }
+            }
+        ''', 'sample/StaticBuilderWithoutClosureConsumer.groovy')
+
+        and: 'AnnoDocimal projects the same explicit public contract'
+        File mirrorRoot = new File(tempFolder.root, 'issue-719-mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'sample/Foo_DSL.class')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        String mirror = new File(mirrorRoot, 'sample/Foo_DSL.java').text
+
+        then: 'the runtime behavior remains equivalent to the closure-taking creation form'
+        consumer.create().primary.name == 'from public Builder'
+
+        and: 'the mirror lists the shorter direct and collection creator overloads'
+        mirror.contains('Child_DSL.Builder<Child> primary(Map<String, ?> values)')
+        mirror.contains('Child_DSL.Builder<Child> kid(Map<String, ?> values)')
+    }
+
     @Issue('710')
     def "AnnoDocimal source mirror matches the bytecode namespace and nested Template Factory contract"() {
         given:


### PR DESCRIPTION
## Summary

Projects the generated relationship-creator overloads that omit a trailing default `Closure` into `Foo_DSL.Builder`, and keeps AnnoDocimal mirrors aligned.

The generated implementation already accepts these calls through Groovy's default-argument synthesis; this correction makes the same supported signatures explicit in the static public Builder contract. Projection is constrained to generator-marked relationship creators, preserving their declared return type, generics, annotations, documentation, visibility, and deprecation.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.compiler.internal.ast.GeneratedDslSupportSpec --console=plain --no-daemon`
- `./gradlew :klum-ast:groovy4Tests --no-daemon`
- `./gradlew :klum-ast:groovy5Tests --no-daemon`
- `./gradlew check --console=plain --no-daemon`
- Standards and Spec reviews against `origin/master`, with findings addressed and re-reviewed cleanly.

## User impact

Static Groovy consumers typed solely as `Foo_DSL.Builder` can now use supported relationship creator map calls without an empty closure. User migration guidance and `CHANGES.md` document the additive 4.0 RC correction.

Related: #719
