### PR TITLE
Document canonical schema annotation imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Documentation infrastructure
 
+- Made the initial Schema onboarding examples directly copyable by showing the canonical `com.blackbuild.klum.ast`
+  imports for `@DSL`, `@Key`, and `@Validate` ([#742](https://github.com/klum-dsl/klum-ast/issues/742)).
 - Corrected 4.0 Fundamentals terminology for validation, lifecycle examples, Builder-first ownership timing, rooted composition, Owner backlinks, and `LINK` side connections. Gradle Onboarding now documents optional local source-mirror automation while retaining explicit portable refresh tasks. Exact versioned documentation now exposes the Changelog and a square Season 4 favicon ([#724](https://github.com/klum-dsl/klum-ast/issues/724)).
 - Current 4.x user documentation is authored in `docs/user/` and rendered locally from an explicit Git revision into an immutable exact-version static HTML tree. The renderer captures a deterministic site manifest and versioned Season/logo input, while the former mutable wiki publisher fails closed ([#456](https://github.com/klum-dsl/klum-ast/issues/456)).
 - Exact 4.x documentation renders six isolated module-Javadoc trees below `/&lt;version&gt;/api/` for `klum-ast`, runtime, annotations, Jackson, Bean Validation, and the Gradle plugin. The BOM and IDE-only source mirrors are not public API inputs ([#456](https://github.com/klum-dsl/klum-ast/issues/456)).

--- a/agent-skills/fixtures/minimal-gradle-project/src/main/groovy/onboarding/Deployment.groovy
+++ b/agent-skills/fixtures/minimal-gradle-project/src/main/groovy/onboarding/Deployment.groovy
@@ -1,8 +1,8 @@
 package onboarding
 
-import com.blackbuild.groovy.configdsl.transform.DSL
-import com.blackbuild.groovy.configdsl.transform.Key
-import com.blackbuild.groovy.configdsl.transform.Validate
+import com.blackbuild.klum.ast.DSL
+import com.blackbuild.klum.ast.Key
+import com.blackbuild.klum.ast.Validate
 
 @DSL
 class Deployment {

--- a/docs/user/Basics.md
+++ b/docs/user/Basics.md
@@ -15,6 +15,15 @@ DSL is used to designate a DSL/Model object, which is enriched using the AST tra
 
 The DSL annotation leads to the creation of a couple of useful methods.
 
+Start a Schema source file with the canonical KlumAST annotation imports. These imports apply to ordinary Schema
+annotations regardless of whether the project later adopts a separate Domain API.
+
+```groovy
+import com.blackbuild.klum.ast.DSL
+import com.blackbuild.klum.ast.Key
+import com.blackbuild.klum.ast.Validate
+```
+
 ## Factory construction
 
 Each instantiable DSL class gets a static field `Create` of either a subclass of `KlumFactory.Keyed` or
@@ -23,6 +32,10 @@ implementation of `KlumFactory` instead.
 
 ```groovy
 given: // Schema
+import com.blackbuild.klum.ast.DSL
+import com.blackbuild.klum.ast.Key
+import com.blackbuild.klum.ast.Validate
+
 @DSL
 class Config {
 }

--- a/docs/user/Gradle-Onboarding.md
+++ b/docs/user/Gradle-Onboarding.md
@@ -52,7 +52,7 @@ import com.blackbuild.klum.ast.Validate
 @DSL
 class Deployment {
     @Key String name
-    @Validate String environment
+    @Validate({ it in ['development', 'production', 'test'] }) String environment
     Service service
 }
 

--- a/docs/user/Gradle-Onboarding.md
+++ b/docs/user/Gradle-Onboarding.md
@@ -45,10 +45,14 @@ flags for it.
 Place Schema classes in `src/main/groovy`, add one root `@DSL` type, and write a test in `src/test/groovy` that constructs a completed model through `Create.With`. Run `./gradlew test` before expanding the model. Use the model plugin only when a separate configured-model artifact is needed; see [Gradle Plugins](Gradle-Plugins.md).
 
 ```groovy
+import com.blackbuild.klum.ast.DSL
+import com.blackbuild.klum.ast.Key
+import com.blackbuild.klum.ast.Validate
+
 @DSL
 class Deployment {
     @Key String name
-    String environment
+    @Validate String environment
     Service service
 }
 


### PR DESCRIPTION
## Summary

- Show the canonical `com.blackbuild.klum.ast` imports for `@DSL`, `@Key`, and `@Validate` in the initial Basics and Gradle onboarding examples.
- Make the Gradle example exercise `@Validate` and align the executable minimal onboarding fixture with the same canonical imports.
- Record the 4.0 onboarding correction in `CHANGES.md`.

## Validation

- `./gradlew -p agent-skills/fixtures/minimal-gradle-project test --console=plain --warning-mode=none`
- Isolated public-plugin fixture using `com.blackbuild.klum-ast-schema` `4.0.0-rc.20`: `test`
- `./gradlew renderLocalDocumentation --console=plain --warning-mode=none`
- `git diff --check origin/master...HEAD`

## Tracker

Closes #742

#546 remains related adopter evidence and is not changed.