### PR TITLE
Promote AnnoDocimal and KlumCast final coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,15 +14,19 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Dependency compatibility
 
-- Migrated to released [AnnoDocimal 1.0.0-rc.8](https://github.com/blackbuild/anno-docimal/releases/tag/v1.0.0-rc.8)
-  (`a01ef0a7a507a5800401886b63e9106f351997cd`). KlumAST now uses its supported documentation-authoring and source-projection
+- Promoted to final [AnnoDocimal 1.0.0](https://github.com/blackbuild/anno-docimal/releases/tag/v1.0.0), released from
+  [`2780ab1b4e919d40ec19476eac1e3288378fda0b`](https://github.com/blackbuild/anno-docimal/commit/2780ab1b4e919d40ec19476eac1e3288378fda0b).
+  KlumAST uses its supported documentation-authoring and source-projection
   APIs. The schema plugin retains its IDEA-only mirror policy while using the configuration-cache-safe projection task;
   property documentation is projected verbatim to generated Model and Builder accessors unless an accessor supplies its
   own documentation ([#461](https://github.com/klum-dsl/klum-ast/issues/461)). Source-mirror projection now resolves
   public generated-interface references from the Schema compile classpath without making mirrors compilation inputs
-  ([#700](https://github.com/klum-dsl/klum-ast/issues/700)). Final AnnoDocimal 1.0 remains a KlumAST
-  final-release prerequisite; this change validates the immutable RC train only.
-- Upgraded to the immutable [KlumCast 0.4.0-rc.2](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0-rc.2) artifact set: `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas and custom checks for 4.0.
+  ([#700](https://github.com/klum-dsl/klum-ast/issues/700), [#523](https://github.com/klum-dsl/klum-ast/issues/523)).
+- Promoted to final [KlumCast 0.4.0](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0), released from
+  [`770b1ad2d6b4c109b4e5131b294fa2dafdef09b4`](https://github.com/klum-dsl/klum-cast/commit/770b1ad2d6b4c109b4e5131b294fa2dafdef09b4):
+  `klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. The artifacts have stable automatic module names
+  (`com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`) and no split KlumCast packages. Recompile schemas
+  and custom checks for 4.0 ([#524](https://github.com/klum-dsl/klum-ast/issues/524)).
 - Migrated KlumAST's eight name-bound compiler checks to KlumCast's stateless `Check` SPI. Their expected violations now emit source-positioned structured diagnostics; diagnostic codes are the check implementation names, while unexpected failures remain technical errors with their causes. Invalid `@Overwrite.Single(MERGE)` strategies on non-DSL fields are rejected during compilation ([#460](https://github.com/klum-dsl/klum-ast/issues/460)).
 
 ## Java modules

--- a/docs/implementation/evidence/issue-391-jp-close-acceptance-audit.md
+++ b/docs/implementation/evidence/issue-391-jp-close-acceptance-audit.md
@@ -14,10 +14,11 @@ or named-schema fixture boundaries.
   its executable sequence is the [ADR 0014 plan](../adr-0014-groovy4-jpms-boundary.md).
 - The upstream consumer-adoption gates are closed: [#459](https://github.com/klum-dsl/klum-ast/issues/459)
   (2026-07-20) and [#461](https://github.com/klum-dsl/klum-ast/issues/461)
-  (2026-07-27). Their immutable RC coordinates are present in
-  `settings.gradle`. Final-coordinate release promotion remains separately
-  owned by [#524](https://github.com/klum-dsl/klum-ast/issues/524), not by this
-  audit or a reopened #391.
+  (2026-07-27). Their historical RC coordinates established this audit's
+  baseline. The separately owned final-coordinate promotion is now complete in
+  [#523](https://github.com/klum-dsl/klum-ast/issues/523) and
+  [#524](https://github.com/klum-dsl/klum-ast/issues/524), which pin final
+  AnnoDocimal 1.0.0 and KlumCast 0.4.0 without reopening #391.
 - PR #608 merged `8d1b8414`, `21369682`, and `ced0c195` on 2026-07-29. Its
   build, JUnit report, SonarCloud, and SonarCloud analysis checks succeeded.
   The audit additionally reran its acceptance test locally rather than treating
@@ -32,7 +33,7 @@ or named-schema fixture boundaries.
 | Criterion | Current-master evidence | Status | Owner | Exact next action |
 | --- | --- | --- | --- | --- |
 | Accepted module/package decision and implementation sequence | ADR 0014, its plan, and `issue-391-jp2c-package-migration.md` record the five fixed artifacts, Groovy 4/5 named boundary, classpath Groovy 3 boundary, and complete old-to-new map. | met | #391 | Retain as closure evidence. |
-| #459/#461 dependency inputs are synchronized without local substitutions | Closed live issues; `settings.gradle` pins KlumCast `0.4.0-rc.2` and AnnoDocimal `1.0.0-rc.7`; PR #608 fixture resolves their module identities. Final coordinates are #523/#524 scope. | met | #459/#461; #523/#524 for release promotion | Do not reopen the closed adoption gates; consume the final-coordinate work when its owners deliver it. |
+| #459/#461 dependency inputs are synchronized without local substitutions | Closed live issues established the historical RC proof; `settings.gradle` now pins final [KlumCast 0.4.0](https://github.com/klum-dsl/klum-cast/commit/770b1ad2d6b4c109b4e5131b294fa2dafdef09b4) and [AnnoDocimal 1.0.0](https://github.com/blackbuild/anno-docimal/commit/2780ab1b4e919d40ec19476eac1e3288378fda0b) through #523/#524. PR #608 fixture resolves their module identities. | met | #459/#461; #523/#524 completed promotion | Retain the historical adoption gates; hand the final-coordinate source revision to #525 without reopening #391. |
 | Five explicit canonical descriptors and package ownership | The five `src/main/module-info/module-info.java` files define the ADR names. `JpmsPackageBoundaryTest` inspects their built JAR descriptors, singleton package ownership, no legacy package in the artifacts, exact exports, qualified compiler opens, and service declarations. | met | #391 | Retain the descriptor test; no descriptor redesign. |
 | Generated-schema ABI and named-module linkage | JP-ABI records plus `JpmsPackageBoundaryTest` scan generated named-schema class files for runtime-internal references and prove generated factory/template and protected lifecycle shapes. | met | #391 | Do not reopen ABI bridge work without a new failing descriptor or fixture. |
 | Real Groovy 4/5 named schema and Groovy 3 classpath boundary | On this baseline, all three focused commands passed: `:klum-ast:test`, `:klum-ast:groovy4Tests`, and `:klum-ast:groovy5Tests`, each filtered to `com.blackbuild.klum.ast.JpmsPackageBoundaryTest`. The test compiles a user-owned schema descriptor, runs Java and `@CompileStatic` Groovy consumers, exercises lifecycle, services, Jackson, Bean Validation, and rejects portability flags. | met | #391 | Retain the three-lane test evidence as the JP-1b closure proof. |

--- a/docs/user/Migration.md
+++ b/docs/user/Migration.md
@@ -96,9 +96,10 @@ methods, lifecycle closures, and validation classes, replace their shortcuts wit
 object. It retains that object's construction path and does not alter lifecycle ordering. The separate #406 compiler
 restriction remains a later placement check; it is not a migration fallback.
 
-## KlumCast 0.4 RC dependencies
+## KlumCast 0.4 final dependencies
 
-KlumAST 4.0 uses the immutable KlumCast `0.4.0-rc.2` artifact set: `klum-cast-annotations`, `klum-cast-spi`, and
+KlumAST 4.0 uses the immutable [KlumCast `0.4.0` artifact set](https://github.com/klum-dsl/klum-cast/releases/tag/v0.4.0):
+`klum-cast-annotations`, `klum-cast-spi`, and
 `klum-cast-compile`. Its stable automatic module names are `com.blackbuild.klum.cast.annotations`,
 `com.blackbuild.klum.cast.spi`, and `com.blackbuild.klum.cast.compiler`; do not substitute filename-derived names or use
 local module-path flags to compensate for an invalid dependency graph.

--- a/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
+++ b/klum-ast-jackson/src/test/groovy/com/blackbuild/klum/ast/jackson/JacksonImporterConsumerTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.TempDir
 
-@Issue("463")
+@Issue(["463", "523"])
 class JacksonImporterConsumerTest extends Specification {
 
     @TempDir
@@ -122,7 +122,7 @@ class JacksonImporterConsumerTest extends Specification {
                         System.getProperty('klumAnnotationsJar'),
                         System.getProperty('klumRuntimeJar'),
                         System.getProperty('klumJacksonJar'))
-                implementation 'com.blackbuild.annodocimal:anno-docimal-ast:1.0.0-rc.7'
+                implementation 'com.blackbuild.annodocimal:anno-docimal-ast:1.0.0'
                 implementation 'org.codehaus.groovy:groovy:3.0.25'
                 implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
             }

--- a/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastFinalIntegrationTest.groovy
+++ b/klum-ast/src/test/groovy/com/blackbuild/groovy/configdsl/transform/KlumCastFinalIntegrationTest.groovy
@@ -32,16 +32,16 @@ import java.lang.module.ModuleFinder
 import java.nio.file.Path
 import java.util.jar.JarFile
 
-@Issue("459")
-class KlumCastRcIntegrationTest extends Specification {
+@Issue(["459", "524"])
+class KlumCastFinalIntegrationTest extends Specification {
 
-    private static final String RC_VERSION = "0.4.0-rc.2"
+    private static final String FINAL_VERSION = "0.4.0"
     private static final String AST_TRANSFORMATION_SERVICE = "META-INF/services/org.codehaus.groovy.transform.ASTTransformation"
 
-    def "uses the published KlumCast RC artifacts with their stable module names"() {
+    def "uses the published final KlumCast artifacts with their stable module names"() {
         expect:
         moduleName(jar) == expectedModuleName
-        moduleVersion(jar) == RC_VERSION
+        moduleVersion(jar) == FINAL_VERSION
 
         where:
         jar                       | expectedModuleName
@@ -50,7 +50,7 @@ class KlumCastRcIntegrationTest extends Specification {
         compilerJar()             | "com.blackbuild.klum.cast.compiler"
     }
 
-    def "KlumCast RC artifacts have exclusive package ownership"() {
+    def "final KlumCast artifacts have exclusive package ownership"() {
         given:
         def packageSets = [jarOf(KlumCastValidated), jarOf(KlumCastCheck), compilerJar()]
                 .collect { packagesIn(it) }
@@ -66,7 +66,7 @@ class KlumCastRcIntegrationTest extends Specification {
     }
 
     private static Path compilerJar() {
-        def service = KlumCastRcIntegrationTest.classLoader.getResources(AST_TRANSFORMATION_SERVICE)
+        def service = KlumCastFinalIntegrationTest.classLoader.getResources(AST_TRANSFORMATION_SERVICE)
                 .toList()
                 .find { it.toExternalForm().contains("klum-cast-compile") }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
 
             library("jb-anno", "org.jetbrains:annotations:16.0.2")
 
-            version("klum-cast", "0.4.0-rc.2")
+            version("klum-cast", "0.4.0")
             library("klum-cast-compile", "com.blackbuild.klum.cast", "klum-cast-compile").versionRef("klum-cast")
             library("klum-cast-annotations", "com.blackbuild.klum.cast", "klum-cast-annotations").versionRef("klum-cast")
             library("klum-cast-spi", "com.blackbuild.klum.cast", "klum-cast-spi").versionRef("klum-cast")
@@ -63,7 +63,7 @@ dependencyResolutionManagement {
 
             bundle "spockRuntime", ["bytebuddy", "objenesis"]
 
-            version("annodocimal", "1.0.0-rc.8")
+            version("annodocimal", "1.0.0")
             library("annodocimal-annotations", "com.blackbuild.annodocimal", "anno-docimal-annotations").versionRef("annodocimal")
             library("annodocimal-global-ast", "com.blackbuild.annodocimal", "anno-docimal-global-ast").versionRef("annodocimal")
             library("annodocimal-gradle-plugin", "com.blackbuild.annodocimal", "anno-docimal-gradle-plugin").versionRef("annodocimal")


### PR DESCRIPTION
## Summary

Promotes the validated upstream RC coordinates to AnnoDocimal 1.0.0 and KlumCast 0.4.0. The existing KlumCast artifact-role/module/package contract now asserts final artifacts; the external Jackson consumer resolves final AnnoDocimal. Release-facing documentation and the historical JPMS evidence record the authoritative release commits.

Closes #523
Closes #524

## Validation

- `./gradlew check --console=plain --warning-mode=none` (Groovy 3/4/5 lanes and lane isolation)
- `./gradlew :klum-ast:test --tests com.blackbuild.klum.ast.KlumCastFinalIntegrationTest --console=plain --warning-mode=none`
- `./gradlew :klum-ast-gradle-plugin:test --tests com.blackbuild.klum.ast.gradle.KlumDslSourceMirrorsIntegrationTest --console=plain --warning-mode=none`
- `./gradlew :klum-ast-jackson:test --tests com.blackbuild.klum.ast.jackson.JacksonImporterConsumerTest verifyVersionedDocumentationRenderer --console=plain --warning-mode=none`
- Dependency-insight confirmation for AnnoDocimal 1.0.0 and KlumCast 0.4.0 artifact roles
- `git diff --check origin/master...HEAD`

## Follow-up

#525 remains the external final-coordinate KlumAST RC validation gate; this PR does not publish or validate a KlumAST RC.