### PR TITLE
Keep AsBuilder contract on declared defaulted model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,7 +52,9 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 - Replaced the active-session JavaBean accessor and Groovy-property spelling with the one explicit Java/Groovy operation
   `Foo.Create.AsBuilder()`. Update nested Builder creation, importer calls, and static consumers to call the operation;
   `getAsBuilder()` and `Create.AsBuilder` are intentionally not retained. The change corrects IntelliJ completion before
-  the 4.0 API freeze without changing construction-session or lifecycle behavior ([#729](https://github.com/klum-dsl/klum-ast/issues/729)).
+  the 4.0 API freeze without changing construction-session or lifecycle behavior. Its generated public factory contract
+  consistently names the declared model and Builder even when `@DSL(defaultImpl = ...)` selects the runtime implementation
+  ([#729](https://github.com/klum-dsl/klum-ast/issues/729)).
 - Public `Foo_DSL.Builder` contracts and their IDEA-only AnnoDocimal mirrors now explicitly expose supported generated
   relationship-creator overloads that omit the optional trailing configuration closure. This is an additive 4.0 API
   correction; existing lifecycle, relationship, Factory, and source-DSL behavior is unchanged ([#719](https://github.com/klum-dsl/klum-ast/issues/719)).

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1642,7 +1642,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
             factoryClass.addConstructor(ACC_PUBLIC, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, block());
 
         overrideFactoryMethods(factoryClass, defaultImpl);
-        createAsBuilderFactoryOperation(factoryClass, defaultImpl);
+        createAsBuilderFactoryOperation(factoryClass);
 
         annotatedClass.getModule().addClass(factoryClass);
 
@@ -1754,7 +1754,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         factoryClass.addMethod(override);
     }
 
-    private void createAsBuilderFactoryOperation(InnerClassNode factoryClass, ClassNode defaultImpl) {
+    private void createAsBuilderFactoryOperation(InnerClassNode factoryClass) {
         ClassNode factoryType;
         if (isAssignableTo(factoryClass, KEYED_FACTORY))
             factoryType = KEYED_BUILDER_FACTORY;
@@ -1766,7 +1766,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         ClassNode specialized = factoryType.getPlainNodeReference();
         specialized.setUsingGenerics(true);
         specialized.setGenericsTypes(new GenericsType[] {
-                new GenericsType(defaultImpl.getPlainNodeReference()),
+                new GenericsType(annotatedClass.getPlainNodeReference()),
                 new GenericsType(GeneratedDslSupport.of(annotatedClass).getBuilderInterface())
         });
 

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -558,6 +558,76 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         noExceptionThrown()
     }
 
+    @Issue('729')
+    def "AsBuilder() keeps a defaulted abstract keyed model's public contract coherent"() {
+        given: 'the declared abstract model selects an implementation at runtime'
+        createSecondaryClass('''
+            package defaulted
+
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Key
+
+            @DSL(defaultImpl = Impl)
+            abstract class Base {
+                @Key String name
+            }
+
+            @DSL
+            class Impl extends Base {
+            }
+
+            @DSL
+            class Concrete {
+                @Key String name
+            }
+
+            @DSL
+            abstract class AbstractKeyed {
+                @Key String name
+            }
+        ''', 'defaulted/DefaultedKeyedSchema.groovy')
+        Class<?> baseFactory = getClass('defaulted.Base_DSL$Factory')
+        Class<?> concreteFactory = getClass('defaulted.Concrete_DSL$Factory')
+        Class<?> abstractFactory = getClass('defaulted.AbstractKeyed_DSL$Factory')
+
+        when: 'the public source mirror is generated from the same bytecode contract'
+        File mirrorRoot = new File(tempFolder.root, 'defaulted-keyed-mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'defaulted/Base_DSL.class')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        File mirror = new File(mirrorRoot, 'defaulted/Base_DSL.java')
+
+        and: 'a Java client names the provider return advertised by the declared model'
+        compileJavaConsumer('''
+            package defaulted;
+
+            import com.blackbuild.klum.ast.runtime.KlumFactory.BuilderFactory;
+
+            public final class JavaDslConsumer {
+                public static BuilderFactory<Base, Base_DSL.Builder<Base>> factory() {
+                    return Base.Create.AsBuilder();
+                }
+            }
+        ''', 'defaulted/JavaDslConsumer.java')
+
+        then: 'the bytecode signature agrees with the provider contract and Java source mirror'
+        baseFactory.genericInterfaces*.typeName == [
+                'com.blackbuild.klum.ast.runtime.KlumFactory$BuilderFactoryProvider<defaulted.Base, defaulted.Base_DSL$Builder<defaulted.Base>>'
+        ]
+        baseFactory.getMethod('AsBuilder').genericReturnType.typeName ==
+                'com.blackbuild.klum.ast.runtime.KlumFactory$KeyedBuilderFactory<defaulted.Base, defaulted.Base_DSL$Builder<defaulted.Base>>'
+        mirror.text.contains('KeyedBuilderFactory<Base, Builder<Base>> AsBuilder()')
+        compileJavaSource(mirror)
+
+        and: 'defaultImpl still selects the runtime factory implementation'
+        getClass('defaulted.Base').getField('Create').get(null).modelType == getClass('defaulted.Impl')
+
+        and: 'valid keyed specialization and abstract-without-default behavior remain unchanged'
+        concreteFactory.getMethod('AsBuilder').genericReturnType.typeName ==
+                'com.blackbuild.klum.ast.runtime.KlumFactory$KeyedBuilderFactory<defaulted.Concrete, defaulted.Concrete_DSL$Builder<defaulted.Concrete>>'
+        abstractFactory.getMethod('AsBuilder').genericReturnType.typeName ==
+                'com.blackbuild.klum.ast.runtime.KlumFactory$BuilderFactory<defaulted.AbstractKeyed, defaulted.AbstractKeyed_DSL$Builder<defaulted.AbstractKeyed>>'
+    }
+
     @Issue('644')
     def "public Builder contracts expose typed same-model copy sources"() {
         given:
@@ -1162,10 +1232,14 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         }
     }
 
-    private void compileJavaConsumer(@Language('JAVA') String source) {
-        File sourceFile = new File(tempFolder.root, 'sample/JavaDslConsumer.java')
+    private void compileJavaConsumer(@Language('JAVA') String source, String filename = 'sample/JavaDslConsumer.java') {
+        File sourceFile = new File(tempFolder.root, filename)
         sourceFile.parentFile.mkdirs()
         sourceFile.text = source.stripIndent()
+        compileJavaSource(sourceFile)
+    }
+
+    private void compileJavaSource(File sourceFile) {
         String classpath = [System.getProperty('java.class.path'), compilerConfiguration.targetDirectory.absolutePath]
                 .join(File.pathSeparator)
         int result = ToolProvider.systemJavaCompiler.run(


### PR DESCRIPTION
## Summary

- Keep the public `Create.AsBuilder()` generic result aligned with the declared DSL model.
- Preserve `@DSL(defaultImpl = ...)` solely for runtime factory selection.
- Add compiler, bytecode, source-mirror `javac`, and Java-consumer coverage for abstract keyed models with a default implementation.

## Root cause

The generator previously used `defaultImpl` for the public `AsBuilder()` generic return while the generated `BuilderFactoryProvider` contract used the declared model. That produced incompatible generic signatures for an abstract keyed model.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.compiler.internal.ast.GeneratedDslSupportSpec --console=plain`
- `./gradlew check groovy4Tests groovy5Tests --console=plain --warning-mode=none --quiet`
- Local standards review: no findings.
- Local specification review: no findings.

Related: #729

This pull request leaves issue #729 open for CI/Sonar and Hive reconciliation.