### PR TITLE
Project same-source Builders into public DSL contracts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 - Fixed cross-source `@Owner(root = true)` public Builder accessors to expose the target model's
   `Root_DSL.Builder<Root>` contract instead of the hidden `Root$Builder` implementation. Generated
   AnnoDocimal source mirrors now preserve that same public type ([#702](https://github.com/klum-dsl/klum-ast/issues/702)).
+- Fixed same-source forward relationship declarations so public Builder accessors, creators, and AnnoDocimal source
+  mirrors use the target's `Child_DSL.Builder<Child>` contract rather than the hidden `Child$Builder`
+  implementation ([#728](https://github.com/klum-dsl/klum-ast/issues/728)).
 - Public static methods declared on custom `Factory` classes now fail compilation instead of being silently omitted from
   `Create`. Make these public factory operations instance methods; private, protected, and package-private static helpers
   and model-level static converters remain supported ([#706](https://github.com/klum-dsl/klum-ast/issues/706)).

--- a/docs/user/Builder-First-Migration.md
+++ b/docs/user/Builder-First-Migration.md
@@ -39,9 +39,10 @@ use this guide for Builder-first diagnostics:
 
 ### Public Builder Contracts
 
-Generated accessors always expose `Foo_DSL.Builder<Foo>`, never the hidden `Foo$Builder` implementation. This also
-applies when two source files compile together and an `@Owner(root = true)` target has not yet been resolved. (See:
-`GeneratedDslSupportSpec#'projects an unresolved cross-source owner Builder into the public namespace'`.)
+Generated accessors and relationship creators always expose `Foo_DSL.Builder<Foo>`, never the hidden `Foo$Builder`
+implementation. This also applies when a forward relationship target is unresolved during transformation, whether the
+models share a source file or compile from separate source files. (See:
+`GeneratedDslSupportSpec#'projects same-source forward relationship Builders into the public namespace'`.)
 
 For same-project IntelliJ source completion, refresh the IDEA-only `Foo_DSL` mirrors through the Schema plugin and reload
 the Gradle project. The refresh materializes one root-owned GDSL resource directory and registers it with every Schema
@@ -52,18 +53,17 @@ not add bytecode or independent read-only semantics. This is IDE metadata only: 
 compiler, package, or downstream inputs.
 
 ```groovy
-// Child.groovy
+// Schema.groovy
 @DSL
-class Child {
-    @Owner(root = true) Root root
+class Parent {
+    Child child
 }
 
-// Root.groovy
 @DSL
-class Root {}
+class Child {}
 ```
 
-In generated signatures and IDE source mirrors, `Child_DSL.Builder` uses `Root_DSL.Builder<Root>` for `root`.
+In generated signatures and IDE source mirrors, `Parent_DSL.Builder` uses `Child_DSL.Builder<Child>` for `child`.
 
 #### Relationship creator overloads
 

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/DslHelper.java
@@ -22,9 +22,10 @@
  * SOFTWARE.
  */
 package com.blackbuild.klum.ast.runtime.internal;
-import com.blackbuild.klum.ast.runtime.KlumSchemaException;
-import com.blackbuild.klum.ast.runtime.KlumModelException;
+import com.blackbuild.klum.ast.runtime.KlumBuilder;
 import com.blackbuild.klum.ast.runtime.KlumFactory;
+import com.blackbuild.klum.ast.runtime.KlumModelException;
+import com.blackbuild.klum.ast.runtime.KlumSchemaException;
 
 import com.blackbuild.klum.ast.DSL;
 import com.blackbuild.klum.ast.FieldType;
@@ -318,7 +319,7 @@ public class DslHelper {
     private static boolean virtualSetterAccepts(Class<?> parameterType, Class<?> modelType) {
         if (parameterType.isAssignableFrom(modelType))
             return true;
-        return InternalKlumBuilder.class.isAssignableFrom(parameterType)
+        return KlumBuilder.class.isAssignableFrom(parameterType)
                 && parameterType.isAssignableFrom(GeneratedBuilderSupport.builderTypeFor(modelType));
     }
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1025,7 +1025,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         String methodName = getElementNameForCollectionField(fieldNode);
         ClassNode defaultImpl = getDefaultImplOfFieldOrMethod(fieldNode, elementType);
         ClassNode dslBaseType = getDslBaseType(elementType, defaultImpl);
-        ClassNode elementBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl).getPlainNodeReference();
+        ClassNode elementBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl, fieldNode.getOwner()).getPlainNodeReference();
         FieldType relationshipType = getFieldType(fieldNode);
         boolean linkField = relationshipType == FieldType.LINK;
         boolean optionalLinkField = relationshipType == FieldType.OPTIONAL_LINK;
@@ -1240,7 +1240,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         String methodName = getElementNameForCollectionField(fieldNode);
         String fieldName = fieldNode.getName();
 
-        ClassNode elementBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl).getPlainNodeReference();
+        ClassNode elementBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl, fieldNode.getOwner()).getPlainNodeReference();
         FieldType relationshipType = getFieldType(fieldNode);
         boolean linkField = relationshipType == FieldType.LINK;
         boolean optionalLinkField = relationshipType == FieldType.OPTIONAL_LINK;
@@ -1381,7 +1381,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
 
         FieldNode targetTypeKeyField = getKeyField(dslBaseType);
         String targetKeyFieldName = targetTypeKeyField != null ? targetTypeKeyField.getName() : null;
-        ClassNode targetBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl).getPlainNodeReference();
+        ClassNode targetBuilderType = DslAstHelper.getBuilderClassOf(defaultImpl, fieldNode.getOwner()).getPlainNodeReference();
 
         Expression keyProvider = getStaticKeyExpression(fieldNode);
         boolean needKeyParameter = targetTypeKeyField != null && keyProvider == null;

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DslAstHelper.java
@@ -128,13 +128,13 @@ public class DslAstHelper {
     }
 
     /**
-     * Returns a Builder type for a field that may be projected into another source's public contract.
-     * Cross-source unresolved placeholders have no {@linkplain ClassNode#getOuterClass() outer class}, so retain
-     * their model identity explicitly for {@link GeneratedDslSupport#publicType(ClassNode)}.
+     * Returns a Builder type for a field whose owner contributes to a public contract projection.
+     * Unresolved placeholders have no {@linkplain ClassNode#getOuterClass() outer class}, so retain their model
+     * identity explicitly for {@link GeneratedDslSupport#publicType(ClassNode)}.
      */
     public static ClassNode getBuilderClassOf(ClassNode classNode, ClassNode projectionConsumer) {
         ClassNode result = getBuilderClassOf(classNode);
-        if (result != null && !classNode.isResolved() && classNode.getModule() != projectionConsumer.getModule()
+        if (projectionConsumer != null && result != null && !classNode.isResolved()
                 && result.redirect().getNodeMetaData(MODEL_CLASS_METADATA_KEY) == null)
             result.redirect().setNodeMetaData(MODEL_CLASS_METADATA_KEY, classNode.redirect());
         return result;

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFieldGenericTypeTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/BuilderFieldGenericTypeTest.groovy
@@ -78,7 +78,8 @@ class BuilderFieldGenericTypeTest extends AbstractDSLSpec {
         getClass('pk.Subscription$Builder').getMethod('getCustomers').genericReturnType.typeName == 'java.util.List<java.lang.String>'
     }
 
-    def "relationship collection getters retain generated Builder element types"() {
+    @Issue(['646', '728'])
+    def "relationship collection getters retain generated public Builder element types"() {
         given:
         createClass '''
             package pk
@@ -96,6 +97,6 @@ class BuilderFieldGenericTypeTest extends AbstractDSLSpec {
 
         expect:
         getClass('pk.Order_DSL$Builder').getMethod('getItems').genericReturnType.typeName ==
-                'java.util.List<pk.LineItem$Builder>'
+                'java.util.List<pk.LineItem_DSL$Builder<pk.LineItem>>'
     }
 }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConverterSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/ConverterSpec.groovy
@@ -322,6 +322,7 @@ class ConverterSpec extends AbstractDSLSpec {
         instance.bar.birthday.time == 123L
     }
 
+    @Issue(['148', '728'])
     def "converter factory for keyed dsl list"() {
         when:
         createClass '''
@@ -340,7 +341,7 @@ class ConverterSpec extends AbstractDSLSpec {
             '''
 
         then:
-        builderClass.getMethod("bar", getBuilderClass("Bar"))
+        builderClass.getMethod("bar", getClass("Bar_DSL\$Builder"))
         builderClass.getMethod("bar", String, long)
 
         when:
@@ -352,6 +353,7 @@ class ConverterSpec extends AbstractDSLSpec {
         instance.bars.first().birthday.time == 123L
     }
 
+    @Issue(['148', '728'])
     def "converter factory for keyed dsl map"() {
         when:
         createClass '''
@@ -370,7 +372,7 @@ class ConverterSpec extends AbstractDSLSpec {
             '''
 
         then:
-        builderClass.getMethod("bar", getBuilderClass("Bar"))
+        builderClass.getMethod("bar", getClass("Bar_DSL\$Builder"))
         builderClass.getMethod("bar", String, long)
 
         when:
@@ -570,7 +572,7 @@ class Other<E> {
         noExceptionThrown()
     }
 
-    @Issue(["300", "319"])
+    @Issue(["300", "319", "728"])
     def "methods of the factory are included in collection factories"() {
         when:
         createClass '''import com.blackbuild.klum.ast.runtime.KlumFactory
@@ -599,7 +601,7 @@ import java.time.Duration
         def barsFactory = getClass('Foo$_bars')
 
         then:
-        hasMethod(barsFactory, 'bar', getBuilderClass('Bar'))
+        hasMethod(barsFactory, 'bar', getClass('Bar_DSL$Builder'))
         hasMethod(barsFactory, 'From', Class)
         hasMethod(barsFactory, 'WithAge', Duration)
         hasMethod(barsFactory, 'WithAges', Duration[])
@@ -628,7 +630,7 @@ import java.time.Duration
         instance.bars.size() == 2
     }
 
-    @Issue(["300", "319"])
+    @Issue(["300", "319", "728"])
     def "methods of the factory are included in collection factories for maps"() {
         when:
         createClass '''import com.blackbuild.klum.ast.runtime.KlumFactory
@@ -658,7 +660,7 @@ import java.time.Duration
         def barsFactory = getClass('Foo$_bars')
 
         then:
-        hasMethod(barsFactory, 'bar', getBuilderClass('Bar'))
+        hasMethod(barsFactory, 'bar', getClass('Bar_DSL$Builder'))
         hasMethod(barsFactory, 'From', Class)
         hasMethod(barsFactory, 'WithAge', String, Duration)
         hasMethod(barsFactory, 'WithAges', Map)

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TransformSpec.groovy
@@ -1752,6 +1752,7 @@ import org.codehaus.groovy.control.CompilePhase
         Serializable.isAssignableFrom(clazz)
     }
 
+    @Issue('728')
     def "DelegatesTo annotations for unkeyed inner models are created"() {
         given:
         createClass('''
@@ -1784,13 +1785,14 @@ import org.codehaus.groovy.control.CompilePhase
         delegatesToPointsToDelegateTarget(polymorphicMethodWithNamesParams[2])
 
         and:
-        delegatesToPointsTo(builderClass.getMethod(methodName, Closure).parameterAnnotations[0], 'pk.Inner.Builder')
-        delegatesToPointsTo(builderClass.getMethod(methodName, Map, Closure).parameterAnnotations[1], 'pk.Inner.Builder')
+        delegatesToPointsTo(builderClass.getMethod(methodName, Closure).parameterAnnotations[0], 'pk.Inner_DSL.Builder')
+        delegatesToPointsTo(builderClass.getMethod(methodName, Map, Closure).parameterAnnotations[1], 'pk.Inner_DSL.Builder')
 
         where:
         methodName << ["inner", "listInner"]
     }
 
+    @Issue('728')
     def "DelegatesTo annotations for keyed inner models are created"() {
         given:
         createClass('''
@@ -1824,8 +1826,8 @@ import org.codehaus.groovy.control.CompilePhase
         delegatesToPointsToDelegateTarget(polymorphicMethodWithNamesParams[3])
 
         and:
-        delegatesToPointsTo(builderClass.getMethod(methodName, String, Closure).parameterAnnotations[1], 'pk.Inner.Builder')
-        delegatesToPointsTo(builderClass.getMethod(methodName, Map, String, Closure).parameterAnnotations[2], 'pk.Inner.Builder')
+        delegatesToPointsTo(builderClass.getMethod(methodName, String, Closure).parameterAnnotations[1], 'pk.Inner_DSL.Builder')
+        delegatesToPointsTo(builderClass.getMethod(methodName, Map, String, Closure).parameterAnnotations[2], 'pk.Inner_DSL.Builder')
 
         where:
         methodName << ["inner", "listInner", "mapInner"]

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/AnnoDocTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/AnnoDocTest.groovy
@@ -271,6 +271,7 @@ class MyFactory extends KlumFactory.Unkeyed<Foo> {
 @return The instantiated object."""
     }
 
+    @Issue(['197', '728'])
     def "annodoc for collection methods"() {
         when:
         createClass("dummy/Foo.groovy", '''
@@ -297,7 +298,7 @@ class MyFactory extends KlumFactory.Unkeyed<Foo> {
 @param values the optional parameters
 @param closure the closure to configure the new element
 @return the newly created Builder""" // closures has a default value, so during ast it is a single method
-        builderImplementationMethodDoc("bars", getArrayClass("dummy.Bar\$Builder")) == """Adds one or more 'bar' Builders to the Builder's 'bars' collection.
+        builderImplementationMethodDoc("bars", getArrayClass("dummy.Bar_DSL\$Builder")) == """Adds one or more 'bar' Builders to the Builder's 'bars' collection.
 
 @param values the elements to add"""
         builderImplementationMethodDoc("bars", Iterable) == """Adds one or more 'bar' Builders to the Builder's 'bars' collection.

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -45,6 +45,7 @@ import groovy.transform.CompileStatic
 import org.intellij.lang.annotations.Language
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.codehaus.groovy.ast.ClassHelper
 import spock.lang.Issue
 import spock.lang.See
 import spock.lang.Tag
@@ -54,6 +55,7 @@ import java.io.DataInputStream
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.net.URLClassLoader
+import java.util.stream.Stream
 
 class GeneratedDslSupportSpec extends AbstractDSLSpec {
 
@@ -693,7 +695,7 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         !dynamicEndpointMethod.isAnnotationPresent(Deprecated)
     }
 
-    @Issue('719')
+    @Issue(['719', '728'])
     def "public Builder contracts and source mirrors declare relationship creators without their optional closure"() {
         given:
         Class<?> fooBuilder = getClass('sample.Foo_DSL$Builder')
@@ -783,9 +785,9 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         mirror.contains('Child_DSL.Builder<Child> primary(Map<String, ?> values)')
         mirror.contains('Child_DSL.Builder<Child> kid(Map<String, ?> values)')
         mirror.readLines().any { it.contains(' primary(Map<String, ?> values)') && !it.contains('Closure') }
-        (deploymentMirror =~ /(?s)Endpoint\.Builder endpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends Endpoint> typeToCreate\);/).find()
+        (deploymentMirror =~ /(?s)Endpoint_DSL\.Builder<Endpoint> endpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends Endpoint> typeToCreate\);/).find()
         (deploymentMirror =~ /(?s)B endpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target\("factory"\) KlumFactory\.BuilderFactoryProvider<T, B> factory\);/).find()
-        (deploymentMirror =~ /(?s)KeyedEndpoint\.Builder keyedEndpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends KeyedEndpoint> typeToCreate,?\s+String key\);/).find()
+        (deploymentMirror =~ /(?s)KeyedEndpoint_DSL\.Builder<KeyedEndpoint> keyedEndpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target Class<\? extends KeyedEndpoint> typeToCreate,?\s+String key\);/).find()
         (deploymentMirror =~ /(?s)B keyedEndpoint\(Map<String, \?> values,\s+@DelegatesTo\.Target\("factory"\) KlumFactory\.BuilderFactoryProvider<T, B> factory,*\s+String key\);/).find()
     }
 
@@ -875,6 +877,135 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         and: 'the IDE-only source mirror names the same public Builder contract'
         mirror.contains('Root_DSL.Builder<Root>')
         !mirror.contains('Root.Builder')
+    }
+
+    @Issue('728')
+    def "projects same-source forward relationship Builders into the public namespace"() {
+        given: 'Parent is transformed before its relationship target is resolved from the same Schema source'
+        def unit = new CompilationUnit(compilerConfiguration, null, loader)
+        unit.addSource('SameSourceSchema.groovy', '''
+            package samesource
+
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Key
+
+            @DSL class Parent {
+                Child primaryChild
+                List<Child> children
+                Map<String, Child> childrenByName
+            }
+
+            @DSL class Child {
+                @Key String name
+            }
+        ''')
+
+        when:
+        unit.compile()
+        def sameSourceLoader = new URLClassLoader([compilerConfiguration.targetDirectory.toURI().toURL()] as URL[], loader)
+        Class<?> parentBuilder = sameSourceLoader.loadClass('samesource.Parent_DSL$Builder')
+        Class<?> childBuilder = sameSourceLoader.loadClass('samesource.Child_DSL$Builder')
+        Class<?> collectionFactory = sameSourceLoader.loadClass('samesource.Parent_DSL$Builder$CollectionFactory_children')
+
+        and: 'a static Groovy extension relies on the generated public contracts only'
+        Class<?> consumer = new GroovyClassLoader(sameSourceLoader, compilerConfiguration).parseClass('''
+            package samesource
+
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class SameSourcePublicBuilderConsumer {
+                static Child_DSL.Builder<Child> primary(Parent_DSL.Builder<Parent> parent) {
+                    parent.primaryChild
+                }
+            }
+        ''', 'samesource/SameSourcePublicBuilderConsumer.groovy')
+
+        and: 'AnnoDocimal mirrors the generated namespace rather than an implementation descriptor'
+        File mirrorRoot = new File(tempFolder.root, 'same-source-mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'samesource/Parent_DSL.class')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        String mirror = new File(mirrorRoot, 'samesource/Parent_DSL.java').text
+
+        then: 'accessors and every relationship-creator path use the public Child Builder contract'
+        parentBuilder.getMethod('getPrimaryChild').returnType == childBuilder
+        parentBuilder.getMethod('setPrimaryChild', childBuilder)
+        parentBuilder.getMethod('getChildren').genericReturnType.typeName ==
+                'java.util.List<samesource.Child_DSL$Builder<samesource.Child>>'
+        parentBuilder.getMethod('setChildren', List).genericParameterTypes[0].typeName ==
+                'java.util.List<samesource.Child_DSL$Builder<samesource.Child>>'
+        parentBuilder.getMethod('getChildrenByName').genericReturnType.typeName ==
+                'java.util.Map<java.lang.String, samesource.Child_DSL$Builder<samesource.Child>>'
+        parentBuilder.getMethod('setChildrenByName', Map).genericParameterTypes[0].typeName ==
+                'java.util.Map<java.lang.String, samesource.Child_DSL$Builder<samesource.Child>>'
+        closureDelegate(parentBuilder.declaredMethods.find {
+            it.name == 'primaryChild' && it.returnType == childBuilder &&
+                    !it.parameterTypes.toList().contains(Class) && !it.parameterTypes.toList().contains(BuilderFactoryProvider) &&
+                    it.parameterTypes.last() == Closure
+        }) == childBuilder
+        closureDelegate(collectionFactory.declaredMethods.find {
+            it.returnType == childBuilder && !it.parameterTypes.toList().contains(Class) &&
+                    !it.parameterTypes.toList().contains(BuilderFactoryProvider) && it.parameterTypes.last() == Closure
+        }) == childBuilder
+        closureDelegate(parentBuilder.declaredMethods.find {
+            it.name == 'childrenByName' && it.returnType == childBuilder &&
+                    !it.parameterTypes.toList().contains(Class) && !it.parameterTypes.toList().contains(BuilderFactoryProvider) &&
+                    it.parameterTypes.last() == Closure
+        }) == childBuilder
+        parentBuilder.declaredMethods.findAll { it.name in ['primaryChild', 'childrenByName'] }.every { method ->
+            !method.toGenericString().contains('Child$Builder')
+        }
+        collectionFactory.declaredMethods.findAll { it.name == 'child' }.every { method ->
+            !method.toGenericString().contains('Child$Builder')
+        }
+
+        and: 'dynamic Class and typed Factory creator paths retain their public generic contract for every relationship shape'
+        List<Method> dynamicCreators = [
+                parentBuilder.declaredMethods.find { it.name == 'primaryChild' && it.parameterTypes.toList().contains(Class) && it.parameterTypes.last() == Closure },
+                collectionFactory.declaredMethods.find { it.name == 'children' && it.parameterTypes.toList().contains(Class) && it.parameterTypes.last() == Closure },
+                parentBuilder.declaredMethods.find { it.name == 'childrenByName' && it.parameterTypes.toList().contains(Class) && it.parameterTypes.last() == Closure }
+        ]
+        List<Method> factoryCreators = [
+                parentBuilder.declaredMethods.find { it.name == 'primaryChild' && it.parameterTypes.toList().contains(BuilderFactoryProvider) && it.parameterTypes.last() == Closure },
+                collectionFactory.declaredMethods.find { it.name == 'children' && it.parameterTypes.toList().contains(BuilderFactoryProvider) && it.parameterTypes.last() == Closure },
+                parentBuilder.declaredMethods.find { it.name == 'childrenByName' && it.parameterTypes.toList().contains(BuilderFactoryProvider) && it.parameterTypes.last() == Closure }
+        ]
+        dynamicCreators*.returnType == [childBuilder, childBuilder, childBuilder]
+        dynamicCreators.every { creator ->
+            creator.genericParameterTypes.find { it.typeName.startsWith('java.lang.Class') }.typeName ==
+                    'java.lang.Class<? extends samesource.Child>'
+            creator.parameters.last().getAnnotation(DelegatesTo).with {
+                genericTypeIndex() == 0 && strategy() == Closure.DELEGATE_ONLY
+            }
+        }
+        factoryCreators.every { creator ->
+            creator.genericReturnType.typeName == 'B'
+            creator.genericParameterTypes.find { it.typeName.contains('BuilderFactoryProvider') }.typeName ==
+                    'com.blackbuild.klum.ast.runtime.KlumFactory$BuilderFactoryProvider<T, B>'
+            creator.parameters.last().getAnnotation(DelegatesTo).with {
+                target() == 'factory' && genericTypeIndex() == 1 && strategy() == Closure.DELEGATE_ONLY
+            }
+        }
+
+        and: 'the source mirror is as truthful as bytecode and the public static consumer compiles'
+        mirror.contains('Child_DSL.Builder<Child> getPrimaryChild()')
+        mirror.contains('void setPrimaryChild(Child_DSL.Builder<Child>')
+        mirror.contains('List<Child_DSL.Builder<Child>> getChildren()')
+        mirror.contains('void setChildren(List<Child_DSL.Builder<Child>>')
+        mirror.contains('Map<String, Child_DSL.Builder<Child>> getChildrenByName()')
+        mirror.contains('void setChildrenByName(Map<String, Child_DSL.Builder<Child>>')
+        mirror.contains('Child_DSL.Builder<Child> primaryChild(')
+        mirror.contains('Child_DSL.Builder<Child> child(')
+        mirror.contains('Child_DSL.Builder<Child> childrenByName(')
+        !mirror.contains('Child.Builder')
+        !mirror.contains('Child$Builder')
+        consumer.getMethod('primary', parentBuilder).returnType == childBuilder
+    }
+
+    @Issue('728')
+    def "does not project an ordinary Java nested Builder type"() {
+        expect:
+        GeneratedDslSupport.publicType(ClassHelper.make(Stream.Builder)).name == Stream.Builder.name
     }
 
     private void createRepresentativeSchema() {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/UtilityTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/UtilityTest.groovy
@@ -23,6 +23,8 @@
  */
 package com.blackbuild.klum.ast.compiler.internal.ast
 
+import org.codehaus.groovy.ast.ClassHelper
+import spock.lang.Issue
 import spock.lang.Specification
 
 class UtilityTest extends Specification {
@@ -37,5 +39,12 @@ class UtilityTest extends Specification {
         'small'   || -1
         'Big'     || 0
         'enD'     || 2
+    }
+
+    @Issue('728')
+    def "Builder lookup tolerates absent public-projection inputs"() {
+        expect:
+        DslAstHelper.getBuilderClassOf(null, null) == null
+        DslAstHelper.getBuilderClassOf(ClassHelper.STRING_TYPE, ClassHelper.OBJECT_TYPE) == null
     }
 }


### PR DESCRIPTION
## Summary
- project unresolved same-source forward relationship Builders through the public generated DSL contract
- preserve public Builder signatures in accessors, relationship creators, delegates, and AnnoDocimal mirrors
- retain virtual setter dispatch for public Builder contracts and cover Groovy 3/4/5 compatibility

## Validation
- focused GeneratedDslSupportSpec
- focused Groovy 4 GeneratedDslSupportSpec and TransformSpec
- root Gradle check

Related: #728

The separate Create.AsBuilder API redesign remains intentionally out of scope.