### PR TITLE
Allow Builder converter twins in Template definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Builder-first construction
 
+- Template definition now forms a separate nested Builder-composition scope. Generated converter twins create
+  Template-owned children while defining `Create.Template.With` or `From`, including inside an active root Construction
+  session; no nested lifecycle or session attachment occurs, and ordinary `Create.AsBuilder` behavior resumes when the
+  Template scope exits ([#731](https://github.com/klum-dsl/klum-ast/issues/731)).
 - Public `Foo_DSL.Builder` contracts and their IDEA-only AnnoDocimal mirrors now explicitly expose supported generated
   relationship-creator overloads that omit the optional trailing configuration closure. This is an additive 4.0 API
   correction; existing lifecycle, relationship, Factory, and source-DSL behavior is unchanged ([#719](https://github.com/klum-dsl/klum-ast/issues/719)).

--- a/docs/adr/0004-asbuilder-composition-protocol.md
+++ b/docs/adr/0004-asbuilder-composition-protocol.md
@@ -50,6 +50,19 @@ as composition at one relationship entry, while an already claimed Builder or co
 Aggregation-only `LINK` rejects fresh Builders. The distinction is per single value, collection element, or map value;
 an optional collection or map may therefore mix owned and aggregation targets.
 
+### Give Template definition a separate composition scope
+
+`Create.Template.With` and `Create.Template.From` establish a lexical Template-definition scope while they configure and
+materialize their Template graph. Within that scope, `Create.AsBuilder` creates a Template-mode owned child Builder;
+it does not attach to a Construction session, register with `PhaseDriver`, or run `PostCreate`, `PostApply`, graph
+phases, Materialization, or validation independently. Every such child carries Template identity when its graph is
+materialized.
+
+Template definition has precedence over an active Construction session. After the lexical scope exits, including by an
+exception, the original session remains current and normal `Create.AsBuilder` behavior resumes. Nested definition scopes
+are stack-safe. Scoped recipe application through `Template.With` or `Template.WithAll` does not establish this
+composition scope. Outside both scopes, `Create.AsBuilder` keeps its existing rejection.
+
 ### Project adaptable factory methods into Builder-producing methods
 
 Collection and Cluster factories call Builder-producing implementations and return the created Builder. Factory methods
@@ -133,6 +146,8 @@ boundary, not the general past/current-phase guard tracked by #281.
 - Root factories retain completed-model signatures and behavior.
 - Public generated APIs advertise only adaptable composition methods.
 - Source converters retain direct-call behavior while generated twins provide truthful Builder results.
+- Template definition can use those generated twins without creating a nested lifecycle or contaminating the enclosing
+  Construction session.
 - Template recipes have persistent identity without contaminating ordinary completed models.
 - Existing use of completed models as value-only copy sources remains valid.
 - Opaque nested materializing programs and late `applyLater` scheduling are explicit compatibility breaks.

--- a/docs/user/Templates.md
+++ b/docs/user/Templates.md
@@ -58,6 +58,42 @@ and `Template.CreateFrom` still forward to the canonical creation operations, bu
 def template = ServiceConfiguration.Create.Template.From(new File('service-template.groovy'))
 ```
 
+## Nested Builder composition
+
+Defining a Template is its own nested composition scope. A source-visible converter may therefore use a normal
+`Child.Create.With(...)` implementation while the generated Builder converter twin creates a Template-owned child.
+Those children carry Template identity and run no lifecycle or validation until the Template is rehydrated into an
+ordinary root creation. This scope takes precedence when a Template is defined inside an active Construction session;
+after it exits, ordinary `Create.AsBuilder` calls continue in that original session. `Template.With` and
+`Template.WithAll` only apply recipes and do not open Template-definition composition.
+
+(See: `TemplatesDocumentaryTest#'defines a Template through a fluent child converter'`.)
+
+```groovy
+@DSL
+class Parent {
+    Child child
+}
+
+@DSL
+class Child {
+    String value
+
+    static Child fromString(String value) {
+        Child.Create.With(value: value)
+    }
+}
+
+def template = Parent.Create.Template.With {
+    child 'template-child'
+}
+
+Parent.Template.With(template) {
+    def registry = Parent.Create.One()
+    assert registry.child.value == 'template-child'
+}
+```
+
 There are currently four options to apply templates; all examples use the following class and template:
 
 ```groovy

--- a/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/internal/KlumDeserializer.java
+++ b/klum-ast-jackson/src/main/java/com/blackbuild/klum/ast/jackson/internal/KlumDeserializer.java
@@ -205,7 +205,7 @@ public final class KlumDeserializer extends StdDeserializer<Object> implements C
     private Object replay(ObjectNode configuration, JsonParser source, DeserializationContext context) {
         ResolvedProperties properties = resolveProperties(modelType, context);
         String key = resolveKey(modelType, configuration, null, properties);
-        ReplaySession replaySession = new ReplaySession(source, context);
+        ReplaySession replaySession = new ReplaySession(source, context, false);
         return PhaseDriver.withBuilderLifecycle(
                 () -> FactoryHelper.createBuilder(modelType, key),
                 builder -> replaySession.replay(builder, configuration, properties, true)
@@ -213,8 +213,10 @@ public final class KlumDeserializer extends StdDeserializer<Object> implements C
     }
 
     private Object replayTemplate(ObjectNode configuration, JsonParser source, DeserializationContext context) {
-        InternalKlumBuilder<?> builder = internalBuilder(FactoryHelper.createTemplateBuilderForImport(modelType));
-        return replayInto(builder, configuration, source, context, true);
+        return FactoryHelper.withTemplateDefinition(() -> {
+            InternalKlumBuilder<?> builder = internalBuilder(FactoryHelper.createTemplateBuilderForImport(modelType));
+            return replayInto(builder, configuration, source, context, true);
+        });
     }
 
     private Object replayInto(InternalKlumBuilder<?> builder, ObjectNode configuration, JsonParser source,
@@ -227,7 +229,7 @@ public final class KlumDeserializer extends StdDeserializer<Object> implements C
         if (builder == null)
             throw new KlumModelException("Managed Jackson import did not receive a Builder target");
         ResolvedProperties properties = resolveProperties(modelType, context);
-        ReplaySession replaySession = new ReplaySession(source, context);
+        ReplaySession replaySession = new ReplaySession(source, context, template);
         replaySession.replay(builder, configuration, properties, !template);
         return template ? InternalKlumBuilder.materializeTemplateForImport(builder) : builder;
     }
@@ -447,12 +449,14 @@ public final class KlumDeserializer extends StdDeserializer<Object> implements C
     private final class ReplaySession {
         private final JsonParser source;
         private final DeserializationContext context;
+        private final boolean template;
         private final List<PendingBuilder> pendingBuilders = new ArrayList<>();
         private final Map<ObjectNode, PendingBuilder> buildersByConfiguration = new IdentityHashMap<>();
 
-        private ReplaySession(JsonParser source, DeserializationContext context) {
+        private ReplaySession(JsonParser source, DeserializationContext context, boolean template) {
             this.source = source;
             this.context = context;
+            this.template = template;
         }
 
         private void replay(InternalKlumBuilder<?> root, ObjectNode configuration, ResolvedProperties properties,
@@ -593,7 +597,9 @@ public final class KlumDeserializer extends StdDeserializer<Object> implements C
                 throws IOException {
             ResolvedProperties properties = resolveProperties(childType, context);
             String key = resolveKey(childType, object, keyHint, properties);
-            InternalKlumBuilder<?> child = FactoryHelper.createBuilder(childType, key);
+            InternalKlumBuilder<?> child = internalBuilder(template
+                    ? FactoryHelper.createTemplateBuilderForImport(childType, key)
+                    : FactoryHelper.createBuilder(childType, key));
             addBuilder(child, object, properties);
             return child;
         }

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/KlumJacksonImporterSpec.groovy
@@ -95,6 +95,34 @@ class KlumJacksonImporterSpec extends AbstractDSLSpec {
         TemplateManager.isTemplate(imported)
     }
 
+    @Issue("731")
+    def "readTemplate imports nested values as Template-owned children"() {
+        given:
+        createClass('''
+            package pk
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+            }
+        ''')
+        def mapper = new ObjectMapper().findAndRegisterModules()
+
+        when:
+        def template = KlumJacksonImporter.using(mapper).readTemplate(clazz,
+                KlumJacksonInput.map([child: [value: 'imported-child']]))
+
+        then:
+        template.child.value == 'imported-child'
+        TemplateManager.isTemplate(template)
+        TemplateManager.isTemplate(template.child)
+    }
+
     def "the importer requires a caller-configured Klum module without mutating the mapper"() {
         given:
         createClass('''

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/FactoryHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/FactoryHelper.java
@@ -69,6 +69,11 @@ public class FactoryHelper extends GroovyObjectSupport {
         // static only
     }
 
+    /** Internal scope for Template-definition import paths that need nested Builder composition. */
+    public static <T> T withTemplateDefinition(Supplier<T> action) {
+        return TemplateManager.withTemplateDefinition(action);
+    }
+
     public static <T> InternalKlumBuilder<T> createBuilder(Class<T> type, String key) {
         return createBuilder(type, key, null);
     }
@@ -110,6 +115,11 @@ public class FactoryHelper extends GroovyObjectSupport {
     /** Internal adapter hook for importing a value-only Template without a Groovy configuration source. */
     public static <T> KlumBuilder<T> createTemplateBuilderForImport(Class<T> type) {
         return createTemplateBuilder(type);
+    }
+
+    /** Internal adapter hook for a nested Template value imported without a Groovy configuration source. */
+    public static <T> KlumBuilder<T> createTemplateBuilderForImport(Class<T> type, String key) {
+        return createBuilder(type, key, null, true);
     }
 
     @SuppressWarnings("java:S1452") // the concrete generated Builder type is selected from the recipe at runtime
@@ -338,9 +348,11 @@ public class FactoryHelper extends GroovyObjectSupport {
 
     public static <T> InternalKlumBuilder<T> createAsBuilder(Class<T> type, Map<String, ?> values, String key, Closure<?> body,
                                                      String operation) {
-        PhaseDriver.requireActiveConstructionSession();
+        boolean template = TemplateManager.isDefiningTemplate();
+        if (!template)
+            PhaseDriver.requireActiveConstructionSession();
         return BreadcrumbCollector.withBreadcrumb(DslHelper.shortNameFor(type) + ".AsBuilder." + operation, null, key,
-                () -> prepareNestedBuilder(type, key, false, builder -> builder.applyOnly(values, body)));
+                () -> prepareNestedBuilder(type, key, template, builder -> builder.applyOnly(values, body)));
     }
 
     /**
@@ -450,13 +462,15 @@ public class FactoryHelper extends GroovyObjectSupport {
      */
     public static <T> T createAsTemplate(Class<T> type, String text, ClassLoader loader) {
         return BreadcrumbCollector.withBreadcrumb(() -> {
-            InternalKlumBuilder<T> builder = createTemplateBuilder(type);
-            builder.copyFromTemplate();
+            return withTemplateDefinition(() -> {
+                InternalKlumBuilder<T> builder = createTemplateBuilder(type);
+                builder.copyFromTemplate();
 
-            DelegatingScript script = (DelegatingScript) createGroovyShell(loader).parse(text);
-            script.setDelegate(builder);
-            script.run();
-            return (T) InternalKlumBuilder.materializeGraph(builder);
+                DelegatingScript script = (DelegatingScript) createGroovyShell(loader).parse(text);
+                script.setDelegate(builder);
+                script.run();
+                return (T) InternalKlumBuilder.materializeGraph(builder);
+            });
         });
     }
 
@@ -496,10 +510,12 @@ public class FactoryHelper extends GroovyObjectSupport {
      */
     public static <T> T createAsTemplate(Class<T> type, Map<String, ?> values, Closure<?> closure) {
         return BreadcrumbCollector.withBreadcrumb(() -> {
-            InternalKlumBuilder<T> builder = createTemplateBuilder(type);
-            builder.copyFromTemplate();
-            builder.applyOnly(values, closure);
-            return (T) InternalKlumBuilder.materializeGraph(builder);
+            return withTemplateDefinition(() -> {
+                InternalKlumBuilder<T> builder = createTemplateBuilder(type);
+                builder.copyFromTemplate();
+                builder.applyOnly(values, closure);
+                return (T) InternalKlumBuilder.materializeGraph(builder);
+            });
         });
     }
 
@@ -524,15 +540,19 @@ public class FactoryHelper extends GroovyObjectSupport {
     }
 
     public static <T> InternalKlumBuilder<T> createFromMapAsBuilder(Class<T> type, Map<String, Object> configMap) {
-        PhaseDriver.requireActiveConstructionSession();
+        boolean template = TemplateManager.isDefiningTemplate();
+        if (!template)
+            PhaseDriver.requireActiveConstructionSession();
         Class<T> effectiveType = deduceClass(type, (String) configMap.get(TYPE_HINT));
         String key = keyFromMap(effectiveType, configMap);
         return BreadcrumbCollector.withBreadcrumb(DslHelper.shortNameFor(type) + ".AsBuilder.FromMap", null, key,
-                () -> prepareNestedBuilder(effectiveType, key, false, builder -> builder.copyFrom(configMap)));
+                () -> prepareNestedBuilder(effectiveType, key, template, builder -> builder.copyFrom(configMap)));
     }
 
     public static <T> InternalKlumBuilder<T> createFromAsBuilder(Class<T> type, Class<? extends Script> scriptType) {
-        PhaseDriver.requireActiveConstructionSession();
+        boolean template = TemplateManager.isDefiningTemplate();
+        if (!template)
+            PhaseDriver.requireActiveConstructionSession();
         if (!DelegatingScript.class.isAssignableFrom(scriptType))
             throw new KlumModelException("Create.AsBuilder.From only accepts DelegatingScript configuration recipes. "
                     + "A regular Script may materialize a completed DSL Object and cannot join owned composition; "
@@ -542,7 +562,7 @@ public class FactoryHelper extends GroovyObjectSupport {
         String scriptName = DslHelper.shortNameFor(scriptType);
         return BreadcrumbCollector.withBreadcrumb(
                 DslHelper.shortNameFor(type) + ".AsBuilder.From", "script", scriptName,
-                () -> prepareNestedBuilder(type, key, false, builder -> {
+                () -> prepareNestedBuilder(type, key, template, builder -> {
                     DelegatingScript script = (DelegatingScript) InvokerHelper.invokeConstructorOf(scriptType, null);
                     script.setDelegate(builder);
                     script.run();

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/FactoryHelper.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/FactoryHelper.java
@@ -38,6 +38,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +83,8 @@ public class FactoryHelper extends GroovyObjectSupport {
         return createBuilder(type, key, breadcrumbPathExtension, false);
     }
 
-    private static <T> InternalKlumBuilder<T> createBuilder(Class<T> type, String key, String breadcrumbPathExtension, boolean template) {
+    private static <T> InternalKlumBuilder<T> createBuilder(Class<T> type, String key,
+                                                            @Nullable String breadcrumbPathExtension, boolean template) {
         if (!template && !DslHelper.isInstantiable(type))
             throw new KlumModelException("Cannot instantiate abstract class " + type.getName());
         try {
@@ -461,8 +463,8 @@ public class FactoryHelper extends GroovyObjectSupport {
      * @return The created instance
      */
     public static <T> T createAsTemplate(Class<T> type, String text, ClassLoader loader) {
-        return BreadcrumbCollector.withBreadcrumb(() -> {
-            return withTemplateDefinition(() -> {
+        return BreadcrumbCollector.withBreadcrumb(() ->
+            withTemplateDefinition(() -> {
                 InternalKlumBuilder<T> builder = createTemplateBuilder(type);
                 builder.copyFromTemplate();
 
@@ -470,8 +472,8 @@ public class FactoryHelper extends GroovyObjectSupport {
                 script.setDelegate(builder);
                 script.run();
                 return (T) InternalKlumBuilder.materializeGraph(builder);
-            });
-        });
+            })
+        );
     }
 
     /**
@@ -504,19 +506,19 @@ public class FactoryHelper extends GroovyObjectSupport {
      *
      * @param type    The type to create
      * @param values  The value map to apply
-     * @param closure The config closure to apply
+     * @param closure The optional config closure to apply
      * @param <T>     The type to create
      * @return The created instance
      */
-    public static <T> T createAsTemplate(Class<T> type, Map<String, ?> values, Closure<?> closure) {
-        return BreadcrumbCollector.withBreadcrumb(() -> {
-            return withTemplateDefinition(() -> {
+    public static <T> T createAsTemplate(Class<T> type, Map<String, ?> values, @Nullable Closure<?> closure) {
+        return BreadcrumbCollector.withBreadcrumb(() ->
+            withTemplateDefinition(() -> {
                 InternalKlumBuilder<T> builder = createTemplateBuilder(type);
                 builder.copyFromTemplate();
                 builder.applyOnly(values, closure);
                 return (T) InternalKlumBuilder.materializeGraph(builder);
-            });
-        });
+            })
+        );
     }
 
     private static String extractKeyFromUrl(URL url) {

--- a/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/TemplateManager.java
+++ b/klum-ast-runtime/src/main/java/com/blackbuild/klum/ast/runtime/internal/TemplateManager.java
@@ -29,6 +29,7 @@ import groovy.lang.Closure;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -44,6 +45,7 @@ import static java.util.stream.Collectors.toMap;
 public class TemplateManager {
 
     private static final ThreadLocal<TemplateManager> INSTANCE = new ThreadLocal<>();
+    private static final ThreadLocal<Integer> TEMPLATE_DEFINITION_DEPTH = new ThreadLocal<>();
 
     /**
      * Returns the current instance of the TemplateManager.
@@ -59,6 +61,28 @@ public class TemplateManager {
 
     private TemplateManager() {
         // Thread local singleton
+    }
+
+    /**
+     * Executes Template creation while allowing nested Builder-producing composition to create Template Builders.
+     * Template definition is intentionally separate from scoped Template application and Construction sessions.
+     */
+    static <T> T withTemplateDefinition(Supplier<T> action) {
+        Integer depth = TEMPLATE_DEFINITION_DEPTH.get();
+        TEMPLATE_DEFINITION_DEPTH.set(depth == null ? 1 : depth + 1);
+        try {
+            return action.get();
+        } finally {
+            if (depth == null)
+                TEMPLATE_DEFINITION_DEPTH.remove();
+            else
+                TEMPLATE_DEFINITION_DEPTH.set(depth);
+        }
+    }
+
+    /** Returns whether the current thread is defining a Template graph. */
+    static boolean isDefiningTemplate() {
+        return TEMPLATE_DEFINITION_DEPTH.get() != null;
     }
 
     /**

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplateBuilderConverterTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplateBuilderConverterTest.groovy
@@ -1,0 +1,235 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.klum.ast
+
+import com.blackbuild.klum.ast.runtime.KlumModelException
+import com.blackbuild.klum.ast.runtime.internal.TemplateManager
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+
+@Issue("731")
+class TemplateBuilderConverterTest extends AbstractDSLSpec {
+
+    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "template creation projects nested source converters into owned Template relationships"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+                int postCreateCalls
+
+                @PostCreate
+                void initialize() {
+                    postCreateCalls++
+                }
+
+                static Child fromString(String value) {
+                    Child.Create.With(value: value)
+                }
+            }
+        '''
+        def Parent = clazz
+
+        when:
+        def template = Parent.Create.Template.With {
+            child 'template-child'
+        }
+        def mapTemplate = Parent.Create.Template.With(child: 'map-child')
+        def first
+        def second
+        Parent.Template.With(template) {
+            first = Parent.Create.One()
+            second = Parent.Create.One()
+        }
+
+        then:
+        template.child.value == 'template-child'
+        template.child.postCreateCalls == 0
+        TemplateManager.isTemplate(template)
+        TemplateManager.isTemplate(template.child)
+        mapTemplate.child.value == 'map-child'
+        TemplateManager.isTemplate(mapTemplate.child)
+
+        and: 'each application rehydrates a distinct ordinary Builder graph'
+        first.child.value == 'template-child'
+        first.child.postCreateCalls == 1
+        !TemplateManager.isTemplate(first)
+        !TemplateManager.isTemplate(first.child)
+        !first.child.is(template.child)
+        !second.child.is(template.child)
+        !second.child.is(first.child)
+    }
+
+    def "Template definition takes precedence over an active Construction session and restores it afterwards"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Registry {
+                Child child
+            }
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+
+                static Child fromString(String value) {
+                    Child.Create.With(value: value)
+                }
+            }
+        '''
+        def Registry = clazz
+        def Parent = getClass('pk.Parent')
+
+        when:
+        def template
+        def registry = Registry.Create.With {
+            template = Parent.Create.Template.With {
+                child 'template-child'
+            }
+            child 'session-child'
+        }
+
+        then:
+        TemplateManager.isTemplate(template)
+        TemplateManager.isTemplate(template.child)
+        registry.child.value == 'session-child'
+        !TemplateManager.isTemplate(registry)
+        !TemplateManager.isTemplate(registry.child)
+
+        when: 'the Template definition scope has exited'
+        getClass('pk.Child').Create.AsBuilder.One()
+
+        then:
+        thrown(KlumModelException)
+    }
+
+    def "Template file and URL sources retain converter composition as Template-owned children"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+
+                static Child fromString(String value) {
+                    Child.Create.With(value: value)
+                }
+            }
+        '''
+        def Parent = clazz
+        def templateFile = temporaryFolder.newFile('parent-template.groovy')
+        templateFile.text = "child 'source-child'"
+
+        when:
+        def fileTemplate = Parent.Create.Template.From(templateFile)
+        def urlTemplate = Parent.Create.Template.From(templateFile.toURI().toURL())
+
+        then:
+        [fileTemplate, urlTemplate].every {
+            it.child.value == 'source-child'
+                    && TemplateManager.isTemplate(it)
+                    && TemplateManager.isTemplate(it.child)
+        }
+    }
+
+    def "nested and failed Template definitions restore their composition scope"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+
+                static Child fromString(String value) {
+                    Child.Create.With(value: value)
+                }
+            }
+        '''
+        def Parent = clazz
+        def Child = getClass('pk.Child')
+
+        when:
+        def nested
+        def outer = Parent.Create.Template.With {
+            nested = Parent.Create.Template.With { child 'nested-child' }
+            child 'outer-child'
+        }
+
+        then:
+        TemplateManager.isTemplate(outer.child)
+        TemplateManager.isTemplate(nested.child)
+
+        when: 'scoped Template application is not Template-definition composition'
+        Parent.Template.With(outer) {
+            Child.Create.AsBuilder.One()
+        }
+
+        then:
+        thrown(KlumModelException)
+
+        when: 'an exceptional definition also cleans up its scope'
+        Parent.Create.Template.With {
+            child 'before-failure'
+            throw new IllegalStateException('expected failure')
+        }
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        Child.Create.AsBuilder.One()
+
+        then:
+        thrown(KlumModelException)
+    }
+}

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesDocumentaryTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/TemplatesDocumentaryTest.groovy
@@ -72,6 +72,43 @@ class TemplatesDocumentaryTest extends AbstractDSLSpec {
         !template.postCreateCalled
     }
 
+    @Issue("731")
+    @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#nested-builder-composition")
+    def "defines a Template through a fluent child converter"() {
+        given:
+        createClass '''
+            package pk
+
+            @DSL
+            class Parent {
+                Child child
+            }
+
+            @DSL
+            class Child {
+                String value
+
+                static Child fromString(String value) {
+                    Child.Create.With(value: value)
+                }
+            }
+        '''
+
+        when:
+        def template = clazz.Create.Template.With {
+            child 'template-child'
+        }
+        def registry
+        clazz.Template.With(template) {
+            registry = clazz.Create.One()
+        }
+
+        then:
+        template.child.value == 'template-child'
+        registry.child.value == 'template-child'
+        !registry.child.is(template.child)
+    }
+
     @Issue("710")
     @See("https://github.com/klum-dsl/klum-ast/blob/master/docs/user/Templates.md#creating-templates")
     def "creates a template from a DelegatingScript file"() {


### PR DESCRIPTION
## Summary

- Establish a stack-safe Template-definition composition scope that takes precedence over an active Construction session.
- Let generated Create.AsBuilder converter twins produce Template-mode children without lifecycle or session registration.
- Preserve nested Template identity through map, file/URL, and managed Jackson Template import paths.
- Document the behavior in ADR 0004, Templates guidance, CHANGES, and executable documentary coverage.

## Root cause

A generated Builder converter twin rewrote Create.With to Create.AsBuilder.With, but Template creation intentionally has no active Construction session. The runtime therefore rejected valid Template-owned composition.

## Validation

- Focused Groovy 3 regressions in TemplateBuilderConverterTest and KlumJacksonImporterSpec.
- ./gradlew :klum-ast:test :klum-ast-jackson:test
- ./gradlew groovy4Tests groovy5Tests
- ./gradlew check

Closes #731