### PR TITLE
Clarify validation form selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This is a breaking release. See the [Builder-first construction migration](docs/
 
 ## Documentation infrastructure
 
+- Clarified when to choose `@Required`, a field `@Validate` closure, or an `@Validate` method for a validation rule.
 - Made the initial Schema onboarding examples directly copyable by showing the canonical `com.blackbuild.klum.ast`
   imports for `@DSL`, `@Key`, and `@Validate` ([#742](https://github.com/klum-dsl/klum-ast/issues/742)).
 - Corrected 4.0 Fundamentals terminology for validation, lifecycle examples, Builder-first ownership timing, rooted composition, Owner backlinks, and `LINK` side connections. Gradle Onboarding now documents optional local source-mirror automation while retaining explicit portable refresh tasks. Exact versioned documentation now exposes the Changelog and a square Season 4 favicon ([#724](https://github.com/klum-dsl/klum-ast/issues/724)).

--- a/docs/user/Validation.md
+++ b/docs/user/Validation.md
@@ -35,6 +35,34 @@ The `@Validate` annotation controls validation of a single field. If the annotat
  * A closure that takes a single argument, the value of the field. This closure must either be a single expression that
    is evaluated against Groovy Truth or else an `assert` statement itself.
 
+### Choose a validation form
+
+Use `@Required` for a presence or Groovy-truth rule. For a single-field constraint that is one expression, use a field
+`@Validate({ ... })` closure. Use an `@Validate` method when a rule relates fields, is reused, or has several steps; a
+method remains the right form for those rules even when it happens to be short.
+
+```groovy
+import com.blackbuild.klum.ast.DSL
+import com.blackbuild.klum.ast.Required
+import com.blackbuild.klum.ast.Validate
+
+@DSL
+class Deployment {
+    @Required
+    String image
+
+    @Validate({ it in 1..20 })
+    int replicas
+
+    int minimumReplicas
+
+    @Validate
+    void replicasMeetMinimum() {
+        assert replicas >= minimumReplicas : "replicas must meet the configured minimum"
+    }
+}
+```
+
 (See: `ValidationDocumentaryTest#'validates a numeric field with a closure'`.)
 
 ```groovy


### PR DESCRIPTION
## Summary
- Clarify when to use `@Required`, a field validation closure, or a validation method.
- Add canonical 4.0 imports to the selection example and record the correction in the changelog.

## Validation
- `git diff --check f449c818..HEAD`
- `./gradlew -p /private/tmp/klumast-schema-adopter-bootstrap-r11-validation-choice-forward-check compileGroovy --console=plain --warning-mode=none`
- `./gradlew renderLocalDocumentation --console=plain --warning-mode=none` in a clean detached worktree at the PR tip

Tracker impact: none.