### PR TITLE
Document generated DSL methods with AnnoDoc

### DIFF
--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1123,10 +1123,10 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                 .optional()
                 .mod(visibility)
                 .linkToField(fieldNode)
-                .returning(storedElementType)
+                .returning(storedElementType, "the added element")
                 .documentationTitle("Adds one " + storedElementDescription + COLLECTION_DOCUMENTATION_SUFFIX)
                 .constantParam(fieldName)
-                .param(storedElementType, "value")
+                .param(storedElementType, "value", "the element to add")
                 .addTo(builderClass);
 
         if (optionalLinkField) {
@@ -1188,34 +1188,40 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                     .optional()
                     .mod(visibility)
                     .linkToField(fieldNode)
+                    .documentationTitle("Adds one or more values to the Builder's '{{fieldName}}' map.")
                     .constantParam(methodName)
-                    .param(makeClassSafeWithGenerics(MAP_TYPE, new GenericsType(keyType), new GenericsType(valueType)), "values")
+                    .param(makeClassSafeWithGenerics(MAP_TYPE, new GenericsType(keyType), new GenericsType(valueType)), "values",
+                            "the map entries to add")
                     .addTo(builderClass);
         } else {
             createProxyMethod(methodName, "addElementsToMap")
                     .optional()
                     .mod(visibility)
                     .linkToField(fieldNode)
+                    .documentationTitle("Adds one or more values to the Builder's '{{fieldName}}' map.")
                     .constantParam(methodName)
-                    .param(makeClassSafeWithGenerics(CommonAstHelper.COLLECTION_TYPE, new GenericsType(valueType)), "values")
+                    .param(makeClassSafeWithGenerics(CommonAstHelper.COLLECTION_TYPE, new GenericsType(valueType)), "values",
+                            "the values to add")
                     .addTo(builderClass);
             createProxyMethod(methodName, "addElementsToMap")
                     .optional()
                     .mod(visibility)
                     .linkToField(fieldNode)
+                    .documentationTitle("Adds one or more values to the Builder's '{{fieldName}}' map.")
                     .constantParam(methodName)
-                    .arrayParam(valueType, "values")
+                    .arrayParam(valueType, "values", "the values to add")
                     .addTo(builderClass);
         }
 
         createProxyMethod(singleElementMethod, ADD_ELEMENT_TO_MAP)
                 .optional()
                 .mod(visibility)
-                .returning(valueType)
+                .returning(valueType, "the added value")
                 .linkToField(fieldNode)
+                .documentationTitle("Adds one value to the Builder's '{{fieldName}}' map.")
                 .constantParam(methodName)
-                .optionalParam(keyType, "key", keyMappingClosure == null)
-                .param(valueType, "value")
+                .optionalParam(keyType, "key", keyMappingClosure == null, "the map key for the value")
+                .param(valueType, "value", "the value to add")
                 .addTo(builderClass);
 
         createConverterMethods(fieldNode, singleElementMethod, true);
@@ -1329,12 +1335,13 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         createProxyMethod(methodName, ADD_ELEMENT_TO_MAP)
                 .optional()
                 .mod(visibility)
-                .returning(storedElementType)
+                .returning(storedElementType, "the added value")
                 .linkToField(fieldNode)
                 .documentationTitle("Adds one " + storedElementDescription + MAP_DOCUMENTATION_SUFFIX)
+                .withDocumentation(documentation -> documentation.param("key", "the map key for the value"))
                 .constantParam(fieldName)
                 .constantParam(null)
-                .param(storedElementType, elementToAddVarName)
+                .param(storedElementType, elementToAddVarName, "the value to add")
                 .addTo(builderClass);
 
         if (optionalLinkField) {
@@ -1395,7 +1402,12 @@ public class DSLASTTransformation extends AbstractASTTransformation {
                     .tag(GeneratedDslSupport.RELATIONSHIP_CREATOR_TAG)
                     .mod(visibility)
                     .linkToField(fieldNode)
-                    .returning(targetBuilderType)
+                    .returning(targetBuilderType, NEW_BUILDER_RETURN_DOCUMENTATION)
+                    .withDocumentation(doc -> doc
+                            .title("Creates a new '{{singleElementName}}' Builder to this Builder.")
+                            .p(NEW_BUILDER_CONFIGURATION_DOCUMENTATION)
+                            .param("values", OPTIONAL_PARAMETERS_DOCUMENTATION)
+                            .param(CLOSURE_PARAMETER, CONFIGURATION_CLOSURE_DOCUMENTATION))
                     .namedParams("values")
                     .constantParam(fieldName)
                     .constantClassParam(defaultImpl)
@@ -1600,19 +1612,25 @@ public class DSLASTTransformation extends AbstractASTTransformation {
     private void createApplyMethods() {
         createProxyMethod(APPLY_LATER, SCHEDULE_APPLY_LATER)
                 .mod(ACC_PUBLIC)
-                .delegatingClosureParam(builderClass, null, null)
+                .documentationTitle("Schedules a Builder configuration closure for the default apply-later phase.")
+                .documentationParagraph("The closure runs while this Builder is still active, before materialization and validation.")
+                .delegatingClosureParam(builderClass, null, "the Builder configuration to schedule")
                 .addTo(builderClass);
 
         createProxyMethod(APPLY_LATER, SCHEDULE_APPLY_LATER)
                 .mod(ACC_PUBLIC)
-                .param(Integer_TYPE, "phase")
-                .delegatingClosureParam(builderClass, null, null)
+                .documentationTitle("Schedules a Builder configuration closure for a numeric apply-later phase.")
+                .documentationParagraph("The closure runs while this Builder is still active, before materialization and validation.")
+                .param(Integer_TYPE, "phase", "the numeric phase at which to run the configuration")
+                .delegatingClosureParam(builderClass, null, "the Builder configuration to schedule")
                 .addTo(builderClass);
 
         createProxyMethod(APPLY_LATER, SCHEDULE_APPLY_LATER)
                 .mod(ACC_PUBLIC)
-                .param(make(DefaultKlumPhase.class), "phase")
-                .delegatingClosureParam(builderClass, null, null)
+                .documentationTitle("Schedules a Builder configuration closure for a named apply-later phase.")
+                .documentationParagraph("The closure runs while this Builder is still active, before materialization and validation.")
+                .param(make(DefaultKlumPhase.class), "phase", "the named phase at which to run the configuration")
+                .delegatingClosureParam(builderClass, null, "the Builder configuration to schedule")
                 .addTo(builderClass);
     }
 

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/DSLASTTransformation.java
@@ -1012,7 +1012,7 @@ public class DSLASTTransformation extends AbstractASTTransformation {
         createProxyMethod(elementName, ADD_ELEMENT_TO_COLLECTION)
                 .optional()
                 .mod(visibility)
-                .returning(elementType)
+                .returning(elementType, "the added value")
                 .linkToField(fieldNode)
                 .documentationTitle(DocUtil.getCollectionAdderText(fieldNode))
                 .constantParam(fieldName)

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupport.java
@@ -361,6 +361,7 @@ public final class GeneratedDslSupport {
         Parameter[] parameters = cloneParameters(implementationMethod.getParameters());
         MethodNode existing = publicInterface.getDeclaredMethod(implementationMethod.getName(), parameters);
         if (existing != null) {
+            copyProjectedDocumentation(implementationMethod, existing);
             implementationMethod.setNodeMetaData(API_METHOD_METADATA_KEY, existing);
             return;
         }
@@ -375,6 +376,7 @@ public final class GeneratedDslSupport {
         );
         apiMethod.setGenericsTypes(projectGenericsTypes(implementationMethod.getGenericsTypes()));
         copyAnnotationsFromSourceToTarget(implementationMethod, apiMethod, Collections.emptyList());
+        copyProjectedDocumentation(implementationMethod, apiMethod);
         publicInterface.addMethod(apiMethod);
         implementationMethod.setNodeMetaData(API_METHOD_METADATA_KEY, apiMethod);
         addProjectedRelationshipClosureOmission(publicInterface, apiMethod, hasGeneratedRelationshipCreatorTag(implementationMethod));
@@ -405,7 +407,16 @@ public final class GeneratedDslSupport {
         );
         apiMethod.setGenericsTypes(projectedMethod.getGenericsTypes());
         copyAnnotationsFromSourceToTarget(projectedMethod, apiMethod, Collections.emptyList());
+        copyProjectedDocumentation(projectedMethod, apiMethod);
         publicInterface.addMethod(apiMethod);
+    }
+
+    private static void copyProjectedDocumentation(MethodNode source, MethodNode target) {
+        AstDocumentation.extractExact(source).ifPresent(documentation -> {
+            KlumDocumentation projected = new KlumDocumentation().replace(documentation);
+            projected.filterParameters(Arrays.stream(target.getParameters()).map(Parameter::getName).toList());
+            AstDocumentation.attach(target, projected.rendered());
+        });
     }
 
     private static void projectMethodSignature(MethodNode method) {

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/ProxyMethodBuilder.java
@@ -259,8 +259,9 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
                 if (!deprecatedAnnotations.isEmpty())
                     method.addAnnotation(deprecatedAnnotations.get(0));
             }
+            if (documentation.isEmpty())
+                copyDocWithReMappingFrom(targetMethod);
             addParameterJavaDocs(documentation);
-            copyDocWithReMappingFrom(targetMethod);
             AstDocumentation.attach(method, documentation.rendered());
         } else {
             AstDocumentation.attach(method, addParameterJavaDocs(documentation.copy()).rendered());
@@ -390,7 +391,7 @@ public final class ProxyMethodBuilder extends AbstractMethodBuilder<ProxyMethodB
      * @param doAdd If this parameter is null, the method does nothing
      */
     public ProxyMethodBuilder optionalStringParam(String name, boolean doAdd) {
-        return optionalStringParam(name, doAdd, null);
+        return optionalStringParam(name, doAdd, "the key for the new element");
     }
 
     /**

--- a/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
+++ b/klum-ast/src/main/java/com/blackbuild/klum/ast/compiler/internal/ast/TemplateMethods.java
@@ -197,6 +197,7 @@ class TemplateMethods {
         MethodNode publicMethod = correctToGenericsSpec(Collections.singletonMap("T", bridgeModelType), bridgeMethod);
         publicMethod.setModifiers(ACC_PUBLIC | ACC_ABSTRACT);
         publicMethod.setCode(EmptyStatement.INSTANCE);
+        documentScopedTemplateMethod(publicMethod, name);
         if (name.startsWith("Create"))
             markAsDeprecatedTemplateCreationAlias(publicMethod, name);
         for (int index = 0; index < parameters.length; index++)
@@ -236,6 +237,7 @@ class TemplateMethods {
         MethodNode publicMethod = correctToGenericsSpec(Collections.singletonMap("T", annotatedClass), bridgeMethod);
         publicMethod.setModifiers(ACC_PUBLIC | ACC_ABSTRACT);
         publicMethod.setCode(EmptyStatement.INSTANCE);
+        documentTemplateFactoryMethod(publicMethod, name);
         for (int index = 0; index < parameters.length; index++)
             copyAnnotationsFromSourceToTarget(parameters[index], publicMethod.getParameters()[index], Collections.emptyList());
         GeneratedDslSupport.of(annotatedClass).getTemplateFactoryInterface().addMethod(publicMethod);
@@ -248,6 +250,51 @@ class TemplateMethods {
         bridgeCall.setMethodTarget(bridgeMethod);
         adapterMethod.setCode(returnS(bridgeCall));
         templateFactoryAdapter.addMethod(adapterMethod);
+    }
+
+    private void documentScopedTemplateMethod(MethodNode method, String name) {
+        if (name.startsWith("Create")) return;
+
+        KlumDocumentation documentation = new KlumDocumentation()
+                .title("Applies Template recipes while executing a scoped configuration body.")
+                .p("The previous Template scope is restored after the body completes.")
+                .returnType("the value returned by the scoped body");
+        if (name.equals("With")) {
+            boolean mapRecipe = CommonAstHelper.isMap(method.getParameters()[0].getType());
+            documentation.param(method.getParameters()[0].getName(), mapRecipe
+                    ? "the inline Template values to apply for this scope"
+                    : "the Template recipe to apply for this scope");
+        } else {
+            boolean mapRecipes = CommonAstHelper.isMap(method.getParameters()[0].getType());
+            documentation.param(method.getParameters()[0].getName(), mapRecipes
+                    ? "the Template values grouped by model type"
+                    : "the Template recipes to apply in order");
+        }
+        documentation.param("body", "the configuration body that runs with the Template scope");
+        AstDocumentation.attach(method, documentation.rendered());
+    }
+
+    private void documentTemplateFactoryMethod(MethodNode method, String name) {
+        KlumDocumentation documentation = new KlumDocumentation()
+                .returnType("the created marked Template model");
+        if (name.equals("With")) {
+            documentation.title("Creates a reusable Template model from optional values and configuration.");
+            for (Parameter parameter : method.getParameters()) {
+                if (parameter.getName().equals("configMap"))
+                    documentation.param(parameter.getName(), "the property values for the Template");
+                else if (parameter.getName().equals("configuration"))
+                    documentation.param(parameter.getName(), "the Builder configuration for the Template");
+            }
+        } else {
+            documentation.title("Creates a reusable Template model from a script source.");
+            for (Parameter parameter : method.getParameters()) {
+                if (parameter.getName().equals("loader"))
+                    documentation.param(parameter.getName(), "the class loader used to evaluate the source");
+                else
+                    documentation.param(parameter.getName(), "the script source that defines the Template");
+            }
+        }
+        AstDocumentation.attach(method, documentation.rendered());
     }
 
     private static boolean hasSameBridgeArguments(MethodNode candidate, Parameter[] arguments) {

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -807,13 +807,17 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         dynamicWithoutClosure.returnType == dynamicWithClosure.returnType
         factoryWithoutClosure.genericReturnType.typeName == 'B'
         factoryWithoutClosure.typeParameters*.bounds*.typeName == factoryWithClosure.typeParameters*.bounds*.typeName
-        factoryWithoutClosure.getAnnotation(AnnoDoc).value() == factoryWithClosure.getAnnotation(AnnoDoc).value()
+        factoryWithoutClosure.getAnnotation(AnnoDoc).value().contains('@param factory')
+        !factoryWithoutClosure.getAnnotation(AnnoDoc).value().contains('@param closure')
+        factoryWithClosure.getAnnotation(AnnoDoc).value().contains('@param closure')
         factoryWithoutClosure.parameters[1].isAnnotationPresent(DelegatesTo.Target)
         Modifier.isPublic(factoryWithoutClosure.modifiers)
         !factoryWithoutClosure.isAnnotationPresent(Deprecated)
         deprecatedWithoutClosure.isAnnotationPresent(Deprecated)
         deprecatedWithClosure.isAnnotationPresent(Deprecated)
-        deprecatedWithoutClosure.getAnnotation(AnnoDoc).value() == deprecatedWithClosure.getAnnotation(AnnoDoc).value()
+        deprecatedWithoutClosure.getAnnotation(AnnoDoc).value().contains('@deprecated')
+        !deprecatedWithoutClosure.getAnnotation(AnnoDoc).value().contains('@param closure')
+        deprecatedWithClosure.getAnnotation(AnnoDoc).value().contains('@param closure')
         keyedNoClosureMethods.any { it.parameterTypes.contains(String) }
         keyedNoClosureMethods.any { it.parameterTypes.contains(Class) }
         keyedNoClosureMethods.any { it.parameterTypes.contains(BuilderFactoryProvider) && it.genericReturnType.typeName == 'B' }
@@ -912,6 +916,79 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         mirror.contains('The generated DSL support namespace for sample.Foo.')
         mirror.contains('Creates a new')
         getClass('sample.Foo_DSL$Builder').getAnnotation(AnnoDoc).value().contains('public Builder contract')
+    }
+
+    @Issue('736')
+    def "generated public methods and their source mirror retain meaningful AnnoDoc"() {
+        given: 'a neutral product schema exercises direct and simple collection operations'
+        createSecondaryClass('''
+            package documentation
+
+            import com.blackbuild.klum.ast.DSL
+            import com.blackbuild.klum.ast.Key
+
+            @DSL class Product {
+                Child primaryChild
+                List<Child> children
+                Map<String, Child> childrenByName
+                Map<String, String> metadata
+            }
+
+            @DSL class Child {
+                @Key String name
+            }
+        ''', 'documentation/Product.groovy')
+        Class<?> product = getClass('documentation.Product')
+        Class<?> builder = getClass('documentation.Product_DSL$Builder')
+        Class<?> factoryTemplate = getClass('documentation.Product_DSL$Factory$Template')
+        Class<?> scopedTemplate = getClass('documentation.Product_DSL$Template')
+
+        when: 'representative bytecode contract methods are inspected'
+        List<Method> directRelationshipCreators = [
+                builder.getMethod('primaryChild', Map, String, Closure),
+                builder.getMethod('primaryChild', Map, String),
+                builder.getMethod('children', Map, String, Closure),
+                builder.getMethod('children', Map, String),
+                builder.getMethod('childrenByName', Map, String, Closure),
+                builder.getMethod('childrenByName', Map, String)
+        ]
+        List<Method> templateCreation = [
+                factoryTemplate.getMethod('With', Map, Closure),
+                factoryTemplate.getMethod('From', File, ClassLoader)
+        ]
+        List<Method> scopedApplication = [
+                scopedTemplate.getMethod('With', product, Closure),
+                scopedTemplate.getMethod('WithAll', Map, Closure),
+                scopedTemplate.getMethod('WithAll', List, Closure)
+        ]
+        List<Method> applyLater = builder.declaredMethods.findAll { it.name == 'applyLater' }
+        List<Method> simpleMapAdders = [
+                builder.getMethod('metadata', Map),
+                builder.getMethod('metadata', String, String)
+        ]
+        List<Method> documentedMethods = directRelationshipCreators + templateCreation + scopedApplication + applyLater + simpleMapAdders
+
+        then: 'every supported generated public method carries an informative contract with parameter documentation'
+        List<Method> insufficientDocumentation = documentedMethods.findAll { Method method ->
+            AnnoDoc documentation = method.getAnnotation(AnnoDoc)
+            documentation == null || !documentation.value().contains('@param') || documentation.value().size() <= 80
+        }
+        assert insufficientDocumentation.empty
+        directRelationshipCreators.every { it.getAnnotation(AnnoDoc).value().contains('Creates a new') }
+        templateCreation.every { it.getAnnotation(AnnoDoc).value().contains('Template') }
+        scopedApplication.every { it.getAnnotation(AnnoDoc).value().contains('Template') }
+        applyLater.size() == 3
+        applyLater.every { it.getAnnotation(AnnoDoc).value().contains('Schedules') }
+        applyLater.find { it.parameterCount == 2 }.getAnnotation(AnnoDoc).value().contains('@param phase')
+        simpleMapAdders.every { it.getAnnotation(AnnoDoc).value().contains('Adds') }
+
+        and: 'AnnoDocimal exposes the same public documentation in the IDE-only source mirror'
+        File mirrorRoot = new File(tempFolder.root, 'issue-736-mirrors')
+        File namespaceClass = new File(compilerConfiguration.targetDirectory, 'documentation/Product_DSL.class')
+        new SourceProjector(ProjectionPolicy.documentation()).projectToDirectory(namespaceClass.toPath(), mirrorRoot.toPath())
+        String mirror = new File(mirrorRoot, 'documentation/Product_DSL.java').text
+
+        documentedMethods.collect { it.getAnnotation(AnnoDoc).value().split('\\n\\n').first() }.toSet().every { mirror.contains(it) }
     }
 
     @Issue('702')

--- a/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/klum/ast/compiler/internal/ast/GeneratedDslSupportSpec.groovy
@@ -931,6 +931,7 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
                 Child primaryChild
                 List<Child> children
                 Map<String, Child> childrenByName
+                List<String> labels
                 Map<String, String> metadata
             }
 
@@ -966,10 +967,13 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
                 builder.getMethod('metadata', Map),
                 builder.getMethod('metadata', String, String)
         ]
-        List<Method> documentedMethods = directRelationshipCreators + templateCreation + scopedApplication + applyLater + simpleMapAdders
+        List<Method> simpleCollectionAdders = [
+                builder.getMethod('label', String)
+        ]
+        List<Method> documentedMethods = directRelationshipCreators + templateCreation + scopedApplication + applyLater + simpleCollectionAdders + simpleMapAdders
 
         then: 'every supported generated public method carries an informative contract with parameter documentation'
-        List<Method> insufficientDocumentation = documentedMethods.findAll { Method method ->
+        List<Method> insufficientDocumentation = (documentedMethods - simpleCollectionAdders).findAll { Method method ->
             AnnoDoc documentation = method.getAnnotation(AnnoDoc)
             documentation == null || !documentation.value().contains('@param') || documentation.value().size() <= 80
         }
@@ -980,6 +984,9 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         applyLater.size() == 3
         applyLater.every { it.getAnnotation(AnnoDoc).value().contains('Schedules') }
         applyLater.find { it.parameterCount == 2 }.getAnnotation(AnnoDoc).value().contains('@param phase')
+        simpleCollectionAdders.every { it.getAnnotation(AnnoDoc).value().with {
+            contains('Adds') && contains('@param value') && contains('@return the added value')
+        } }
         simpleMapAdders.every { it.getAnnotation(AnnoDoc).value().contains('Adds') }
 
         and: 'AnnoDocimal exposes the same public documentation in the IDE-only source mirror'
@@ -989,6 +996,8 @@ class GeneratedDslSupportSpec extends AbstractDSLSpec {
         String mirror = new File(mirrorRoot, 'documentation/Product_DSL.java').text
 
         documentedMethods.collect { it.getAnnotation(AnnoDoc).value().split('\\n\\n').first() }.toSet().every { mirror.contains(it) }
+        mirror.contains('@param value The value to add')
+        mirror.contains('@return the added value')
     }
 
     @Issue('702')


### PR DESCRIPTION
## What changed

Documents the generated public `Foo_DSL` contract consistently and carries that AnnoDoc into the IDE source mirror.

- Covers direct relationship creators and supported shorter overloads.
- Documents Factory.Template creation, scoped Template application, Builder.applyLater, and simple collection/Map adders.
- Adds a public-contract regression test for meaningful bytecode AnnoDoc and projected source-mirror documentation.

## Why

Generated public methods previously lost or omitted meaningful documentation even though their implementation counterparts had it. This makes the public generated API and its IDE projection incomplete.

## Impact

No runtime behavior or generated signatures change. #720 raw-PSI GDSL field documentation remains out of scope.

## Validation

- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.compiler.internal.ast.GeneratedDslSupportSpec --console=plain --no-daemon`
- `./gradlew :klum-ast:groovy4Tests --console=plain --no-daemon`
- `./gradlew :klum-ast:groovy5Tests --console=plain --no-daemon`
- `./gradlew check --console=plain --no-daemon`
- `git diff --check origin/master...HEAD`

Closes #736
